### PR TITLE
NRLF-93 Setup

### DIFF
--- a/nrlf.sh
+++ b/nrlf.sh
@@ -44,6 +44,7 @@ function nrlf() {
     "bootstrap") _bootstrap "${@:2}" ;;
     "lint") _lint "${@:2}" ;;
     "swagger") _swagger "${@:2}" ;;
+    "truststore") echo "placeholder for mTLS work" ;;
     *) _nrlf_commands_help ;;
   esac
 


### PR DESCRIPTION
NRLF-93 includes changes to the CI routines, which rely on some new `nrlf truststore` commands.  This gets exceedingly messy because some branches don't have that command added yet and therefore the CI struggles.  This features adds a dummy command, which will allow the main NRLF-93 ci to work as expected.   This change will be replaced in NRLF-93.