### PR TITLE
[NRLF-346] Added validation to check that the body id and path id match before updating in the updateDocumentPointer handler

### DIFF
--- a/api/producer/updateDocumentReference/src/v1/handler.py
+++ b/api/producer/updateDocumentReference/src/v1/handler.py
@@ -13,6 +13,7 @@ from nrlf.core.common_steps import parse_headers, parse_path_id
 from nrlf.core.errors import (
     AuthenticationError,
     ImmutableFieldViolationError,
+    ItemNotFound,
     RequestValidationError,
 )
 from nrlf.core.model import DocumentPointer
@@ -39,8 +40,8 @@ def parse_request_body(
 ) -> PipelineData:
     body = fetch_body_from_event(event)
 
-    if ("id" in body and "id" in data) and (body["id"] is not data["id"]):
-        raise RequestValidationError("The path id and body id must match")
+    if ("id" in body and "id" in data) and (body["id"] != data["id"]):
+        raise ItemNotFound("Item could not be found")
 
     core_model = update_document_pointer_from_fhir_json(body, API_VERSION)
     return PipelineData(core_model=core_model, **data)

--- a/feature_tests/features/producer/producer-updateDocumentPointer-edge.feature
+++ b/feature_tests/features/producer/producer-updateDocumentPointer-edge.feature
@@ -102,11 +102,11 @@ Feature: Producer Update Success scenarios
       | description | Therapy Summary Document for Patient 9278693472 |
       | url         | https://example.org/different-doc.pdf           |
     Then the operation is unsuccessful
-    And the status is 400
+    And the status is 404
     And the response is an OperationOutcome according to the OUTCOME template with the below values
-      | property          | value                                                   |
-      | issue_type        | processing                                              |
-      | issue_level       | error                                                   |
-      | issue_code        | VALIDATION_ERROR                                        |
-      | issue_description | A parameter or value has resulted in a validation error |
-      | message           | The path id and body id must match                      |
+      | property          | value                   |
+      | issue_type        | processing              |
+      | issue_level       | error                   |
+      | issue_code        | RESOURCE_NOT_FOUND      |
+      | issue_description | Resource not found      |
+      | message           | Item could not be found |

--- a/feature_tests/features/producer/producer-updateDocumentPointer-failure.feature
+++ b/feature_tests/features/producer/producer-updateDocumentPointer-failure.feature
@@ -264,11 +264,11 @@ Feature: Producer Update Failure scenarios
       | subject     | 9278693472      |
       | contentType | application/pdf |
     Then the operation is unsuccessful
-    And the status is 400
+    And the status is 404
     And the response is an OperationOutcome according to the OUTCOME template with the below values
-      | property          | value                                                                                                               |
-      | issue_type        | processing                                                                                                          |
-      | issue_level       | error                                                                                                               |
-      | issue_code        | VALIDATION_ERROR                                                                                                    |
-      | issue_description | A parameter or value has resulted in a validation error                                                             |
-      | message           | DocumentReference validation failure - Invalid __root__ - Input is not composite of the form a-b: 8FW23\|1234567890 |
+      | property          | value                   |
+      | issue_type        | processing              |
+      | issue_level       | error                   |
+      | issue_code        | RESOURCE_NOT_FOUND      |
+      | issue_description | Resource not found      |
+      | message           | Item could not be found |


### PR DESCRIPTION
This PR address the issue where a user could update a document with differing ids between the path and the request body.