### PR TITLE
[NRLF-372] OAS iteration

### DIFF
--- a/api/consumer/nrl-consumer-api.yaml
+++ b/api/consumer/nrl-consumer-api.yaml
@@ -6,36 +6,55 @@ info:
   title: National Record Locator Consumer - FHIR API
   description: |
     ## Overview
-    The National Record Locator (NRL) is a service that holds pointers to data held in local provider systems.
 
-    The service facilitates national sharing, removing the need for organisations to create duplicate copies of information across systems and organisations, by enabling access to up-to-date information directly from the source.
+    The National Record Locator (NRL) enables organisations to share Patient data nationwide.  It acts as an Index, or Directory, of patient data.  Rather than handling the data itself it shares pointers held in partner systems, using the FHIR R4 DocumentReference standard.
+
+    Users of the service fall into the categories of:
+
+    * Producers - capable of creating and managing pointers
+    * Consumers - capable of searching and reading pointers
+
+    The service removes the need for organisations to create duplicate copies of information across systems and organisations, by enabling access to up-to-date information directly from the source.
 
     It can be used to store and publish pointers to patient data held in health systems across England and to look up where relevant patient data is held.
 
-    As a "consumer" of pointers relating to citizens, you can:
-
-    -Search a pointer, where you are authorised to do so, for a given patient
-    -Read a pointer, where you are authorised to do so, for a given patient
-
-    This service is a new version of the NRL moving to R4 from STU3, more information on the existing STU3 NRL service can be found on the following page, [National Record Locator (NRL)](https://digital.nhs.uk/services/national-record-locator).
-
     There is a growing list of health and social care organisations authorised to share records using NRL.
 
+    ### As a Consumer
+
+    * Search for pointers, restricted to a single Patient at a time
+    * Read a specific pointer
+    * Operations are restricted to document types agreed during the on-boarding process
+
+    ### What has changed?
+
+    This service is a replacement for the existing [National Record Locator (NRL)](https://digital.nhs.uk/services/national-record-locator).
+
+    * Upgraded from FHIR STU3 to R4.
+    * Improved performance and scalability.
+    * Improved on-boarding experience.
+    * Authenticated using [signed JWT](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation/application-restricted-restful-apis-signed-jwt-authentication) rather than mTLS
+    * Greater flexibility, by wider support of the FHIR R4 DocumentReference resource.
+
     ### Data availability, timing and quality
+
     Pointers are available to be consumed almost immediately after they have been produced by the provider.
 
     ## Who can use this API
+
     This API:
-    - is only for use by patient-facing applications
-    - is only for non-clinical use
-    - can only be used where there is a legal basis to do so
+
+    * is only for use by patient-facing applications
+    * is only for non-clinical use
+    * can only be used where there is a legal basis to do so
 
     You can not currently use this API to retrieve pointers for:
-    - mental health crisis plans
-    - end of life plans
-    - emergency care plans (eRedbags)
-    - national early warning scores (NEWS)
-    - urgent care plan
+
+    * mental health crisis plans
+    * end of life plans
+    * emergency care plans (eRedbags)
+    * national early warning scores (NEWS)
+    * urgent care plan
 
     Make sure you have a valid use case before you go too far with your development.
     To do this, [contact us](https://digital.nhs.uk/developer/help-and-support).
@@ -43,6 +62,7 @@ info:
     You must do this before you can go live (see ‘Onboarding’ below).
 
     ## API status and roadmap
+
     This API is [in development](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#statuses).
 
     To see our roadmap, or to suggest, comment or vote on features for this API, see our [interactive product backlog](https://nhs-digital-api-management.featureupvote.com/?tag=national-record-locator-api).
@@ -56,6 +76,7 @@ info:
     For more details, see [service levels](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#service-levels).
 
     ## Technology
+
     This API is [RESTful](https://digital.nhs.uk/developer/guides-and-documentation/our-api-technologies#basic-rest).
 
     It conforms to the [FHIR](https://digital.nhs.uk/developer/guides-and-documentation/our-api-technologies#fhir) global standard for health care data exchange, specifically to [FHIR R4 (v4.0.1)](https://hl7.org/fhir/r4/), except that it does not support the [capabilities](http://hl7.org/fhir/R4/http.html#capabilities) interaction.
@@ -63,10 +84,12 @@ info:
     It includes some country-specific FHIR extensions, which conform to [FHIR UK Core](https://digital.nhs.uk/services/fhir-uk-core), specifically [fhir.r4.ukcore.stu1 0.5.1](https://simplifier.net/packages/fhir.r4.ukcore.stu1/0.5.1).
 
     You do not need to know much about FHIR to use this API - FHIR APIs are just RESTful APIs that follow specific rules.
+
     In particular:
-    - resource names are capitalised and singular, and use US spellings, for example `/Immunization` not `/immunisations`
-    - array names are singular, for example `entry` not `entries` for address lines
-    - data items that are country-specific and thus not included in the FHIR global base resources are usually wrapped in an `extension` object
+
+    * resource names are capitalised and singular, and use US spellings, for example `/Immunization` not `/immunisations`
+    * array names are singular, for example `entry` not `entries` for address lines
+    * data items that are country-specific and thus not included in the FHIR global base resources are usually wrapped in an `extension` object
 
     There are [libraries and SDKs available](https://digital.nhs.uk/developer/guides-and-documentation/api-technologies-at-nhs-digital#fhir-libraries-and-sdks) to help with FHIR API integration.
 
@@ -78,16 +101,11 @@ info:
     ## Security and authorisation
 
     This API uses the following access modes:
-    * application-restricted access
 
-    ### Application-restricted access
-
-    This access mode is [application-restricted](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation#application-restricted-apis), meaning we authenticate the calling application but not the end user.
-
-    To use this access mode, use the following security pattern:
     * [Application-restricted RESTful API - signed JWT authentication](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation/application-restricted-restful-apis-signed-jwt-authentication)
 
     ## Environments and testing
+
     | Environment       | Base URL                                                               |
     | ----------------- | ---------------------------------------------------------------------- |
     | Sandbox           | `https://sandbox.api.service.nhs.uk/nrl-consumer-api/FHIR/R4/`     |
@@ -95,6 +113,7 @@ info:
     | Production        | `https://api.service.nhs.uk/nrl-consumer-api/FHIR/R4/`             |
 
     ### Sandbox testing
+
     Our [sandbox environment](https://digital.nhs.uk/developer/guides-and-documentation/testing#sandbox-testing):
     * is for early developer testing
     * only covers a limited set of scenarios
@@ -107,7 +126,9 @@ info:
     [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/TBC)
 
     ### Integration testing
+
     Our [integration test environment](https://digital.nhs.uk/developer/guides-and-documentation/testing#integration-testing):
+
     * is for formal integration testing
     * includes authorisation
 
@@ -116,6 +137,7 @@ info:
     For more details see [integration testing with our RESTful APIs](https://digital.nhs.uk/developer/guides-and-documentation/testing#integration-testing-with-our-restful-apis).
 
     ## Onboarding
+
     You need to get your software approved by us before it can go live with this API. We call this onboarding. The onboarding process can sometimes be quite long, so it’s worth planning well ahead.
 
     This API uses our online digital onboarding process.
@@ -139,13 +161,9 @@ servers:
     description: Integration test environment.
   - url: https://api.service.nhs.uk/nrl-consumer-api/FHIR/R4
     description: Production environment.
-tags:
-  - name: NRLF Consumer
 paths:
   /DocumentReference:
     get:
-      tags:
-        - NRLF Consumer
       summary: Search (GET)
       operationId: searchDocumentReference
       parameters:
@@ -260,11 +278,9 @@ paths:
             X-Request-Id:
               $ref: "#/components/headers/RequestId"
       description: |
-        Perform a Search using GET query string parameters
+        Search a single Patient's records.
   /DocumentReference/_search:
     post:
-      tags:
-        - NRLF Consumer
       summary: Search (POST)
       operationId: searchPostDocumentReference
       parameters:
@@ -376,11 +392,14 @@ paths:
             X-Request-Id:
               $ref: "#/components/headers/RequestId"
       description: |
-        Same as above but a POST to avoid URL length limits
+        Search a single Patient's records, but implemented as a POST operation
+        because of limitations associated with GET:
+
+        * query string parameters are visible on the network and in logs, and may have privacy implications for consumers.
+        * GET operations can be cached by intermediary network infrastructure, such as CDNs, routers and proxies.
+        * URLs have a maximum length of 2,048 characters which complex searches can exceed.  NRL does not currently exceed this limit, but may evolve in the future.
   /DocumentReference/{id}:
     get:
-      tags:
-        - NRLF Consumer
       summary: Read
       operationId: readDocumentReference
       parameters:
@@ -467,7 +486,7 @@ paths:
             X-Request-Id:
               $ref: "#/components/headers/RequestId"
       description: |
-        Read a single DocumentReference record
+        Read a single DocumentReference record using the `DocumentReference.id`
 components:
   requestBodies:
     DocumentReference:
@@ -633,7 +652,7 @@ components:
             - VisionPrescription
         id:
           type: string
-          pattern: '[A-Za-z0-9\-\.]{1,64}'
+          pattern: "[A-Za-z0-9\\-\\.]{1,64}"
           description: The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.
         meta:
           $ref: "#/components/schemas/Meta"
@@ -644,7 +663,7 @@ components:
           description: A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.
         language:
           type: string
-          pattern: '[^\s]+(\s[^\s]+)*'
+          pattern: "[^\\s]+(\\s[^\\s]+)*"
           description: The base language in which the resource is written.
       required:
         - resourceType
@@ -689,11 +708,11 @@ components:
                 description: Other identifiers associated with the document, including version independent identifiers.
             status:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The status of this document reference.
             docStatus:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The status of the underlying document.
             type:
               $ref: "#/components/schemas/CodeableConcept"
@@ -728,7 +747,7 @@ components:
                 description: Relationships that this document has with other document references that already exist.
             description:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Human&ndash;readable description of the source document.
             securityLabel:
               type: array
@@ -1039,7 +1058,7 @@ components:
               description: A persistent identifier for the bundle that won't change as a bundle is copied from server to server.
             type:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Indicates the purpose of this bundle &ndash; how it is intended to be used.
             timestamp:
               type: string
@@ -1265,7 +1284,7 @@ components:
           properties:
             status:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The status code returned by processing this entry. The status SHALL start with a 3 digit HTTP code (e.g. 404) and may contain the standard HTTP description associated with the status code.
             location:
               type: string
@@ -1273,7 +1292,7 @@ components:
               description: The location header created by processing this operation, populated if the operation returns a location.
             etag:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The Etag for the resource, if the operation for the entry produced a versioned resource (see [Resource Metadata and Versioning](http.html#versioning) and [Managing Resource Contention](http.html#concurrency)).
             lastModified:
               type: string
@@ -1291,7 +1310,7 @@ components:
           properties:
             method:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: In a transaction or batch, this is the HTTP action to be executed for this entry. In a history bundle, this indicates the HTTP action that occurred.
             url:
               type: string
@@ -1299,7 +1318,7 @@ components:
               description: The URL for this entry, relative to the root (the address to which the request is posted).
             ifNoneMatch:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: If the ETag values match, return a 304 Not Modified status. See the API documentation for ["Conditional Read"](http.html#cread).
             ifModifiedSince:
               type: string
@@ -1307,11 +1326,11 @@ components:
               description: Only perform the operation if the last updated date matches. See the API documentation for ["Conditional Read"](http.html#cread).
             ifMatch:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Only perform the operation if the Etag value matches. For more information, see the API section ["Managing Resource Contention"](http.html#concurrency).
             ifNoneExist:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Instruct the server not to perform the create if a specified resource already exists. For further information, see the API documentation for ["Conditional Create"](http.html#ccreate). This is just the query portion of the URL &ndash; what follows the "?" (not including the "?").
           required:
             - method
@@ -1323,7 +1342,7 @@ components:
           properties:
             mode:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Why this entry is in the result set &ndash; whether it's included as a match or because of an _include requirement, or to convey information or warning information about the search process.
             score:
               type: number
@@ -1335,7 +1354,7 @@ components:
           properties:
             relation:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A name which details the functional use for this link &ndash; see [http://www.iana.org/assignments/link&ndash;relations/link&ndash;relations.xhtml#link&ndash;relations&ndash;1](http://www.iana.org/assignments/link&ndash;relations/link&ndash;relations.xhtml#link&ndash;relations&ndash;1).
             url:
               type: string
@@ -1396,7 +1415,7 @@ components:
           properties:
             code:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The type of relationship that this document has with anther document.
             target:
               $ref: "#/components/schemas/Reference"
@@ -1411,30 +1430,30 @@ components:
           properties:
             severity:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Indicates whether the issue indicates a variation from successful processing.
             code:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Describes the type of the issue. The system that creates an OperationOutcome SHALL choose the most applicable code from the IssueType value set, and may additional provide its own code for the error in the details element.
             details:
               $ref: "#/components/schemas/CodeableConcept"
               description: Additional details about the error. This may be a text description of the error or a system code that identifies the error.
             diagnostics:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Additional diagnostic information about the issue.
             location:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: "This element is deprecated because it is XML specific. It is replaced by issue.expression, which is format independent, and simpler to parse. \n\nFor resource issues, this will be a simple XPath limited to element names, repetition indicators and the default child accessor that identifies one of the elements in the resource that caused this issue to be raised.  For HTTP errors, will be \"http.\" + the parameter name."
             expression:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: A [simple subset of FHIRPath](fhirpath.html#simple) limited to element names, repetition indicators and the default child accessor that identifies one of the elements in the resource that caused this issue to be raised.
           required:
             - severity
@@ -1444,7 +1463,7 @@ components:
       properties:
         id:
           type: string
-          pattern: '[A-Za-z0-9\-\.]{1,64}'
+          pattern: "[A-Za-z0-9\\-\\.]{1,64}"
           description: Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.
         extension:
           type: array
@@ -1474,41 +1493,41 @@ components:
           properties:
             use:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The purpose of this address.
             type:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Distinguishes between physical addresses (those you can visit) and mailing addresses (e.g. PO Boxes and care&ndash;of addresses). Most addresses are both.
             text:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Specifies the entire address as it should be displayed e.g. on a postal label. This may be provided instead of or as well as the specific parts.
             line:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: This component contains the house number, apartment number, street name, street direction,  P.O. Box number, delivery hints, and similar address information.
             city:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The name of the city, town, suburb, village or other community or delivery center.
             district:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The name of the administrative area (county).
             state:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Sub&ndash;unit of a country with limited sovereignty in a federally organized country. A code may be used if codes are in common use (e.g. US 2 letter state codes).
             postalCode:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A postal code designating a region defined by the postal service.
             country:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Country &ndash; a nation as commonly understood or generally accepted.
             period:
               $ref: "#/components/schemas/Period"
@@ -1528,7 +1547,7 @@ components:
               description: The individual responsible for making the annotation.
             authorString:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The individual responsible for making the annotation.
             time:
               type: string
@@ -1536,7 +1555,7 @@ components:
               description: Indicates when this particular annotation was made.
             text:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The text of the annotation in markdown format.
           required:
             - text
@@ -1547,11 +1566,11 @@ components:
           properties:
             contentType:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Identifies the type of the data in the attachment and allows a method to be chosen to interpret or render the data. Includes mime type parameters such as charset where appropriate.
             language:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The human language of the content. The value can be any valid value according to BCP 47.
             data:
               type: string
@@ -1571,7 +1590,7 @@ components:
               description: The calculated hash of the data using SHA&ndash;1. Represented using base64.
             title:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A label or set of text to display in place of the data.
             creation:
               type: string
@@ -1589,7 +1608,7 @@ components:
                 description: A reference to a code defined by a terminology system.
             text:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.
     Coding:
       allOf:
@@ -1602,15 +1621,15 @@ components:
               description: The identification of the code system that defines the meaning of the symbol in the code.
             version:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The version of the code system which was used when choosing this code. Note that a well&ndash;maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.
             code:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post&ndash;coordination).
             display:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A representation of the meaning of the code in the system, following the rules of the system.
             userSelected:
               type: boolean
@@ -1622,15 +1641,15 @@ components:
           properties:
             system:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Telecommunications form for contact point &ndash; what communications system is required to make use of the contact.
             value:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address).
             use:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Identifies the purpose for the contact point.
             rank:
               type: integer
@@ -1661,33 +1680,33 @@ components:
           properties:
             use:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Identifies the purpose for this name.
             text:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Specifies the entire name as it should be displayed e.g. on an application UI. This may be provided instead of or as well as the specific parts.
             family:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father.
             given:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: Given name.
             prefix:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name.
             suffix:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name.
             period:
               $ref: "#/components/schemas/Period"
@@ -1699,7 +1718,7 @@ components:
           properties:
             use:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The purpose of this identifier.
             type:
               $ref: "#/components/schemas/CodeableConcept"
@@ -1710,7 +1729,7 @@ components:
               description: Establishes the namespace for the value &ndash; that is, a URL that describes a set values that are unique.
             value:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The portion of the identifier typically relevant to the user and which is unique within the context of the system.
             period:
               $ref: "#/components/schemas/Period"
@@ -1732,7 +1751,7 @@ components:
               description: Numerical value (with implicit precision).
             currency:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: ISO 4217 Currency Code.
     MoneyQuantity:
       allOf:
@@ -1762,11 +1781,11 @@ components:
               description: The value of the measured amount. The value includes an implicit precision in the presentation of the value.
             comparator:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: How the value should be understood and represented &ndash; whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is "<" , then the real value is < stated value.
             unit:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A human&ndash;readable form of the unit.
             system:
               type: string
@@ -1774,7 +1793,7 @@ components:
               description: The identification of the system that provides the coded form of the unit.
             code:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: A computer processable form of the unit in some unit representation system.
     Range:
       allOf:
@@ -1805,7 +1824,7 @@ components:
           properties:
             reference:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with '#') refer to contained resources.
             type:
               type: string
@@ -1819,7 +1838,7 @@ components:
               description: An identifier for the target resource. This is used when there is no way to reference the other resource directly, either because the entity it represents is not available through a FHIR server, or because there is no way for the author of the resource to convert a known identifier to an actual location. There is no requirement that a Reference.identifier point to something that is actually exposed as a FHIR instance, but it SHALL point to a business concept that would be expected to be exposed as a FHIR instance, and that instance would need to be of a FHIR resource type allowed by the reference.
             display:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Plain text narrative that identifies the resource in addition to the resource reference.
     SampledData:
       allOf:
@@ -1847,7 +1866,7 @@ components:
               description: The number of sample points at each time point. If this value is greater than one, then the dimensions will be interlaced &ndash; all the sample points for a point in time will be recorded at once.
             data:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A series of data points which are decimal values separated by a single space (character u20). The special values "E" (error), "L" (below detection limit) and "U" (above detection limit) can also be used in place of a decimal value.
           required:
             - origin
@@ -1881,11 +1900,11 @@ components:
               description: A reference to an application&ndash;usable description of the identity that is represented by the signature.
             targetFormat:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: A mime type that indicates the technical format of the target resources signed by the signature.
             sigFormat:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: A mime type that indicates the technical format of the signature. Important mime types are application/signature+xml for X ML DigSig, application/jose for JWS, and image/* for a graphical image of a signature, etc.
             data:
               type: string
@@ -1942,7 +1961,7 @@ components:
               description: If present, indicates that the duration is a range &ndash; so to perform the action between [duration] and [durationMax] time length.
             durationUnit:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The units of time for the duration, in UCUM units.
             frequency:
               type: integer
@@ -1960,13 +1979,13 @@ components:
               description: If present, indicates that the period is a range from [period] to [periodMax], allowing expressing concepts such as "do this once every 3&ndash;5 days.
             periodUnit:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The units of time for the period in UCUM units.
             dayOfWeek:
               type: array
               items:
                 type: string
-                pattern: '[^\s]+(\s[^\s]+)*'
+                pattern: "[^\\s]+(\\s[^\\s]+)*"
                 description: If one or more days of week is provided, then the action happens only on the specified day(s).
             timeOfDay:
               type: array
@@ -1978,7 +1997,7 @@ components:
               type: array
               items:
                 type: string
-                pattern: '[^\s]+(\s[^\s]+)*'
+                pattern: "[^\\s]+(\\s[^\\s]+)*"
                 description: An approximate time period during the day, potentially linked to an event of daily living that indicates when the action should occur.
             offset:
               type: integer
@@ -1991,7 +2010,7 @@ components:
           properties:
             name:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The name of an individual to contact.
             telecom:
               type: array
@@ -2005,19 +2024,19 @@ components:
           properties:
             type:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The type of relationship to the related artifact.
             label:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A short label that can be used to reference the citation from elsewhere in the containing artifact, such as a footnote index.
             display:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A brief description of the document or knowledge resource being referenced, suitable for display to a consumer.
             citation:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A bibliographic citation for the related artifact. This text SHOULD be formatted according to an accepted citation format.
             url:
               type: string
@@ -2061,7 +2080,7 @@ components:
           properties:
             versionId:
               type: string
-              pattern: '[A-Za-z0-9\-\.]{1,64}'
+              pattern: "[A-Za-z0-9\\-\\.]{1,64}"
               description: The version specific identifier, as it appears in the version portion of the URL. This value changes when the resource is created, updated, or deleted.
             lastUpdated:
               type: string
@@ -2094,7 +2113,7 @@ components:
           properties:
             status:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The status of the narrative &ndash; whether it's entirely generated (from just the defined data or the extensions too), or whether a human authored it and it may contain additional data.
             div:
               type: string
@@ -2124,7 +2143,7 @@ components:
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueCode:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueDate:
               type: string
@@ -2139,7 +2158,7 @@ components:
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueId:
               type: string
-              pattern: '[A-Za-z0-9\-\.]{1,64}'
+              pattern: "[A-Za-z0-9\\-\\.]{1,64}"
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueInstant:
               type: string
@@ -2151,7 +2170,7 @@ components:
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueMarkdown:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueOid:
               type: string
@@ -2163,7 +2182,7 @@ components:
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueString:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueTime:
               type: string

--- a/api/consumer/swagger.yaml
+++ b/api/consumer/swagger.yaml
@@ -6,36 +6,55 @@ info:
   title: National Record Locator Consumer - FHIR API
   description: |
     ## Overview
-    The National Record Locator (NRL) is a service that holds pointers to data held in local provider systems.
 
-    The service facilitates national sharing, removing the need for organisations to create duplicate copies of information across systems and organisations, by enabling access to up-to-date information directly from the source.
+    The National Record Locator (NRL) enables organisations to share Patient data nationwide.  It acts as an Index, or Directory, of patient data.  Rather than handling the data itself it shares pointers held in partner systems, using the FHIR R4 DocumentReference standard.
+
+    Users of the service fall into the categories of:
+
+    * Producers - capable of creating and managing pointers
+    * Consumers - capable of searching and reading pointers
+
+    The service removes the need for organisations to create duplicate copies of information across systems and organisations, by enabling access to up-to-date information directly from the source.
 
     It can be used to store and publish pointers to patient data held in health systems across England and to look up where relevant patient data is held.
 
-    As a "consumer" of pointers relating to citizens, you can:
-
-    -Search a pointer, where you are authorised to do so, for a given patient
-    -Read a pointer, where you are authorised to do so, for a given patient
-
-    This service is a new version of the NRL moving to R4 from STU3, more information on the existing STU3 NRL service can be found on the following page, [National Record Locator (NRL)](https://digital.nhs.uk/services/national-record-locator).
-
     There is a growing list of health and social care organisations authorised to share records using NRL.
 
+    ### As a Consumer
+
+    * Search for pointers, restricted to a single Patient at a time
+    * Read a specific pointer
+    * Operations are restricted to document types agreed during the on-boarding process
+
+    ### What has changed?
+
+    This service is a replacement for the existing [National Record Locator (NRL)](https://digital.nhs.uk/services/national-record-locator).
+
+    * Upgraded from FHIR STU3 to R4.
+    * Improved performance and scalability.
+    * Improved on-boarding experience.
+    * Authenticated using [signed JWT](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation/application-restricted-restful-apis-signed-jwt-authentication) rather than mTLS
+    * Greater flexibility, by wider support of the FHIR R4 DocumentReference resource.
+
     ### Data availability, timing and quality
+
     Pointers are available to be consumed almost immediately after they have been produced by the provider.
 
     ## Who can use this API
+
     This API:
-    - is only for use by patient-facing applications
-    - is only for non-clinical use
-    - can only be used where there is a legal basis to do so
+
+    * is only for use by patient-facing applications
+    * is only for non-clinical use
+    * can only be used where there is a legal basis to do so
 
     You can not currently use this API to retrieve pointers for:
-    - mental health crisis plans
-    - end of life plans
-    - emergency care plans (eRedbags)
-    - national early warning scores (NEWS)
-    - urgent care plan
+
+    * mental health crisis plans
+    * end of life plans
+    * emergency care plans (eRedbags)
+    * national early warning scores (NEWS)
+    * urgent care plan
 
     Make sure you have a valid use case before you go too far with your development.
     To do this, [contact us](https://digital.nhs.uk/developer/help-and-support).
@@ -43,6 +62,7 @@ info:
     You must do this before you can go live (see ‘Onboarding’ below).
 
     ## API status and roadmap
+
     This API is [in development](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#statuses).
 
     To see our roadmap, or to suggest, comment or vote on features for this API, see our [interactive product backlog](https://nhs-digital-api-management.featureupvote.com/?tag=national-record-locator-api).
@@ -56,6 +76,7 @@ info:
     For more details, see [service levels](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#service-levels).
 
     ## Technology
+
     This API is [RESTful](https://digital.nhs.uk/developer/guides-and-documentation/our-api-technologies#basic-rest).
 
     It conforms to the [FHIR](https://digital.nhs.uk/developer/guides-and-documentation/our-api-technologies#fhir) global standard for health care data exchange, specifically to [FHIR R4 (v4.0.1)](https://hl7.org/fhir/r4/), except that it does not support the [capabilities](http://hl7.org/fhir/R4/http.html#capabilities) interaction.
@@ -63,10 +84,12 @@ info:
     It includes some country-specific FHIR extensions, which conform to [FHIR UK Core](https://digital.nhs.uk/services/fhir-uk-core), specifically [fhir.r4.ukcore.stu1 0.5.1](https://simplifier.net/packages/fhir.r4.ukcore.stu1/0.5.1).
 
     You do not need to know much about FHIR to use this API - FHIR APIs are just RESTful APIs that follow specific rules.
+
     In particular:
-    - resource names are capitalised and singular, and use US spellings, for example `/Immunization` not `/immunisations`
-    - array names are singular, for example `entry` not `entries` for address lines
-    - data items that are country-specific and thus not included in the FHIR global base resources are usually wrapped in an `extension` object
+
+    * resource names are capitalised and singular, and use US spellings, for example `/Immunization` not `/immunisations`
+    * array names are singular, for example `entry` not `entries` for address lines
+    * data items that are country-specific and thus not included in the FHIR global base resources are usually wrapped in an `extension` object
 
     There are [libraries and SDKs available](https://digital.nhs.uk/developer/guides-and-documentation/api-technologies-at-nhs-digital#fhir-libraries-and-sdks) to help with FHIR API integration.
 
@@ -78,16 +101,11 @@ info:
     ## Security and authorisation
 
     This API uses the following access modes:
-    * application-restricted access
 
-    ### Application-restricted access
-
-    This access mode is [application-restricted](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation#application-restricted-apis), meaning we authenticate the calling application but not the end user.
-
-    To use this access mode, use the following security pattern:
     * [Application-restricted RESTful API - signed JWT authentication](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation/application-restricted-restful-apis-signed-jwt-authentication)
 
     ## Environments and testing
+
     | Environment       | Base URL                                                               |
     | ----------------- | ---------------------------------------------------------------------- |
     | Sandbox           | `https://sandbox.api.service.nhs.uk/nrl-consumer-api/FHIR/R4/`     |
@@ -95,6 +113,7 @@ info:
     | Production        | `https://api.service.nhs.uk/nrl-consumer-api/FHIR/R4/`             |
 
     ### Sandbox testing
+
     Our [sandbox environment](https://digital.nhs.uk/developer/guides-and-documentation/testing#sandbox-testing):
     * is for early developer testing
     * only covers a limited set of scenarios
@@ -107,7 +126,9 @@ info:
     [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/TBC)
 
     ### Integration testing
+
     Our [integration test environment](https://digital.nhs.uk/developer/guides-and-documentation/testing#integration-testing):
+
     * is for formal integration testing
     * includes authorisation
 
@@ -116,6 +137,7 @@ info:
     For more details see [integration testing with our RESTful APIs](https://digital.nhs.uk/developer/guides-and-documentation/testing#integration-testing-with-our-restful-apis).
 
     ## Onboarding
+
     You need to get your software approved by us before it can go live with this API. We call this onboarding. The onboarding process can sometimes be quite long, so it’s worth planning well ahead.
 
     This API uses our online digital onboarding process.
@@ -140,12 +162,10 @@ servers:
   - url: https://api.service.nhs.uk/nrl-consumer-api/FHIR/R4
     description: Production environment.
 tags:
-  - name: NRLF Consumer
 paths:
   /DocumentReference:
     get:
       tags:
-        - NRLF Consumer
       summary: Search (GET)
       operationId: searchDocumentReference
       parameters:
@@ -271,11 +291,10 @@ paths:
         passthroughBehavior: when_no_match
         contentHandling: CONVERT_TO_TEXT
       description: |
-        Perform a Search using GET query string parameters
+        Search a single Patient's records.
   /DocumentReference/_search:
     post:
       tags:
-        - NRLF Consumer
       summary: Search (POST)
       operationId: searchPostDocumentReference
       parameters:
@@ -398,11 +417,15 @@ paths:
         passthroughBehavior: when_no_match
         contentHandling: CONVERT_TO_TEXT
       description: |
-        Same as above but a POST to avoid URL length limits
+        Search a single Patient's records, but implemented as a POST operation
+        because of limitations associated with GET:
+
+        * query string parameters are visible on the network and in logs, and may have privacy implications for consumers.
+        * GET operations can be cached by intermediary network infrastructure, such as CDNs, routers and proxies.
+        * URLs have a maximum length of 2,048 characters which complex searches can exceed.  NRL does not currently exceed this limit, but may evolve in the future.
   /DocumentReference/{id}:
     get:
       tags:
-        - NRLF Consumer
       summary: Read
       operationId: readDocumentReference
       parameters:
@@ -500,11 +523,10 @@ paths:
         passthroughBehavior: when_no_match
         contentHandling: CONVERT_TO_TEXT
       description: |
-        Read a single DocumentReference record
+        Read a single DocumentReference record using the `DocumentReference.id`
   /_status:
     get:
       tags:
-        - NRLF Consumer
       summary: _status endpoint for APIGEE integration
       operationId: status
       responses:
@@ -692,7 +714,7 @@ components:
             - VisionPrescription
         id:
           type: string
-          pattern: '[A-Za-z0-9\-\.]{1,64}'
+          pattern: "[A-Za-z0-9\\-\\.]{1,64}"
           description: The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.
         meta:
           $ref: "#/components/schemas/Meta"
@@ -703,7 +725,7 @@ components:
           description: A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.
         language:
           type: string
-          pattern: '[^\s]+(\s[^\s]+)*'
+          pattern: "[^\\s]+(\\s[^\\s]+)*"
           description: The base language in which the resource is written.
       required:
         - resourceType
@@ -748,11 +770,11 @@ components:
                 description: Other identifiers associated with the document, including version independent identifiers.
             status:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The status of this document reference.
             docStatus:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The status of the underlying document.
             type:
               $ref: "#/components/schemas/CodeableConcept"
@@ -787,7 +809,7 @@ components:
                 description: Relationships that this document has with other document references that already exist.
             description:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Human&ndash;readable description of the source document.
             securityLabel:
               type: array
@@ -1098,7 +1120,7 @@ components:
               description: A persistent identifier for the bundle that won't change as a bundle is copied from server to server.
             type:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Indicates the purpose of this bundle &ndash; how it is intended to be used.
             timestamp:
               type: string
@@ -1324,7 +1346,7 @@ components:
           properties:
             status:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The status code returned by processing this entry. The status SHALL start with a 3 digit HTTP code (e.g. 404) and may contain the standard HTTP description associated with the status code.
             location:
               type: string
@@ -1332,7 +1354,7 @@ components:
               description: The location header created by processing this operation, populated if the operation returns a location.
             etag:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The Etag for the resource, if the operation for the entry produced a versioned resource (see [Resource Metadata and Versioning](http.html#versioning) and [Managing Resource Contention](http.html#concurrency)).
             lastModified:
               type: string
@@ -1350,7 +1372,7 @@ components:
           properties:
             method:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: In a transaction or batch, this is the HTTP action to be executed for this entry. In a history bundle, this indicates the HTTP action that occurred.
             url:
               type: string
@@ -1358,7 +1380,7 @@ components:
               description: The URL for this entry, relative to the root (the address to which the request is posted).
             ifNoneMatch:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: If the ETag values match, return a 304 Not Modified status. See the API documentation for ["Conditional Read"](http.html#cread).
             ifModifiedSince:
               type: string
@@ -1366,11 +1388,11 @@ components:
               description: Only perform the operation if the last updated date matches. See the API documentation for ["Conditional Read"](http.html#cread).
             ifMatch:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Only perform the operation if the Etag value matches. For more information, see the API section ["Managing Resource Contention"](http.html#concurrency).
             ifNoneExist:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Instruct the server not to perform the create if a specified resource already exists. For further information, see the API documentation for ["Conditional Create"](http.html#ccreate). This is just the query portion of the URL &ndash; what follows the "?" (not including the "?").
           required:
             - method
@@ -1382,7 +1404,7 @@ components:
           properties:
             mode:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Why this entry is in the result set &ndash; whether it's included as a match or because of an _include requirement, or to convey information or warning information about the search process.
             score:
               type: number
@@ -1394,7 +1416,7 @@ components:
           properties:
             relation:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A name which details the functional use for this link &ndash; see [http://www.iana.org/assignments/link&ndash;relations/link&ndash;relations.xhtml#link&ndash;relations&ndash;1](http://www.iana.org/assignments/link&ndash;relations/link&ndash;relations.xhtml#link&ndash;relations&ndash;1).
             url:
               type: string
@@ -1455,7 +1477,7 @@ components:
           properties:
             code:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The type of relationship that this document has with anther document.
             target:
               $ref: "#/components/schemas/Reference"
@@ -1470,30 +1492,30 @@ components:
           properties:
             severity:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Indicates whether the issue indicates a variation from successful processing.
             code:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Describes the type of the issue. The system that creates an OperationOutcome SHALL choose the most applicable code from the IssueType value set, and may additional provide its own code for the error in the details element.
             details:
               $ref: "#/components/schemas/CodeableConcept"
               description: Additional details about the error. This may be a text description of the error or a system code that identifies the error.
             diagnostics:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Additional diagnostic information about the issue.
             location:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: "This element is deprecated because it is XML specific. It is replaced by issue.expression, which is format independent, and simpler to parse. \n\nFor resource issues, this will be a simple XPath limited to element names, repetition indicators and the default child accessor that identifies one of the elements in the resource that caused this issue to be raised.  For HTTP errors, will be \"http.\" + the parameter name."
             expression:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: A [simple subset of FHIRPath](fhirpath.html#simple) limited to element names, repetition indicators and the default child accessor that identifies one of the elements in the resource that caused this issue to be raised.
           required:
             - severity
@@ -1503,7 +1525,7 @@ components:
       properties:
         id:
           type: string
-          pattern: '[A-Za-z0-9\-\.]{1,64}'
+          pattern: "[A-Za-z0-9\\-\\.]{1,64}"
           description: Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.
         extension:
           type: array
@@ -1533,41 +1555,41 @@ components:
           properties:
             use:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The purpose of this address.
             type:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Distinguishes between physical addresses (those you can visit) and mailing addresses (e.g. PO Boxes and care&ndash;of addresses). Most addresses are both.
             text:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Specifies the entire address as it should be displayed e.g. on a postal label. This may be provided instead of or as well as the specific parts.
             line:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: This component contains the house number, apartment number, street name, street direction,  P.O. Box number, delivery hints, and similar address information.
             city:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The name of the city, town, suburb, village or other community or delivery center.
             district:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The name of the administrative area (county).
             state:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Sub&ndash;unit of a country with limited sovereignty in a federally organized country. A code may be used if codes are in common use (e.g. US 2 letter state codes).
             postalCode:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A postal code designating a region defined by the postal service.
             country:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Country &ndash; a nation as commonly understood or generally accepted.
             period:
               $ref: "#/components/schemas/Period"
@@ -1587,7 +1609,7 @@ components:
               description: The individual responsible for making the annotation.
             authorString:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The individual responsible for making the annotation.
             time:
               type: string
@@ -1595,7 +1617,7 @@ components:
               description: Indicates when this particular annotation was made.
             text:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The text of the annotation in markdown format.
           required:
             - text
@@ -1606,11 +1628,11 @@ components:
           properties:
             contentType:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Identifies the type of the data in the attachment and allows a method to be chosen to interpret or render the data. Includes mime type parameters such as charset where appropriate.
             language:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The human language of the content. The value can be any valid value according to BCP 47.
             data:
               type: string
@@ -1630,7 +1652,7 @@ components:
               description: The calculated hash of the data using SHA&ndash;1. Represented using base64.
             title:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A label or set of text to display in place of the data.
             creation:
               type: string
@@ -1648,7 +1670,7 @@ components:
                 description: A reference to a code defined by a terminology system.
             text:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.
     Coding:
       allOf:
@@ -1661,15 +1683,15 @@ components:
               description: The identification of the code system that defines the meaning of the symbol in the code.
             version:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The version of the code system which was used when choosing this code. Note that a well&ndash;maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.
             code:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post&ndash;coordination).
             display:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A representation of the meaning of the code in the system, following the rules of the system.
             userSelected:
               type: boolean
@@ -1681,15 +1703,15 @@ components:
           properties:
             system:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Telecommunications form for contact point &ndash; what communications system is required to make use of the contact.
             value:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address).
             use:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Identifies the purpose for the contact point.
             rank:
               type: integer
@@ -1720,33 +1742,33 @@ components:
           properties:
             use:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Identifies the purpose for this name.
             text:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Specifies the entire name as it should be displayed e.g. on an application UI. This may be provided instead of or as well as the specific parts.
             family:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father.
             given:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: Given name.
             prefix:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name.
             suffix:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name.
             period:
               $ref: "#/components/schemas/Period"
@@ -1758,7 +1780,7 @@ components:
           properties:
             use:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The purpose of this identifier.
             type:
               $ref: "#/components/schemas/CodeableConcept"
@@ -1769,7 +1791,7 @@ components:
               description: Establishes the namespace for the value &ndash; that is, a URL that describes a set values that are unique.
             value:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The portion of the identifier typically relevant to the user and which is unique within the context of the system.
             period:
               $ref: "#/components/schemas/Period"
@@ -1791,7 +1813,7 @@ components:
               description: Numerical value (with implicit precision).
             currency:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: ISO 4217 Currency Code.
     MoneyQuantity:
       allOf:
@@ -1821,11 +1843,11 @@ components:
               description: The value of the measured amount. The value includes an implicit precision in the presentation of the value.
             comparator:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: How the value should be understood and represented &ndash; whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is "<" , then the real value is < stated value.
             unit:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A human&ndash;readable form of the unit.
             system:
               type: string
@@ -1833,7 +1855,7 @@ components:
               description: The identification of the system that provides the coded form of the unit.
             code:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: A computer processable form of the unit in some unit representation system.
     Range:
       allOf:
@@ -1864,7 +1886,7 @@ components:
           properties:
             reference:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with '#') refer to contained resources.
             type:
               type: string
@@ -1878,7 +1900,7 @@ components:
               description: An identifier for the target resource. This is used when there is no way to reference the other resource directly, either because the entity it represents is not available through a FHIR server, or because there is no way for the author of the resource to convert a known identifier to an actual location. There is no requirement that a Reference.identifier point to something that is actually exposed as a FHIR instance, but it SHALL point to a business concept that would be expected to be exposed as a FHIR instance, and that instance would need to be of a FHIR resource type allowed by the reference.
             display:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Plain text narrative that identifies the resource in addition to the resource reference.
     SampledData:
       allOf:
@@ -1906,7 +1928,7 @@ components:
               description: The number of sample points at each time point. If this value is greater than one, then the dimensions will be interlaced &ndash; all the sample points for a point in time will be recorded at once.
             data:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A series of data points which are decimal values separated by a single space (character u20). The special values "E" (error), "L" (below detection limit) and "U" (above detection limit) can also be used in place of a decimal value.
           required:
             - origin
@@ -1940,11 +1962,11 @@ components:
               description: A reference to an application&ndash;usable description of the identity that is represented by the signature.
             targetFormat:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: A mime type that indicates the technical format of the target resources signed by the signature.
             sigFormat:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: A mime type that indicates the technical format of the signature. Important mime types are application/signature+xml for X ML DigSig, application/jose for JWS, and image/* for a graphical image of a signature, etc.
             data:
               type: string
@@ -2001,7 +2023,7 @@ components:
               description: If present, indicates that the duration is a range &ndash; so to perform the action between [duration] and [durationMax] time length.
             durationUnit:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The units of time for the duration, in UCUM units.
             frequency:
               type: integer
@@ -2019,13 +2041,13 @@ components:
               description: If present, indicates that the period is a range from [period] to [periodMax], allowing expressing concepts such as "do this once every 3&ndash;5 days.
             periodUnit:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The units of time for the period in UCUM units.
             dayOfWeek:
               type: array
               items:
                 type: string
-                pattern: '[^\s]+(\s[^\s]+)*'
+                pattern: "[^\\s]+(\\s[^\\s]+)*"
                 description: If one or more days of week is provided, then the action happens only on the specified day(s).
             timeOfDay:
               type: array
@@ -2037,7 +2059,7 @@ components:
               type: array
               items:
                 type: string
-                pattern: '[^\s]+(\s[^\s]+)*'
+                pattern: "[^\\s]+(\\s[^\\s]+)*"
                 description: An approximate time period during the day, potentially linked to an event of daily living that indicates when the action should occur.
             offset:
               type: integer
@@ -2050,7 +2072,7 @@ components:
           properties:
             name:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The name of an individual to contact.
             telecom:
               type: array
@@ -2064,19 +2086,19 @@ components:
           properties:
             type:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The type of relationship to the related artifact.
             label:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A short label that can be used to reference the citation from elsewhere in the containing artifact, such as a footnote index.
             display:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A brief description of the document or knowledge resource being referenced, suitable for display to a consumer.
             citation:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A bibliographic citation for the related artifact. This text SHOULD be formatted according to an accepted citation format.
             url:
               type: string
@@ -2120,7 +2142,7 @@ components:
           properties:
             versionId:
               type: string
-              pattern: '[A-Za-z0-9\-\.]{1,64}'
+              pattern: "[A-Za-z0-9\\-\\.]{1,64}"
               description: The version specific identifier, as it appears in the version portion of the URL. This value changes when the resource is created, updated, or deleted.
             lastUpdated:
               type: string
@@ -2153,7 +2175,7 @@ components:
           properties:
             status:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The status of the narrative &ndash; whether it's entirely generated (from just the defined data or the extensions too), or whether a human authored it and it may contain additional data.
             div:
               type: string
@@ -2183,7 +2205,7 @@ components:
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueCode:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueDate:
               type: string
@@ -2198,7 +2220,7 @@ components:
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueId:
               type: string
-              pattern: '[A-Za-z0-9\-\.]{1,64}'
+              pattern: "[A-Za-z0-9\\-\\.]{1,64}"
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueInstant:
               type: string
@@ -2210,7 +2232,7 @@ components:
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueMarkdown:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueOid:
               type: string
@@ -2222,7 +2244,7 @@ components:
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueString:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueTime:
               type: string

--- a/api/producer/nrl-producer-api.yaml
+++ b/api/producer/nrl-producer-api.yaml
@@ -6,30 +6,47 @@ info:
   title: National Record Locator Producer - FHIR API
   description: |
     ## Overview
-    The National Record Locator (NRL) is a service that holds pointers to data held in local provider systems.
 
-    The service facilitates national sharing, removing the need for organisations to create duplicate copies of information across systems and organisations, by enabling access to up-to-date information directly from the source.
+    The National Record Locator (NRL) enables organisations to share Patient data nationwide.  It acts as an Index, or Directory, of patient data.  Rather than handling the data itself it shares pointers held in partner systems, using the FHIR R4 DocumentReference standard.
+
+    Users of the service fall into the categories of:
+
+    * Producers - capable of creating and managing pointers
+    * Consumers - capable of searching and reading pointers
+
+    The service removes the need for organisations to create duplicate copies of information across systems and organisations, by enabling access to up-to-date information directly from the source.
 
     It can be used to store and publish pointers to patient data held in health systems across England and to look up where relevant patient data is held.
 
-    As a "provider" who holds information about patients, you can:
-
-    -create a pointer in the NRL to your information
-    -replace your NRL pointer with a newer pointer, superseding the old one
-    -update some of the metadata associated with your pointer
-    -delete your NRL pointer
-    -Search and read pointers, where you are authorised to do so, for a given patient
-    -Search and read all pointers you have provided
-
-    This service is new version of the NRL moving to R4 from STU3, more information on the existing STU3 NRL service can be found on the following page, [National Record Locator (NRL)](https://digital.nhs.uk/services/national-record-locator).
-
     There is a growing list of health and social care organisations authorised to share records using NRL.
 
+    ### As a Producer
+
+    * Create pointers, restricted to document types agreed during the on-boarding process
+    * Replace your pointers with a newer versions, superseding the old one
+    * Update the metadata associated with your pointers
+    * Delete pointers
+    * Search all pointers you created
+    * Read any pointer you created
+
+    ### What has changed?
+
+    This service is a replacement for the existing [National Record Locator (NRL)](https://digital.nhs.uk/services/national-record-locator).
+
+    * Upgraded from FHIR STU3 to R4.
+    * Improved performance and scalability.
+    * Improved on-boarding experience.
+    * Authenticated using [signed JWT](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation/application-restricted-restful-apis-signed-jwt-authentication) rather than mTLS
+    * Greater flexibility, by wider support of the FHIR R4 DocumentReference resource.
+
     ### Data availability, timing and quality
+
     Pointers are available to be consumed almost immediately after they have been produced by the provider.
 
     Pointers are immediately available to authorised providers and consumers after successful creation.
+
     ## Who can use this API
+
     This API:
     - is only for use by patient-facing applications
     - is only for non-clinical use
@@ -48,6 +65,7 @@ info:
     You must do this before you can go live (see ‘Onboarding’ below).
 
     ## API status and roadmap
+
     This API is [in development](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#statuses).
 
     To see our roadmap, or to suggest, comment or vote on features for this API, see our [interactive product backlog](https://nhs-digital-api-management.featureupvote.com/?tag=national-record-locator-api).
@@ -55,11 +73,13 @@ info:
     If you have any other queries, [contact us](https://digital.nhs.uk/developer/help-and-support).
 
     ## Service level
+
     This API is a bronze service, meaning it is operational and supported only during business hours (8am to 6pm), Monday to Friday excluding bank holidays.
 
     For more details, see [service levels](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#service-levels).
 
     ## Technology
+
     This API is [RESTful](https://digital.nhs.uk/developer/guides-and-documentation/our-api-technologies#basic-rest).
 
     It conforms to the [FHIR](https://digital.nhs.uk/developer/guides-and-documentation/our-api-technologies#fhir) global standard for health care data exchange, specifically to [FHIR R4 (v4.0.1)](https://hl7.org/fhir/r4/), except that it does not support the [capabilities](http://hl7.org/fhir/R4/http.html#capabilities) interaction.
@@ -67,14 +87,17 @@ info:
     It includes some country-specific FHIR extensions, which conform to [FHIR UK Core](https://digital.nhs.uk/services/fhir-uk-core), specifically [fhir.r4.ukcore.stu1 0.5.1](https://simplifier.net/packages/fhir.r4.ukcore.stu1/0.5.1).
 
     You do not need to know much about FHIR to use this API - FHIR APIs are just RESTful APIs that follow specific rules.
+
     In particular:
-    - resource names are capitalised and singular, and use US spellings, for example `/Immunization` not `/immunisations`
-    - array names are singular, for example `entry` not `entries` for address lines
-    - data items that are country-specific and thus not included in the FHIR global base resources are usually wrapped in an `extension` object
+
+    * resource names are capitalised and singular, and use US spellings, for example `/Immunization` not `/immunisations`
+    * array names are singular, for example `entry` not `entries` for address lines
+    * data items that are country-specific and thus not included in the FHIR global base resources are usually wrapped in an `extension` object
 
     There are [libraries and SDKs available](https://digital.nhs.uk/developer/guides-and-documentation/api-technologies-at-nhs-digital#fhir-libraries-and-sdks) to help with FHIR API integration.
 
     ## Network access
+
     This API is available on the internet and, indirectly, on the [Health and Social Care Network (HSCN)](https://digital.nhs.uk/services/health-and-social-care-network).
 
     For more details see [Network access for APIs](https://digital.nhs.uk/developer/guides-and-documentation/network-access-for-apis).
@@ -82,16 +105,11 @@ info:
     ## Security and authorisation
 
     This API uses the following access modes:
-    * application-restricted access
 
-    ### Application-restricted access
-
-    This access mode is [application-restricted](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation#application-restricted-apis), meaning we authenticate the calling application but not the end user.
-
-    To use this access mode, use the following security pattern:
     * [Application-restricted RESTful API - signed JWT authentication](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation/application-restricted-restful-apis-signed-jwt-authentication)
 
     ## Environments and testing
+
     | Environment       | Base URL                                                               |
     | ----------------- | ---------------------------------------------------------------------- |
     | Sandbox           | `https://sandbox.api.service.nhs.uk/nrl-producer-api/FHIR/R4/`     |
@@ -99,6 +117,7 @@ info:
     | Production        | `https://api.service.nhs.uk/nrl-producer-api/FHIR/R4/`             |
 
     ### Sandbox testing
+
     Our [sandbox environment](https://digital.nhs.uk/developer/guides-and-documentation/testing#sandbox-testing):
     * is for early developer testing
     * only covers a limited set of scenarios
@@ -111,6 +130,7 @@ info:
     [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/TBC)
 
     ### Integration testing
+
     Our [integration test environment](https://digital.nhs.uk/developer/guides-and-documentation/testing#integration-testing):
     * is for formal integration testing
     * includes authorisation
@@ -120,6 +140,7 @@ info:
     For more details see [integration testing with our RESTful APIs](https://digital.nhs.uk/developer/guides-and-documentation/testing#integration-testing-with-our-restful-apis).
 
     ## Onboarding
+
     You need to get your software approved by us before it can go live with this API. We call this onboarding. The onboarding process can sometimes be quite long, so it’s worth planning well ahead.
 
     This API uses our online digital onboarding process.
@@ -143,13 +164,9 @@ servers:
     description: Integration test environment.
   - url: https://api.service.nhs.uk/nrl-producer-api/FHIR/R4
     description: Production environment.
-tags:
-  - name: NRLF Producer
 paths:
   /DocumentReference:
     post:
-      tags:
-        - NRLF Producer
       summary: Create / Supersede
       operationId: createDocumentReference
       responses:
@@ -161,7 +178,20 @@ paths:
           content:
             application/fhir+json:
               example:
-                TBC: true
+                resourceType: OperationOutcome
+                id: 76db24dc-324a-468a-bf02-c06e82279488
+                meta:
+                  profile:
+                    - https://fhir.nhs.uk/StructureDefinition/NHSDigital-OperationOutcome
+                issue:
+                  - severity: information
+                    code: informational
+                    details:
+                      coding:
+                        - system: https://fhir.nhs.uk/CodeSystem/NRLF-SuccessCode
+                          code: RESOURCE_CREATED
+                          display: Resource created
+                    diagnostics: Resource created
       requestBody:
         $ref: "#/components/requestBodies/DocumentReference"
       parameters:
@@ -169,10 +199,26 @@ paths:
         - $ref: "#/components/parameters/requestId"
         - $ref: "#/components/parameters/correlationId"
       description: |
-        TBC
+        Create new Pointers, or Supersede existing ones.
+
+        * `id` is a composite of the ODS Code and an identifier that is locally unique to your system.  NRL does not generate globally unique ids, instead relies on producers to provide a locally unique id prefixed with their ODS code, making it globally unique.
+        * `subject` MUST be a `Patient` reference.
+        * `custodian` MUST be an `Organization` reference, and must match the `NHSD-End-User-Organisation-ODS`
+        * `type` MUST match one of the Document Types agreed during on-boarding.
+        * `content` MUST have at least one entry.
+        * `content[].format[]` SHOULD indicate the mechanism for accessing documents, e.g.
+          * `{ "code": "ssp", "display": "Spine Secure Proxy" }`
+          * Further standards to be agreed.
+
+        To supersede existing pointers you must specify:
+        * at least one existing pointer in the `relatesTo` with a `target` or `replaces`.
+        * The following fields MUST match the pointers being superseded:
+          * `subject`
+          * `type`
+
+        This will cause a new pointer to be created and superseded pointers to be deleted.  Multiple documents can
+        be superseded.
     get:
-      tags:
-        - NRLF Producer
       summary: Search (GET)
       operationId: searchDocumentReference
       parameters:
@@ -191,18 +237,180 @@ paths:
               schema:
                 $ref: "#/components/schemas/Bundle"
               example:
-                TBC: true
+                resourceType: Bundle
+                type: searchset
+                total: 2
+                entry:
+                  - resource:
+                      resourceType: DocumentReference
+                      id: Y05868-1834567891
+                      meta:
+                        profile:
+                          - http://fhir.nhs.net/StructureDefinition/nrls-documentreference-1-0
+                      masterIdentifier:
+                        system: urn:ietf:rfc:3986
+                        value: urn:oid:1.3.6.1.4.1.21367.2004.3.7
+                      identifier:
+                        - system: urn:ietf:rfc:3986
+                          value: urn:oid:1.3.6.1.4.1.21367.2005.3.7.1134
+                      status: current
+                      docStatus: "preliminary "
+                      type:
+                        coding:
+                          - system: http://snomed.info/sct
+                            code: "1363501000000100"
+                            display: Royal College of Physicians NEWS2 (National Early Warning Score 2) chart
+                      category:
+                        - coding:
+                            - system: http://loinc.org
+                              code: 34769-0
+                              display: General medicine Physician attending Note
+                      subject:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/nhs-number
+                          value: "3495456481"
+                      date: "2022-12-22T11:45:41+11:00"
+                      author:
+                        - identifier:
+                            value: Practitioner/A782161SZ
+                      authenticator:
+                        identifier:
+                          value: Organization/Y05868
+                      custodian:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/ods-organization-code
+                          value: Y05868
+                      securityLabel:
+                        - coding:
+                            - system: http://terminology.hl7.org/CodeSystem/v3-Confidentiality
+                              code: V
+                              display: very restricted
+                      content:
+                        - attachment:
+                            contentType: application/pdf
+                            language: en-US
+                            url: https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/EPAACS/PhysicianNote.pdf
+                            creation: "2022-12-22T09:45:41+11:00"
+                          format:
+                            system: urn:oid:1.3.6.1.4.1.19376.1.2.3
+                            code: urn:ihe:pcc:handp:2008
+                            display: History and Physical Specification
+                      context:
+                        encounter:
+                          - identifier:
+                              value: Encounter/3495456481
+                        event:
+                          - coding:
+                              - system: http://snomed.info/sct
+                                code: "445627002"
+                                display: Assessment using adult early warning scoring system
+                        period:
+                          start: "2022-12-20T09:00:41+11:00"
+                          end: "2022-12-20T09:45:41+11:00"
+                        facilityType:
+                          coding:
+                            - system: http://snomed.info/sct
+                              code: "273580000"
+                              display: London hospital pain chart assessment
+                        related:
+                          - identifier:
+                              system: https://fhir.nhs.uk/Id/ods-organization-code
+                              value: ROYAL COLLEGE OF PHYSICIANS OF LONDON
+                  - resource:
+                      resourceType: DocumentReference
+                      id: Y05868-1234567891
+                      meta:
+                        profile:
+                          - http://fhir.nhs.net/StructureDefinition/nrls-documentreference-1-0
+                      masterIdentifier:
+                        system: urn:ietf:rfc:3986
+                        value: urn:oid:1.3.6.1.4.1.21367.2005.3.7
+                      identifier:
+                        - system: urn:ietf:rfc:3986
+                          value: urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234
+                      status: current
+                      docStatus: final
+                      type:
+                        coding:
+                          - system: http://snomed.info/sct
+                            code: "861421000000109"
+                            display: End of life care coordination summary
+                      category:
+                        - coding:
+                            - system: http://loinc.org
+                              code: 55112-7
+                              display: Document summary
+                      subject:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/nhs-number
+                          value: "3495456481"
+                      date: "2022-12-21T10:45:41+11:00"
+                      author:
+                        - identifier:
+                            value: Practitioner/A985657ZA
+                      authenticator:
+                        identifier:
+                          value: Organization/Y05868
+                      custodian:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/ods-organization-code
+                          value: Y05868
+                      description: Physical
+                      securityLabel:
+                        - coding:
+                            - system: http://terminology.hl7.org/CodeSystem/v3-Confidentiality
+                              code: V
+                              display: very restricted
+                      content:
+                        - attachment:
+                            contentType: application/pdf
+                            language: en-US
+                            url: https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/EPAACS/EOLSummaryReport.pdf
+                            size: 3654
+                            hash: 2jmj7l5rSw0yVb/vlWAYkK/YBwk=
+                            title: Physical
+                            creation: "2022-12-21T10:45:41+11:00"
+                          format:
+                            system: urn:oid:1.3.6.1.4.1.19376.1.2.3
+                            code: urn:ihe:pcc:cm:2008
+                            display: Care Management
+                      context:
+                        encounter:
+                          - identifier:
+                              value: Encounter/3495456481
+                        event:
+                          - coding:
+                              - system: http://snomed.info/sct
+                                code: "713058002"
+                                display: End of life care planning
+                        period:
+                          start: "2022-12-21T09:00:41+11:00"
+                          end: "2022-12-21T10:45:41+11:00"
+                        facilityType:
+                          coding:
+                            - system: http://snomed.info/sct
+                              code: "73770003"
+                              display: Hospital-based outpatient emergency care center
+                        sourcePatientInfo:
+                          identifier:
+                            value: Patient/3495456481
+                        related:
+                          - identifier:
+                              system: https://fhir.nhs.uk/Id/ods-organization-code
+                              value: TRAFFORD GENERAL HOSPITAL
           headers:
             X-Correlation-Id:
               $ref: "#/components/headers/CorrelationId"
             X-Request-Id:
               $ref: "#/components/headers/RequestId"
       description: |
-        Perform a Search using GET query string parameters
+        Perform a Search using GET query string parameters.
+
+        Results are restricted to pointers you created.
+
+        Results are limited to 20 records, further results are
   /DocumentReference/_search:
     post:
-      tags:
-        - NRLF Producer
       summary: Search (POST)
       operationId: searchPostDocumentReference
       parameters:
@@ -222,18 +430,181 @@ paths:
               schema:
                 $ref: "#/components/schemas/Bundle"
               example:
-                TBC: true
+                resourceType: Bundle
+                type: searchset
+                total: 2
+                entry:
+                  - resource:
+                      resourceType: DocumentReference
+                      id: Y05868-1834567891
+                      meta:
+                        profile:
+                          - http://fhir.nhs.net/StructureDefinition/nrls-documentreference-1-0
+                      masterIdentifier:
+                        system: urn:ietf:rfc:3986
+                        value: urn:oid:1.3.6.1.4.1.21367.2004.3.7
+                      identifier:
+                        - system: urn:ietf:rfc:3986
+                          value: urn:oid:1.3.6.1.4.1.21367.2005.3.7.1134
+                      status: current
+                      docStatus: "preliminary "
+                      type:
+                        coding:
+                          - system: http://snomed.info/sct
+                            code: "1363501000000100"
+                            display: Royal College of Physicians NEWS2 (National Early Warning Score 2) chart
+                      category:
+                        - coding:
+                            - system: http://loinc.org
+                              code: 34769-0
+                              display: General medicine Physician attending Note
+                      subject:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/nhs-number
+                          value: "3495456481"
+                      date: "2022-12-22T11:45:41+11:00"
+                      author:
+                        - identifier:
+                            value: Practitioner/A782161SZ
+                      authenticator:
+                        identifier:
+                          value: Organization/Y05868
+                      custodian:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/ods-organization-code
+                          value: Y05868
+                      securityLabel:
+                        - coding:
+                            - system: http://terminology.hl7.org/CodeSystem/v3-Confidentiality
+                              code: V
+                              display: very restricted
+                      content:
+                        - attachment:
+                            contentType: application/pdf
+                            language: en-US
+                            url: https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/EPAACS/PhysicianNote.pdf
+                            creation: "2022-12-22T09:45:41+11:00"
+                          format:
+                            system: urn:oid:1.3.6.1.4.1.19376.1.2.3
+                            code: urn:ihe:pcc:handp:2008
+                            display: History and Physical Specification
+                      context:
+                        encounter:
+                          - identifier:
+                              value: Encounter/3495456481
+                        event:
+                          - coding:
+                              - system: http://snomed.info/sct
+                                code: "445627002"
+                                display: Assessment using adult early warning scoring system
+                        period:
+                          start: "2022-12-20T09:00:41+11:00"
+                          end: "2022-12-20T09:45:41+11:00"
+                        facilityType:
+                          coding:
+                            - system: http://snomed.info/sct
+                              code: "273580000"
+                              display: London hospital pain chart assessment
+                        related:
+                          - identifier:
+                              system: https://fhir.nhs.uk/Id/ods-organization-code
+                              value: ROYAL COLLEGE OF PHYSICIANS OF LONDON
+                  - resource:
+                      resourceType: DocumentReference
+                      id: Y05868-1234567891
+                      meta:
+                        profile:
+                          - http://fhir.nhs.net/StructureDefinition/nrls-documentreference-1-0
+                      masterIdentifier:
+                        system: urn:ietf:rfc:3986
+                        value: urn:oid:1.3.6.1.4.1.21367.2005.3.7
+                      identifier:
+                        - system: urn:ietf:rfc:3986
+                          value: urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234
+                      status: current
+                      docStatus: final
+                      type:
+                        coding:
+                          - system: http://snomed.info/sct
+                            code: "861421000000109"
+                            display: End of life care coordination summary
+                      category:
+                        - coding:
+                            - system: http://loinc.org
+                              code: 55112-7
+                              display: Document summary
+                      subject:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/nhs-number
+                          value: "3495456481"
+                      date: "2022-12-21T10:45:41+11:00"
+                      author:
+                        - identifier:
+                            value: Practitioner/A985657ZA
+                      authenticator:
+                        identifier:
+                          value: Organization/Y05868
+                      custodian:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/ods-organization-code
+                          value: Y05868
+                      description: Physical
+                      securityLabel:
+                        - coding:
+                            - system: http://terminology.hl7.org/CodeSystem/v3-Confidentiality
+                              code: V
+                              display: very restricted
+                      content:
+                        - attachment:
+                            contentType: application/pdf
+                            language: en-US
+                            url: https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/EPAACS/EOLSummaryReport.pdf
+                            size: 3654
+                            hash: 2jmj7l5rSw0yVb/vlWAYkK/YBwk=
+                            title: Physical
+                            creation: "2022-12-21T10:45:41+11:00"
+                          format:
+                            system: urn:oid:1.3.6.1.4.1.19376.1.2.3
+                            code: urn:ihe:pcc:cm:2008
+                            display: Care Management
+                      context:
+                        encounter:
+                          - identifier:
+                              value: Encounter/3495456481
+                        event:
+                          - coding:
+                              - system: http://snomed.info/sct
+                                code: "713058002"
+                                display: End of life care planning
+                        period:
+                          start: "2022-12-21T09:00:41+11:00"
+                          end: "2022-12-21T10:45:41+11:00"
+                        facilityType:
+                          coding:
+                            - system: http://snomed.info/sct
+                              code: "73770003"
+                              display: Hospital-based outpatient emergency care center
+                        sourcePatientInfo:
+                          identifier:
+                            value: Patient/3495456481
+                        related:
+                          - identifier:
+                              system: https://fhir.nhs.uk/Id/ods-organization-code
+                              value: TRAFFORD GENERAL HOSPITAL
           headers:
             X-Correlation-Id:
               $ref: "#/components/headers/CorrelationId"
             X-Request-Id:
               $ref: "#/components/headers/RequestId"
       description: |
-        Same as above but a POST to avoid URL length limits
+        Search Producer records, but implemented as a POST operation
+        because of limitations associated with GET:
+
+        * query string parameters are visible on the network and in logs, and may have privacy implications for consumers.
+        * GET operations can be cached by intermediary network infrastructure, such as CDNs, routers and proxies.
+        * URLs have a maximum length of 2,048 characters which complex searches can exceed.  NRL does not currently exceed this limit, but may evolve in the future.
   /DocumentReference/{id}:
     get:
-      tags:
-        - NRLF Producer
       summary: Read
       operationId: readDocumentReference
       parameters:
@@ -249,17 +620,79 @@ paths:
               schema:
                 $ref: "#/components/schemas/DocumentReference"
               example:
-                TBC: true
+                resourceType: DocumentReference
+                id: Y05868-1234567892
+                status: current
+                docStatus: final
+                type:
+                  coding:
+                    - system: http://snomed.info/sct
+                      code: "887701000000100"
+                      display: Emergency health care plan
+                category:
+                  - coding:
+                      - system: http://loinc.org
+                        code: 68552-9
+                        display: Emergency medicine Emergency department Admission evaluation note
+                subject:
+                  identifier:
+                    system: https://fhir.nhs.uk/Id/nhs-number
+                    value: "4409815415"
+                date: "2022-12-22T11:45:41+11:00"
+                author:
+                  - identifier:
+                      value: Practitioner/A985657ZA
+                authenticator:
+                  identifier:
+                    value: Organization/Y05868
+                custodian:
+                  identifier:
+                    system: https://fhir.nhs.uk/Id/ods-organization-code
+                    value: Y05868
+                securityLabel:
+                  - coding:
+                      - system: http://terminology.hl7.org/CodeSystem/v3-Confidentiality
+                        code: V
+                        display: very restricted
+                content:
+                  - attachment:
+                      contentType: application/pdf
+                      language: en-US
+                      url: https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/EPAACS/EmergencyCarPlan.pdf
+                      creation: "2022-12-22T09:45:41+11:00"
+                    format:
+                      system: urn:oid:1.3.6.1.4.1.19376.1.2.3
+                      code: urn:ihe:pcc:handp:2008
+                      display: History and Physical Specification
+                context:
+                  encounter:
+                    - identifier:
+                        value: Encounter/4409815415
+                  event:
+                    - coding:
+                        - system: http://snomed.info/sct
+                          code: "702779007"
+                          display: Emergency health care plan agreed
+                  period:
+                    start: "2022-12-20T09:00:41+11:00"
+                    end: "2022-12-20T09:45:41+11:00"
+                  facilityType:
+                    coding:
+                      - system: http://snomed.info/sct
+                        code: "453121000124107"
+                        display: Emergency department healthcare professional
+                  related:
+                    - identifier:
+                        system: https://fhir.nhs.uk/Id/ods-organization-code
+                        value: EMERGENCY DEPT PRIMARY CARE STREAMING
           headers:
             X-Correlation-Id:
               $ref: "#/components/headers/CorrelationId"
             X-Request-Id:
               $ref: "#/components/headers/RequestId"
       description: |
-        Read a single DocumentReference record
+        Read a single pointer you created
     put:
-      tags:
-        - NRLF Producer
       summary: Update
       operationId: updateDocumentReference
       parameters:
@@ -274,17 +707,34 @@ paths:
           content:
             application/fhir+json:
               example:
-                TBC: true
+                resourceType: OperationOutcome
+                id: fc39effb-144c-4342-bdf2-4214f0cb728b
+                meta:
+                  profile:
+                    - https://fhir.nhs.uk/StructureDefinition/NHSDigital-OperationOutcome
+                issue:
+                  - severity: information
+                    code: informational
+                    details:
+                      coding:
+                        - system: https://fhir.nhs.uk/CodeSystem/NRLF-SuccessCode
+                          code: RESOURCE_UPDATED
+                          display: Resource updated
+                    diagnostics: Resource updated
         "201":
           description: Create DocumentReference operation successful (requires 'updateCreateEnabled' configuration option)
           $ref: "#/components/responses/Success"
       requestBody:
         $ref: "#/components/requestBodies/DocumentReference"
       description: |
-        Update a single DocumentReference record
+        Update a single pointer you created.
+
+        Note that the following fields are immutable:
+        * `id`
+        * `subject`
+        * `custodian`
+        * `type`
     delete:
-      tags:
-        - NRLF Producer
       summary: Delete
       operationId: deleteDocumentReference
       parameters:
@@ -302,7 +752,20 @@ paths:
           content:
             application/fhir+json:
               example:
-                TBC: true
+                resourceType: OperationOutcome
+                id: c6113a50-70bf-436e-b417-7c8024d2e8bf
+                meta:
+                  profile:
+                    - https://fhir.nhs.uk/StructureDefinition/NHSDigital-OperationOutcome
+                issue:
+                  - severity: information
+                    code: informational
+                    details:
+                      coding:
+                        - system: https://fhir.nhs.uk/CodeSystem/NRLF-SuccessCode
+                          code: RESOURCE_REMOVED
+                          display: Resource removed
+                    diagnostics: Resource removed
       description: |
         Delete a single DocumentReference record
 components:
@@ -470,7 +933,7 @@ components:
             - VisionPrescription
         id:
           type: string
-          pattern: '[A-Za-z0-9\-\.]{1,64}'
+          pattern: "[A-Za-z0-9\\-\\.]{1,64}"
           description: The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.
         meta:
           $ref: "#/components/schemas/Meta"
@@ -481,7 +944,7 @@ components:
           description: A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.
         language:
           type: string
-          pattern: '[^\s]+(\s[^\s]+)*'
+          pattern: "[^\\s]+(\\s[^\\s]+)*"
           description: The base language in which the resource is written.
       required:
         - resourceType
@@ -526,11 +989,11 @@ components:
                 description: Other identifiers associated with the document, including version independent identifiers.
             status:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The status of this document reference.
             docStatus:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The status of the underlying document.
             type:
               $ref: "#/components/schemas/CodeableConcept"
@@ -565,7 +1028,7 @@ components:
                 description: Relationships that this document has with other document references that already exist.
             description:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Human&ndash;readable description of the source document.
             securityLabel:
               type: array
@@ -876,7 +1339,7 @@ components:
               description: A persistent identifier for the bundle that won't change as a bundle is copied from server to server.
             type:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Indicates the purpose of this bundle &ndash; how it is intended to be used.
             timestamp:
               type: string
@@ -1102,7 +1565,7 @@ components:
           properties:
             status:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The status code returned by processing this entry. The status SHALL start with a 3 digit HTTP code (e.g. 404) and may contain the standard HTTP description associated with the status code.
             location:
               type: string
@@ -1110,7 +1573,7 @@ components:
               description: The location header created by processing this operation, populated if the operation returns a location.
             etag:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The Etag for the resource, if the operation for the entry produced a versioned resource (see [Resource Metadata and Versioning](http.html#versioning) and [Managing Resource Contention](http.html#concurrency)).
             lastModified:
               type: string
@@ -1128,7 +1591,7 @@ components:
           properties:
             method:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: In a transaction or batch, this is the HTTP action to be executed for this entry. In a history bundle, this indicates the HTTP action that occurred.
             url:
               type: string
@@ -1136,7 +1599,7 @@ components:
               description: The URL for this entry, relative to the root (the address to which the request is posted).
             ifNoneMatch:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: If the ETag values match, return a 304 Not Modified status. See the API documentation for ["Conditional Read"](http.html#cread).
             ifModifiedSince:
               type: string
@@ -1144,11 +1607,11 @@ components:
               description: Only perform the operation if the last updated date matches. See the API documentation for ["Conditional Read"](http.html#cread).
             ifMatch:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Only perform the operation if the Etag value matches. For more information, see the API section ["Managing Resource Contention"](http.html#concurrency).
             ifNoneExist:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Instruct the server not to perform the create if a specified resource already exists. For further information, see the API documentation for ["Conditional Create"](http.html#ccreate). This is just the query portion of the URL &ndash; what follows the "?" (not including the "?").
           required:
             - method
@@ -1160,7 +1623,7 @@ components:
           properties:
             mode:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Why this entry is in the result set &ndash; whether it's included as a match or because of an _include requirement, or to convey information or warning information about the search process.
             score:
               type: number
@@ -1172,7 +1635,7 @@ components:
           properties:
             relation:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A name which details the functional use for this link &ndash; see [http://www.iana.org/assignments/link&ndash;relations/link&ndash;relations.xhtml#link&ndash;relations&ndash;1](http://www.iana.org/assignments/link&ndash;relations/link&ndash;relations.xhtml#link&ndash;relations&ndash;1).
             url:
               type: string
@@ -1233,7 +1696,7 @@ components:
           properties:
             code:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The type of relationship that this document has with anther document.
             target:
               $ref: "#/components/schemas/Reference"
@@ -1248,30 +1711,30 @@ components:
           properties:
             severity:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Indicates whether the issue indicates a variation from successful processing.
             code:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Describes the type of the issue. The system that creates an OperationOutcome SHALL choose the most applicable code from the IssueType value set, and may additional provide its own code for the error in the details element.
             details:
               $ref: "#/components/schemas/CodeableConcept"
               description: Additional details about the error. This may be a text description of the error or a system code that identifies the error.
             diagnostics:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Additional diagnostic information about the issue.
             location:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: "This element is deprecated because it is XML specific. It is replaced by issue.expression, which is format independent, and simpler to parse. \n\nFor resource issues, this will be a simple XPath limited to element names, repetition indicators and the default child accessor that identifies one of the elements in the resource that caused this issue to be raised.  For HTTP errors, will be \"http.\" + the parameter name."
             expression:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: A [simple subset of FHIRPath](fhirpath.html#simple) limited to element names, repetition indicators and the default child accessor that identifies one of the elements in the resource that caused this issue to be raised.
           required:
             - severity
@@ -1281,7 +1744,7 @@ components:
       properties:
         id:
           type: string
-          pattern: '[A-Za-z0-9\-\.]{1,64}'
+          pattern: "[A-Za-z0-9\\-\\.]{1,64}"
           description: Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.
         extension:
           type: array
@@ -1311,41 +1774,41 @@ components:
           properties:
             use:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The purpose of this address.
             type:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Distinguishes between physical addresses (those you can visit) and mailing addresses (e.g. PO Boxes and care&ndash;of addresses). Most addresses are both.
             text:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Specifies the entire address as it should be displayed e.g. on a postal label. This may be provided instead of or as well as the specific parts.
             line:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: This component contains the house number, apartment number, street name, street direction,  P.O. Box number, delivery hints, and similar address information.
             city:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The name of the city, town, suburb, village or other community or delivery center.
             district:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The name of the administrative area (county).
             state:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Sub&ndash;unit of a country with limited sovereignty in a federally organized country. A code may be used if codes are in common use (e.g. US 2 letter state codes).
             postalCode:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A postal code designating a region defined by the postal service.
             country:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Country &ndash; a nation as commonly understood or generally accepted.
             period:
               $ref: "#/components/schemas/Period"
@@ -1365,7 +1828,7 @@ components:
               description: The individual responsible for making the annotation.
             authorString:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The individual responsible for making the annotation.
             time:
               type: string
@@ -1373,7 +1836,7 @@ components:
               description: Indicates when this particular annotation was made.
             text:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The text of the annotation in markdown format.
           required:
             - text
@@ -1384,11 +1847,11 @@ components:
           properties:
             contentType:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Identifies the type of the data in the attachment and allows a method to be chosen to interpret or render the data. Includes mime type parameters such as charset where appropriate.
             language:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The human language of the content. The value can be any valid value according to BCP 47.
             data:
               type: string
@@ -1408,7 +1871,7 @@ components:
               description: The calculated hash of the data using SHA&ndash;1. Represented using base64.
             title:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A label or set of text to display in place of the data.
             creation:
               type: string
@@ -1426,7 +1889,7 @@ components:
                 description: A reference to a code defined by a terminology system.
             text:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.
     Coding:
       allOf:
@@ -1439,15 +1902,15 @@ components:
               description: The identification of the code system that defines the meaning of the symbol in the code.
             version:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The version of the code system which was used when choosing this code. Note that a well&ndash;maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.
             code:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post&ndash;coordination).
             display:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A representation of the meaning of the code in the system, following the rules of the system.
             userSelected:
               type: boolean
@@ -1459,15 +1922,15 @@ components:
           properties:
             system:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Telecommunications form for contact point &ndash; what communications system is required to make use of the contact.
             value:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address).
             use:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Identifies the purpose for the contact point.
             rank:
               type: integer
@@ -1498,33 +1961,33 @@ components:
           properties:
             use:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Identifies the purpose for this name.
             text:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Specifies the entire name as it should be displayed e.g. on an application UI. This may be provided instead of or as well as the specific parts.
             family:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father.
             given:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: Given name.
             prefix:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name.
             suffix:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name.
             period:
               $ref: "#/components/schemas/Period"
@@ -1536,7 +1999,7 @@ components:
           properties:
             use:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The purpose of this identifier.
             type:
               $ref: "#/components/schemas/CodeableConcept"
@@ -1547,7 +2010,7 @@ components:
               description: Establishes the namespace for the value &ndash; that is, a URL that describes a set values that are unique.
             value:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The portion of the identifier typically relevant to the user and which is unique within the context of the system.
             period:
               $ref: "#/components/schemas/Period"
@@ -1569,7 +2032,7 @@ components:
               description: Numerical value (with implicit precision).
             currency:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: ISO 4217 Currency Code.
     MoneyQuantity:
       allOf:
@@ -1599,11 +2062,11 @@ components:
               description: The value of the measured amount. The value includes an implicit precision in the presentation of the value.
             comparator:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: How the value should be understood and represented &ndash; whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is "<" , then the real value is < stated value.
             unit:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A human&ndash;readable form of the unit.
             system:
               type: string
@@ -1611,7 +2074,7 @@ components:
               description: The identification of the system that provides the coded form of the unit.
             code:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: A computer processable form of the unit in some unit representation system.
     Range:
       allOf:
@@ -1642,7 +2105,7 @@ components:
           properties:
             reference:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with '#') refer to contained resources.
             type:
               type: string
@@ -1656,7 +2119,7 @@ components:
               description: An identifier for the target resource. This is used when there is no way to reference the other resource directly, either because the entity it represents is not available through a FHIR server, or because there is no way for the author of the resource to convert a known identifier to an actual location. There is no requirement that a Reference.identifier point to something that is actually exposed as a FHIR instance, but it SHALL point to a business concept that would be expected to be exposed as a FHIR instance, and that instance would need to be of a FHIR resource type allowed by the reference.
             display:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Plain text narrative that identifies the resource in addition to the resource reference.
     SampledData:
       allOf:
@@ -1684,7 +2147,7 @@ components:
               description: The number of sample points at each time point. If this value is greater than one, then the dimensions will be interlaced &ndash; all the sample points for a point in time will be recorded at once.
             data:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A series of data points which are decimal values separated by a single space (character u20). The special values "E" (error), "L" (below detection limit) and "U" (above detection limit) can also be used in place of a decimal value.
           required:
             - origin
@@ -1718,11 +2181,11 @@ components:
               description: A reference to an application&ndash;usable description of the identity that is represented by the signature.
             targetFormat:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: A mime type that indicates the technical format of the target resources signed by the signature.
             sigFormat:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: A mime type that indicates the technical format of the signature. Important mime types are application/signature+xml for X ML DigSig, application/jose for JWS, and image/* for a graphical image of a signature, etc.
             data:
               type: string
@@ -1779,7 +2242,7 @@ components:
               description: If present, indicates that the duration is a range &ndash; so to perform the action between [duration] and [durationMax] time length.
             durationUnit:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The units of time for the duration, in UCUM units.
             frequency:
               type: integer
@@ -1797,13 +2260,13 @@ components:
               description: If present, indicates that the period is a range from [period] to [periodMax], allowing expressing concepts such as "do this once every 3&ndash;5 days.
             periodUnit:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The units of time for the period in UCUM units.
             dayOfWeek:
               type: array
               items:
                 type: string
-                pattern: '[^\s]+(\s[^\s]+)*'
+                pattern: "[^\\s]+(\\s[^\\s]+)*"
                 description: If one or more days of week is provided, then the action happens only on the specified day(s).
             timeOfDay:
               type: array
@@ -1815,7 +2278,7 @@ components:
               type: array
               items:
                 type: string
-                pattern: '[^\s]+(\s[^\s]+)*'
+                pattern: "[^\\s]+(\\s[^\\s]+)*"
                 description: An approximate time period during the day, potentially linked to an event of daily living that indicates when the action should occur.
             offset:
               type: integer
@@ -1828,7 +2291,7 @@ components:
           properties:
             name:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The name of an individual to contact.
             telecom:
               type: array
@@ -1842,19 +2305,19 @@ components:
           properties:
             type:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The type of relationship to the related artifact.
             label:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A short label that can be used to reference the citation from elsewhere in the containing artifact, such as a footnote index.
             display:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A brief description of the document or knowledge resource being referenced, suitable for display to a consumer.
             citation:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A bibliographic citation for the related artifact. This text SHOULD be formatted according to an accepted citation format.
             url:
               type: string
@@ -1898,7 +2361,7 @@ components:
           properties:
             versionId:
               type: string
-              pattern: '[A-Za-z0-9\-\.]{1,64}'
+              pattern: "[A-Za-z0-9\\-\\.]{1,64}"
               description: The version specific identifier, as it appears in the version portion of the URL. This value changes when the resource is created, updated, or deleted.
             lastUpdated:
               type: string
@@ -1931,7 +2394,7 @@ components:
           properties:
             status:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The status of the narrative &ndash; whether it's entirely generated (from just the defined data or the extensions too), or whether a human authored it and it may contain additional data.
             div:
               type: string
@@ -1961,7 +2424,7 @@ components:
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueCode:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueDate:
               type: string
@@ -1976,7 +2439,7 @@ components:
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueId:
               type: string
-              pattern: '[A-Za-z0-9\-\.]{1,64}'
+              pattern: "[A-Za-z0-9\\-\\.]{1,64}"
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueInstant:
               type: string
@@ -1988,7 +2451,7 @@ components:
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueMarkdown:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueOid:
               type: string
@@ -2000,7 +2463,7 @@ components:
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueString:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueTime:
               type: string

--- a/api/producer/swagger.yaml
+++ b/api/producer/swagger.yaml
@@ -6,30 +6,47 @@ info:
   title: National Record Locator Producer - FHIR API
   description: |
     ## Overview
-    The National Record Locator (NRL) is a service that holds pointers to data held in local provider systems.
 
-    The service facilitates national sharing, removing the need for organisations to create duplicate copies of information across systems and organisations, by enabling access to up-to-date information directly from the source.
+    The National Record Locator (NRL) enables organisations to share Patient data nationwide.  It acts as an Index, or Directory, of patient data.  Rather than handling the data itself it shares pointers held in partner systems, using the FHIR R4 DocumentReference standard.
+
+    Users of the service fall into the categories of:
+
+    * Producers - capable of creating and managing pointers
+    * Consumers - capable of searching and reading pointers
+
+    The service removes the need for organisations to create duplicate copies of information across systems and organisations, by enabling access to up-to-date information directly from the source.
 
     It can be used to store and publish pointers to patient data held in health systems across England and to look up where relevant patient data is held.
 
-    As a "provider" who holds information about patients, you can:
-
-    -create a pointer in the NRL to your information
-    -replace your NRL pointer with a newer pointer, superseding the old one
-    -update some of the metadata associated with your pointer
-    -delete your NRL pointer
-    -Search and read pointers, where you are authorised to do so, for a given patient
-    -Search and read all pointers you have provided
-
-    This service is new version of the NRL moving to R4 from STU3, more information on the existing STU3 NRL service can be found on the following page, [National Record Locator (NRL)](https://digital.nhs.uk/services/national-record-locator).
-
     There is a growing list of health and social care organisations authorised to share records using NRL.
 
+    ### As a Producer
+
+    * Create pointers, restricted to document types agreed during the on-boarding process
+    * Replace your pointers with a newer versions, superseding the old one
+    * Update the metadata associated with your pointers
+    * Delete pointers
+    * Search all pointers you created
+    * Read any pointer you created
+
+    ### What has changed?
+
+    This service is a replacement for the existing [National Record Locator (NRL)](https://digital.nhs.uk/services/national-record-locator).
+
+    * Upgraded from FHIR STU3 to R4.
+    * Improved performance and scalability.
+    * Improved on-boarding experience.
+    * Authenticated using [signed JWT](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation/application-restricted-restful-apis-signed-jwt-authentication) rather than mTLS
+    * Greater flexibility, by wider support of the FHIR R4 DocumentReference resource.
+
     ### Data availability, timing and quality
+
     Pointers are available to be consumed almost immediately after they have been produced by the provider.
 
     Pointers are immediately available to authorised providers and consumers after successful creation.
+
     ## Who can use this API
+
     This API:
     - is only for use by patient-facing applications
     - is only for non-clinical use
@@ -48,6 +65,7 @@ info:
     You must do this before you can go live (see ‘Onboarding’ below).
 
     ## API status and roadmap
+
     This API is [in development](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#statuses).
 
     To see our roadmap, or to suggest, comment or vote on features for this API, see our [interactive product backlog](https://nhs-digital-api-management.featureupvote.com/?tag=national-record-locator-api).
@@ -55,11 +73,13 @@ info:
     If you have any other queries, [contact us](https://digital.nhs.uk/developer/help-and-support).
 
     ## Service level
+
     This API is a bronze service, meaning it is operational and supported only during business hours (8am to 6pm), Monday to Friday excluding bank holidays.
 
     For more details, see [service levels](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#service-levels).
 
     ## Technology
+
     This API is [RESTful](https://digital.nhs.uk/developer/guides-and-documentation/our-api-technologies#basic-rest).
 
     It conforms to the [FHIR](https://digital.nhs.uk/developer/guides-and-documentation/our-api-technologies#fhir) global standard for health care data exchange, specifically to [FHIR R4 (v4.0.1)](https://hl7.org/fhir/r4/), except that it does not support the [capabilities](http://hl7.org/fhir/R4/http.html#capabilities) interaction.
@@ -67,14 +87,17 @@ info:
     It includes some country-specific FHIR extensions, which conform to [FHIR UK Core](https://digital.nhs.uk/services/fhir-uk-core), specifically [fhir.r4.ukcore.stu1 0.5.1](https://simplifier.net/packages/fhir.r4.ukcore.stu1/0.5.1).
 
     You do not need to know much about FHIR to use this API - FHIR APIs are just RESTful APIs that follow specific rules.
+
     In particular:
-    - resource names are capitalised and singular, and use US spellings, for example `/Immunization` not `/immunisations`
-    - array names are singular, for example `entry` not `entries` for address lines
-    - data items that are country-specific and thus not included in the FHIR global base resources are usually wrapped in an `extension` object
+
+    * resource names are capitalised and singular, and use US spellings, for example `/Immunization` not `/immunisations`
+    * array names are singular, for example `entry` not `entries` for address lines
+    * data items that are country-specific and thus not included in the FHIR global base resources are usually wrapped in an `extension` object
 
     There are [libraries and SDKs available](https://digital.nhs.uk/developer/guides-and-documentation/api-technologies-at-nhs-digital#fhir-libraries-and-sdks) to help with FHIR API integration.
 
     ## Network access
+
     This API is available on the internet and, indirectly, on the [Health and Social Care Network (HSCN)](https://digital.nhs.uk/services/health-and-social-care-network).
 
     For more details see [Network access for APIs](https://digital.nhs.uk/developer/guides-and-documentation/network-access-for-apis).
@@ -82,16 +105,11 @@ info:
     ## Security and authorisation
 
     This API uses the following access modes:
-    * application-restricted access
 
-    ### Application-restricted access
-
-    This access mode is [application-restricted](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation#application-restricted-apis), meaning we authenticate the calling application but not the end user.
-
-    To use this access mode, use the following security pattern:
     * [Application-restricted RESTful API - signed JWT authentication](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation/application-restricted-restful-apis-signed-jwt-authentication)
 
     ## Environments and testing
+
     | Environment       | Base URL                                                               |
     | ----------------- | ---------------------------------------------------------------------- |
     | Sandbox           | `https://sandbox.api.service.nhs.uk/nrl-producer-api/FHIR/R4/`     |
@@ -99,6 +117,7 @@ info:
     | Production        | `https://api.service.nhs.uk/nrl-producer-api/FHIR/R4/`             |
 
     ### Sandbox testing
+
     Our [sandbox environment](https://digital.nhs.uk/developer/guides-and-documentation/testing#sandbox-testing):
     * is for early developer testing
     * only covers a limited set of scenarios
@@ -111,6 +130,7 @@ info:
     [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/TBC)
 
     ### Integration testing
+
     Our [integration test environment](https://digital.nhs.uk/developer/guides-and-documentation/testing#integration-testing):
     * is for formal integration testing
     * includes authorisation
@@ -120,6 +140,7 @@ info:
     For more details see [integration testing with our RESTful APIs](https://digital.nhs.uk/developer/guides-and-documentation/testing#integration-testing-with-our-restful-apis).
 
     ## Onboarding
+
     You need to get your software approved by us before it can go live with this API. We call this onboarding. The onboarding process can sometimes be quite long, so it’s worth planning well ahead.
 
     This API uses our online digital onboarding process.
@@ -144,12 +165,10 @@ servers:
   - url: https://api.service.nhs.uk/nrl-producer-api/FHIR/R4
     description: Production environment.
 tags:
-  - name: NRLF Producer
 paths:
   /DocumentReference:
     post:
       tags:
-        - NRLF Producer
       summary: Create / Supersede
       operationId: createDocumentReference
       responses:
@@ -161,7 +180,20 @@ paths:
           content:
             application/fhir+json:
               example:
-                TBC: true
+                resourceType: OperationOutcome
+                id: 76db24dc-324a-468a-bf02-c06e82279488
+                meta:
+                  profile:
+                    - https://fhir.nhs.uk/StructureDefinition/NHSDigital-OperationOutcome
+                issue:
+                  - severity: information
+                    code: informational
+                    details:
+                      coding:
+                        - system: https://fhir.nhs.uk/CodeSystem/NRLF-SuccessCode
+                          code: RESOURCE_CREATED
+                          display: Resource created
+                    diagnostics: Resource created
       requestBody:
         $ref: "#/components/requestBodies/DocumentReference"
       parameters:
@@ -180,10 +212,27 @@ paths:
         passthroughBehavior: when_no_match
         contentHandling: CONVERT_TO_TEXT
       description: |
-        TBC
+        Create new Pointers, or Supersede existing ones.
+
+        * `id` is a composite of the ODS Code and an identifier that is locally unique to your system.  NRL does not generate globally unique ids, instead relies on producers to provide a locally unique id prefixed with their ODS code, making it globally unique.
+        * `subject` MUST be a `Patient` reference.
+        * `custodian` MUST be an `Organization` reference, and must match the `NHSD-End-User-Organisation-ODS`
+        * `type` MUST match one of the Document Types agreed during on-boarding.
+        * `content` MUST have at least one entry.
+        * `content[].format[]` SHOULD indicate the mechanism for accessing documents, e.g.
+          * `{ "code": "ssp", "display": "Spine Secure Proxy" }`
+          * Further standards to be agreed.
+
+        To supersede existing pointers you must specify:
+        * at least one existing pointer in the `relatesTo` with a `target` or `replaces`.
+        * The following fields MUST match the pointers being superseded:
+          * `subject`
+          * `type`
+
+        This will cause a new pointer to be created and superseded pointers to be deleted.  Multiple documents can
+        be superseded.
     get:
       tags:
-        - NRLF Producer
       summary: Search (GET)
       operationId: searchDocumentReference
       parameters:
@@ -202,7 +251,167 @@ paths:
               schema:
                 $ref: "#/components/schemas/Bundle"
               example:
-                TBC: true
+                resourceType: Bundle
+                type: searchset
+                total: 2
+                entry:
+                  - resource:
+                      resourceType: DocumentReference
+                      id: Y05868-1834567891
+                      meta:
+                        profile:
+                          - http://fhir.nhs.net/StructureDefinition/nrls-documentreference-1-0
+                      masterIdentifier:
+                        system: urn:ietf:rfc:3986
+                        value: urn:oid:1.3.6.1.4.1.21367.2004.3.7
+                      identifier:
+                        - system: urn:ietf:rfc:3986
+                          value: urn:oid:1.3.6.1.4.1.21367.2005.3.7.1134
+                      status: current
+                      docStatus: "preliminary "
+                      type:
+                        coding:
+                          - system: http://snomed.info/sct
+                            code: "1363501000000100"
+                            display: Royal College of Physicians NEWS2 (National Early Warning Score 2) chart
+                      category:
+                        - coding:
+                            - system: http://loinc.org
+                              code: 34769-0
+                              display: General medicine Physician attending Note
+                      subject:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/nhs-number
+                          value: "3495456481"
+                      date: "2022-12-22T11:45:41+11:00"
+                      author:
+                        - identifier:
+                            value: Practitioner/A782161SZ
+                      authenticator:
+                        identifier:
+                          value: Organization/Y05868
+                      custodian:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/ods-organization-code
+                          value: Y05868
+                      securityLabel:
+                        - coding:
+                            - system: http://terminology.hl7.org/CodeSystem/v3-Confidentiality
+                              code: V
+                              display: very restricted
+                      content:
+                        - attachment:
+                            contentType: application/pdf
+                            language: en-US
+                            url: https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/EPAACS/PhysicianNote.pdf
+                            creation: "2022-12-22T09:45:41+11:00"
+                          format:
+                            system: urn:oid:1.3.6.1.4.1.19376.1.2.3
+                            code: urn:ihe:pcc:handp:2008
+                            display: History and Physical Specification
+                      context:
+                        encounter:
+                          - identifier:
+                              value: Encounter/3495456481
+                        event:
+                          - coding:
+                              - system: http://snomed.info/sct
+                                code: "445627002"
+                                display: Assessment using adult early warning scoring system
+                        period:
+                          start: "2022-12-20T09:00:41+11:00"
+                          end: "2022-12-20T09:45:41+11:00"
+                        facilityType:
+                          coding:
+                            - system: http://snomed.info/sct
+                              code: "273580000"
+                              display: London hospital pain chart assessment
+                        related:
+                          - identifier:
+                              system: https://fhir.nhs.uk/Id/ods-organization-code
+                              value: ROYAL COLLEGE OF PHYSICIANS OF LONDON
+                  - resource:
+                      resourceType: DocumentReference
+                      id: Y05868-1234567891
+                      meta:
+                        profile:
+                          - http://fhir.nhs.net/StructureDefinition/nrls-documentreference-1-0
+                      masterIdentifier:
+                        system: urn:ietf:rfc:3986
+                        value: urn:oid:1.3.6.1.4.1.21367.2005.3.7
+                      identifier:
+                        - system: urn:ietf:rfc:3986
+                          value: urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234
+                      status: current
+                      docStatus: final
+                      type:
+                        coding:
+                          - system: http://snomed.info/sct
+                            code: "861421000000109"
+                            display: End of life care coordination summary
+                      category:
+                        - coding:
+                            - system: http://loinc.org
+                              code: 55112-7
+                              display: Document summary
+                      subject:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/nhs-number
+                          value: "3495456481"
+                      date: "2022-12-21T10:45:41+11:00"
+                      author:
+                        - identifier:
+                            value: Practitioner/A985657ZA
+                      authenticator:
+                        identifier:
+                          value: Organization/Y05868
+                      custodian:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/ods-organization-code
+                          value: Y05868
+                      description: Physical
+                      securityLabel:
+                        - coding:
+                            - system: http://terminology.hl7.org/CodeSystem/v3-Confidentiality
+                              code: V
+                              display: very restricted
+                      content:
+                        - attachment:
+                            contentType: application/pdf
+                            language: en-US
+                            url: https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/EPAACS/EOLSummaryReport.pdf
+                            size: 3654
+                            hash: 2jmj7l5rSw0yVb/vlWAYkK/YBwk=
+                            title: Physical
+                            creation: "2022-12-21T10:45:41+11:00"
+                          format:
+                            system: urn:oid:1.3.6.1.4.1.19376.1.2.3
+                            code: urn:ihe:pcc:cm:2008
+                            display: Care Management
+                      context:
+                        encounter:
+                          - identifier:
+                              value: Encounter/3495456481
+                        event:
+                          - coding:
+                              - system: http://snomed.info/sct
+                                code: "713058002"
+                                display: End of life care planning
+                        period:
+                          start: "2022-12-21T09:00:41+11:00"
+                          end: "2022-12-21T10:45:41+11:00"
+                        facilityType:
+                          coding:
+                            - system: http://snomed.info/sct
+                              code: "73770003"
+                              display: Hospital-based outpatient emergency care center
+                        sourcePatientInfo:
+                          identifier:
+                            value: Patient/3495456481
+                        related:
+                          - identifier:
+                              system: https://fhir.nhs.uk/Id/ods-organization-code
+                              value: TRAFFORD GENERAL HOSPITAL
           headers:
             X-Correlation-Id:
               $ref: "#/components/headers/CorrelationId"
@@ -220,11 +429,14 @@ paths:
         passthroughBehavior: when_no_match
         contentHandling: CONVERT_TO_TEXT
       description: |
-        Perform a Search using GET query string parameters
+        Perform a Search using GET query string parameters.
+
+        Results are restricted to pointers you created.
+
+        Results are limited to 20 records, further results are
   /DocumentReference/_search:
     post:
       tags:
-        - NRLF Producer
       summary: Search (POST)
       operationId: searchPostDocumentReference
       parameters:
@@ -244,7 +456,167 @@ paths:
               schema:
                 $ref: "#/components/schemas/Bundle"
               example:
-                TBC: true
+                resourceType: Bundle
+                type: searchset
+                total: 2
+                entry:
+                  - resource:
+                      resourceType: DocumentReference
+                      id: Y05868-1834567891
+                      meta:
+                        profile:
+                          - http://fhir.nhs.net/StructureDefinition/nrls-documentreference-1-0
+                      masterIdentifier:
+                        system: urn:ietf:rfc:3986
+                        value: urn:oid:1.3.6.1.4.1.21367.2004.3.7
+                      identifier:
+                        - system: urn:ietf:rfc:3986
+                          value: urn:oid:1.3.6.1.4.1.21367.2005.3.7.1134
+                      status: current
+                      docStatus: "preliminary "
+                      type:
+                        coding:
+                          - system: http://snomed.info/sct
+                            code: "1363501000000100"
+                            display: Royal College of Physicians NEWS2 (National Early Warning Score 2) chart
+                      category:
+                        - coding:
+                            - system: http://loinc.org
+                              code: 34769-0
+                              display: General medicine Physician attending Note
+                      subject:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/nhs-number
+                          value: "3495456481"
+                      date: "2022-12-22T11:45:41+11:00"
+                      author:
+                        - identifier:
+                            value: Practitioner/A782161SZ
+                      authenticator:
+                        identifier:
+                          value: Organization/Y05868
+                      custodian:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/ods-organization-code
+                          value: Y05868
+                      securityLabel:
+                        - coding:
+                            - system: http://terminology.hl7.org/CodeSystem/v3-Confidentiality
+                              code: V
+                              display: very restricted
+                      content:
+                        - attachment:
+                            contentType: application/pdf
+                            language: en-US
+                            url: https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/EPAACS/PhysicianNote.pdf
+                            creation: "2022-12-22T09:45:41+11:00"
+                          format:
+                            system: urn:oid:1.3.6.1.4.1.19376.1.2.3
+                            code: urn:ihe:pcc:handp:2008
+                            display: History and Physical Specification
+                      context:
+                        encounter:
+                          - identifier:
+                              value: Encounter/3495456481
+                        event:
+                          - coding:
+                              - system: http://snomed.info/sct
+                                code: "445627002"
+                                display: Assessment using adult early warning scoring system
+                        period:
+                          start: "2022-12-20T09:00:41+11:00"
+                          end: "2022-12-20T09:45:41+11:00"
+                        facilityType:
+                          coding:
+                            - system: http://snomed.info/sct
+                              code: "273580000"
+                              display: London hospital pain chart assessment
+                        related:
+                          - identifier:
+                              system: https://fhir.nhs.uk/Id/ods-organization-code
+                              value: ROYAL COLLEGE OF PHYSICIANS OF LONDON
+                  - resource:
+                      resourceType: DocumentReference
+                      id: Y05868-1234567891
+                      meta:
+                        profile:
+                          - http://fhir.nhs.net/StructureDefinition/nrls-documentreference-1-0
+                      masterIdentifier:
+                        system: urn:ietf:rfc:3986
+                        value: urn:oid:1.3.6.1.4.1.21367.2005.3.7
+                      identifier:
+                        - system: urn:ietf:rfc:3986
+                          value: urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234
+                      status: current
+                      docStatus: final
+                      type:
+                        coding:
+                          - system: http://snomed.info/sct
+                            code: "861421000000109"
+                            display: End of life care coordination summary
+                      category:
+                        - coding:
+                            - system: http://loinc.org
+                              code: 55112-7
+                              display: Document summary
+                      subject:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/nhs-number
+                          value: "3495456481"
+                      date: "2022-12-21T10:45:41+11:00"
+                      author:
+                        - identifier:
+                            value: Practitioner/A985657ZA
+                      authenticator:
+                        identifier:
+                          value: Organization/Y05868
+                      custodian:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/ods-organization-code
+                          value: Y05868
+                      description: Physical
+                      securityLabel:
+                        - coding:
+                            - system: http://terminology.hl7.org/CodeSystem/v3-Confidentiality
+                              code: V
+                              display: very restricted
+                      content:
+                        - attachment:
+                            contentType: application/pdf
+                            language: en-US
+                            url: https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/EPAACS/EOLSummaryReport.pdf
+                            size: 3654
+                            hash: 2jmj7l5rSw0yVb/vlWAYkK/YBwk=
+                            title: Physical
+                            creation: "2022-12-21T10:45:41+11:00"
+                          format:
+                            system: urn:oid:1.3.6.1.4.1.19376.1.2.3
+                            code: urn:ihe:pcc:cm:2008
+                            display: Care Management
+                      context:
+                        encounter:
+                          - identifier:
+                              value: Encounter/3495456481
+                        event:
+                          - coding:
+                              - system: http://snomed.info/sct
+                                code: "713058002"
+                                display: End of life care planning
+                        period:
+                          start: "2022-12-21T09:00:41+11:00"
+                          end: "2022-12-21T10:45:41+11:00"
+                        facilityType:
+                          coding:
+                            - system: http://snomed.info/sct
+                              code: "73770003"
+                              display: Hospital-based outpatient emergency care center
+                        sourcePatientInfo:
+                          identifier:
+                            value: Patient/3495456481
+                        related:
+                          - identifier:
+                              system: https://fhir.nhs.uk/Id/ods-organization-code
+                              value: TRAFFORD GENERAL HOSPITAL
           headers:
             X-Correlation-Id:
               $ref: "#/components/headers/CorrelationId"
@@ -262,11 +634,15 @@ paths:
         passthroughBehavior: when_no_match
         contentHandling: CONVERT_TO_TEXT
       description: |
-        Same as above but a POST to avoid URL length limits
+        Search Producer records, but implemented as a POST operation
+        because of limitations associated with GET:
+
+        * query string parameters are visible on the network and in logs, and may have privacy implications for consumers.
+        * GET operations can be cached by intermediary network infrastructure, such as CDNs, routers and proxies.
+        * URLs have a maximum length of 2,048 characters which complex searches can exceed.  NRL does not currently exceed this limit, but may evolve in the future.
   /DocumentReference/{id}:
     get:
       tags:
-        - NRLF Producer
       summary: Read
       operationId: readDocumentReference
       parameters:
@@ -282,7 +658,71 @@ paths:
               schema:
                 $ref: "#/components/schemas/DocumentReference"
               example:
-                TBC: true
+                resourceType: DocumentReference
+                id: Y05868-1234567892
+                status: current
+                docStatus: final
+                type:
+                  coding:
+                    - system: http://snomed.info/sct
+                      code: "887701000000100"
+                      display: Emergency health care plan
+                category:
+                  - coding:
+                      - system: http://loinc.org
+                        code: 68552-9
+                        display: Emergency medicine Emergency department Admission evaluation note
+                subject:
+                  identifier:
+                    system: https://fhir.nhs.uk/Id/nhs-number
+                    value: "4409815415"
+                date: "2022-12-22T11:45:41+11:00"
+                author:
+                  - identifier:
+                      value: Practitioner/A985657ZA
+                authenticator:
+                  identifier:
+                    value: Organization/Y05868
+                custodian:
+                  identifier:
+                    system: https://fhir.nhs.uk/Id/ods-organization-code
+                    value: Y05868
+                securityLabel:
+                  - coding:
+                      - system: http://terminology.hl7.org/CodeSystem/v3-Confidentiality
+                        code: V
+                        display: very restricted
+                content:
+                  - attachment:
+                      contentType: application/pdf
+                      language: en-US
+                      url: https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/EPAACS/EmergencyCarPlan.pdf
+                      creation: "2022-12-22T09:45:41+11:00"
+                    format:
+                      system: urn:oid:1.3.6.1.4.1.19376.1.2.3
+                      code: urn:ihe:pcc:handp:2008
+                      display: History and Physical Specification
+                context:
+                  encounter:
+                    - identifier:
+                        value: Encounter/4409815415
+                  event:
+                    - coding:
+                        - system: http://snomed.info/sct
+                          code: "702779007"
+                          display: Emergency health care plan agreed
+                  period:
+                    start: "2022-12-20T09:00:41+11:00"
+                    end: "2022-12-20T09:45:41+11:00"
+                  facilityType:
+                    coding:
+                      - system: http://snomed.info/sct
+                        code: "453121000124107"
+                        display: Emergency department healthcare professional
+                  related:
+                    - identifier:
+                        system: https://fhir.nhs.uk/Id/ods-organization-code
+                        value: EMERGENCY DEPT PRIMARY CARE STREAMING
           headers:
             X-Correlation-Id:
               $ref: "#/components/headers/CorrelationId"
@@ -300,10 +740,9 @@ paths:
         passthroughBehavior: when_no_match
         contentHandling: CONVERT_TO_TEXT
       description: |
-        Read a single DocumentReference record
+        Read a single pointer you created
     put:
       tags:
-        - NRLF Producer
       summary: Update
       operationId: updateDocumentReference
       parameters:
@@ -318,7 +757,20 @@ paths:
           content:
             application/fhir+json:
               example:
-                TBC: true
+                resourceType: OperationOutcome
+                id: fc39effb-144c-4342-bdf2-4214f0cb728b
+                meta:
+                  profile:
+                    - https://fhir.nhs.uk/StructureDefinition/NHSDigital-OperationOutcome
+                issue:
+                  - severity: information
+                    code: informational
+                    details:
+                      coding:
+                        - system: https://fhir.nhs.uk/CodeSystem/NRLF-SuccessCode
+                          code: RESOURCE_UPDATED
+                          display: Resource updated
+                    diagnostics: Resource updated
         "201":
           description: Create DocumentReference operation successful (requires 'updateCreateEnabled' configuration option)
           $ref: "#/components/responses/Success"
@@ -336,10 +788,15 @@ paths:
         passthroughBehavior: when_no_match
         contentHandling: CONVERT_TO_TEXT
       description: |
-        Update a single DocumentReference record
+        Update a single pointer you created.
+
+        Note that the following fields are immutable:
+        * `id`
+        * `subject`
+        * `custodian`
+        * `type`
     delete:
       tags:
-        - NRLF Producer
       summary: Delete
       operationId: deleteDocumentReference
       parameters:
@@ -357,7 +814,20 @@ paths:
           content:
             application/fhir+json:
               example:
-                TBC: true
+                resourceType: OperationOutcome
+                id: c6113a50-70bf-436e-b417-7c8024d2e8bf
+                meta:
+                  profile:
+                    - https://fhir.nhs.uk/StructureDefinition/NHSDigital-OperationOutcome
+                issue:
+                  - severity: information
+                    code: informational
+                    details:
+                      coding:
+                        - system: https://fhir.nhs.uk/CodeSystem/NRLF-SuccessCode
+                          code: RESOURCE_REMOVED
+                          display: Resource removed
+                    diagnostics: Resource removed
       security:
         - ${authoriser_name}: []
       x-amazon-apigateway-integration:
@@ -373,8 +843,6 @@ paths:
         Delete a single DocumentReference record
   /_status:
     get:
-      tags:
-        - NRLF Producer
       summary: _status endpoint for APIGEE integration
       operationId: status
       responses:
@@ -562,7 +1030,7 @@ components:
             - VisionPrescription
         id:
           type: string
-          pattern: '[A-Za-z0-9\-\.]{1,64}'
+          pattern: "[A-Za-z0-9\\-\\.]{1,64}"
           description: The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.
         meta:
           $ref: "#/components/schemas/Meta"
@@ -573,7 +1041,7 @@ components:
           description: A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.
         language:
           type: string
-          pattern: '[^\s]+(\s[^\s]+)*'
+          pattern: "[^\\s]+(\\s[^\\s]+)*"
           description: The base language in which the resource is written.
       required:
         - resourceType
@@ -618,11 +1086,11 @@ components:
                 description: Other identifiers associated with the document, including version independent identifiers.
             status:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The status of this document reference.
             docStatus:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The status of the underlying document.
             type:
               $ref: "#/components/schemas/CodeableConcept"
@@ -657,7 +1125,7 @@ components:
                 description: Relationships that this document has with other document references that already exist.
             description:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Human&ndash;readable description of the source document.
             securityLabel:
               type: array
@@ -968,7 +1436,7 @@ components:
               description: A persistent identifier for the bundle that won't change as a bundle is copied from server to server.
             type:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Indicates the purpose of this bundle &ndash; how it is intended to be used.
             timestamp:
               type: string
@@ -1194,7 +1662,7 @@ components:
           properties:
             status:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The status code returned by processing this entry. The status SHALL start with a 3 digit HTTP code (e.g. 404) and may contain the standard HTTP description associated with the status code.
             location:
               type: string
@@ -1202,7 +1670,7 @@ components:
               description: The location header created by processing this operation, populated if the operation returns a location.
             etag:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The Etag for the resource, if the operation for the entry produced a versioned resource (see [Resource Metadata and Versioning](http.html#versioning) and [Managing Resource Contention](http.html#concurrency)).
             lastModified:
               type: string
@@ -1220,7 +1688,7 @@ components:
           properties:
             method:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: In a transaction or batch, this is the HTTP action to be executed for this entry. In a history bundle, this indicates the HTTP action that occurred.
             url:
               type: string
@@ -1228,7 +1696,7 @@ components:
               description: The URL for this entry, relative to the root (the address to which the request is posted).
             ifNoneMatch:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: If the ETag values match, return a 304 Not Modified status. See the API documentation for ["Conditional Read"](http.html#cread).
             ifModifiedSince:
               type: string
@@ -1236,11 +1704,11 @@ components:
               description: Only perform the operation if the last updated date matches. See the API documentation for ["Conditional Read"](http.html#cread).
             ifMatch:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Only perform the operation if the Etag value matches. For more information, see the API section ["Managing Resource Contention"](http.html#concurrency).
             ifNoneExist:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Instruct the server not to perform the create if a specified resource already exists. For further information, see the API documentation for ["Conditional Create"](http.html#ccreate). This is just the query portion of the URL &ndash; what follows the "?" (not including the "?").
           required:
             - method
@@ -1252,7 +1720,7 @@ components:
           properties:
             mode:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Why this entry is in the result set &ndash; whether it's included as a match or because of an _include requirement, or to convey information or warning information about the search process.
             score:
               type: number
@@ -1264,7 +1732,7 @@ components:
           properties:
             relation:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A name which details the functional use for this link &ndash; see [http://www.iana.org/assignments/link&ndash;relations/link&ndash;relations.xhtml#link&ndash;relations&ndash;1](http://www.iana.org/assignments/link&ndash;relations/link&ndash;relations.xhtml#link&ndash;relations&ndash;1).
             url:
               type: string
@@ -1325,7 +1793,7 @@ components:
           properties:
             code:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The type of relationship that this document has with anther document.
             target:
               $ref: "#/components/schemas/Reference"
@@ -1340,30 +1808,30 @@ components:
           properties:
             severity:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Indicates whether the issue indicates a variation from successful processing.
             code:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Describes the type of the issue. The system that creates an OperationOutcome SHALL choose the most applicable code from the IssueType value set, and may additional provide its own code for the error in the details element.
             details:
               $ref: "#/components/schemas/CodeableConcept"
               description: Additional details about the error. This may be a text description of the error or a system code that identifies the error.
             diagnostics:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Additional diagnostic information about the issue.
             location:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: "This element is deprecated because it is XML specific. It is replaced by issue.expression, which is format independent, and simpler to parse. \n\nFor resource issues, this will be a simple XPath limited to element names, repetition indicators and the default child accessor that identifies one of the elements in the resource that caused this issue to be raised.  For HTTP errors, will be \"http.\" + the parameter name."
             expression:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: A [simple subset of FHIRPath](fhirpath.html#simple) limited to element names, repetition indicators and the default child accessor that identifies one of the elements in the resource that caused this issue to be raised.
           required:
             - severity
@@ -1373,7 +1841,7 @@ components:
       properties:
         id:
           type: string
-          pattern: '[A-Za-z0-9\-\.]{1,64}'
+          pattern: "[A-Za-z0-9\\-\\.]{1,64}"
           description: Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.
         extension:
           type: array
@@ -1403,41 +1871,41 @@ components:
           properties:
             use:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The purpose of this address.
             type:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Distinguishes between physical addresses (those you can visit) and mailing addresses (e.g. PO Boxes and care&ndash;of addresses). Most addresses are both.
             text:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Specifies the entire address as it should be displayed e.g. on a postal label. This may be provided instead of or as well as the specific parts.
             line:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: This component contains the house number, apartment number, street name, street direction,  P.O. Box number, delivery hints, and similar address information.
             city:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The name of the city, town, suburb, village or other community or delivery center.
             district:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The name of the administrative area (county).
             state:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Sub&ndash;unit of a country with limited sovereignty in a federally organized country. A code may be used if codes are in common use (e.g. US 2 letter state codes).
             postalCode:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A postal code designating a region defined by the postal service.
             country:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Country &ndash; a nation as commonly understood or generally accepted.
             period:
               $ref: "#/components/schemas/Period"
@@ -1457,7 +1925,7 @@ components:
               description: The individual responsible for making the annotation.
             authorString:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The individual responsible for making the annotation.
             time:
               type: string
@@ -1465,7 +1933,7 @@ components:
               description: Indicates when this particular annotation was made.
             text:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The text of the annotation in markdown format.
           required:
             - text
@@ -1476,11 +1944,11 @@ components:
           properties:
             contentType:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Identifies the type of the data in the attachment and allows a method to be chosen to interpret or render the data. Includes mime type parameters such as charset where appropriate.
             language:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The human language of the content. The value can be any valid value according to BCP 47.
             data:
               type: string
@@ -1500,7 +1968,7 @@ components:
               description: The calculated hash of the data using SHA&ndash;1. Represented using base64.
             title:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A label or set of text to display in place of the data.
             creation:
               type: string
@@ -1518,7 +1986,7 @@ components:
                 description: A reference to a code defined by a terminology system.
             text:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.
     Coding:
       allOf:
@@ -1531,15 +1999,15 @@ components:
               description: The identification of the code system that defines the meaning of the symbol in the code.
             version:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The version of the code system which was used when choosing this code. Note that a well&ndash;maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.
             code:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post&ndash;coordination).
             display:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A representation of the meaning of the code in the system, following the rules of the system.
             userSelected:
               type: boolean
@@ -1551,15 +2019,15 @@ components:
           properties:
             system:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Telecommunications form for contact point &ndash; what communications system is required to make use of the contact.
             value:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address).
             use:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Identifies the purpose for the contact point.
             rank:
               type: integer
@@ -1590,33 +2058,33 @@ components:
           properties:
             use:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Identifies the purpose for this name.
             text:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Specifies the entire name as it should be displayed e.g. on an application UI. This may be provided instead of or as well as the specific parts.
             family:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father.
             given:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: Given name.
             prefix:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name.
             suffix:
               type: array
               items:
                 type: string
-                pattern: '[ \r\n\t\S]+'
+                pattern: "[ \\r\\n\\t\\S]+"
                 description: Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name.
             period:
               $ref: "#/components/schemas/Period"
@@ -1628,7 +2096,7 @@ components:
           properties:
             use:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The purpose of this identifier.
             type:
               $ref: "#/components/schemas/CodeableConcept"
@@ -1639,7 +2107,7 @@ components:
               description: Establishes the namespace for the value &ndash; that is, a URL that describes a set values that are unique.
             value:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The portion of the identifier typically relevant to the user and which is unique within the context of the system.
             period:
               $ref: "#/components/schemas/Period"
@@ -1661,7 +2129,7 @@ components:
               description: Numerical value (with implicit precision).
             currency:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: ISO 4217 Currency Code.
     MoneyQuantity:
       allOf:
@@ -1691,11 +2159,11 @@ components:
               description: The value of the measured amount. The value includes an implicit precision in the presentation of the value.
             comparator:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: How the value should be understood and represented &ndash; whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is "<" , then the real value is < stated value.
             unit:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A human&ndash;readable form of the unit.
             system:
               type: string
@@ -1703,7 +2171,7 @@ components:
               description: The identification of the system that provides the coded form of the unit.
             code:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: A computer processable form of the unit in some unit representation system.
     Range:
       allOf:
@@ -1734,7 +2202,7 @@ components:
           properties:
             reference:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with '#') refer to contained resources.
             type:
               type: string
@@ -1748,7 +2216,7 @@ components:
               description: An identifier for the target resource. This is used when there is no way to reference the other resource directly, either because the entity it represents is not available through a FHIR server, or because there is no way for the author of the resource to convert a known identifier to an actual location. There is no requirement that a Reference.identifier point to something that is actually exposed as a FHIR instance, but it SHALL point to a business concept that would be expected to be exposed as a FHIR instance, and that instance would need to be of a FHIR resource type allowed by the reference.
             display:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Plain text narrative that identifies the resource in addition to the resource reference.
     SampledData:
       allOf:
@@ -1776,7 +2244,7 @@ components:
               description: The number of sample points at each time point. If this value is greater than one, then the dimensions will be interlaced &ndash; all the sample points for a point in time will be recorded at once.
             data:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A series of data points which are decimal values separated by a single space (character u20). The special values "E" (error), "L" (below detection limit) and "U" (above detection limit) can also be used in place of a decimal value.
           required:
             - origin
@@ -1810,11 +2278,11 @@ components:
               description: A reference to an application&ndash;usable description of the identity that is represented by the signature.
             targetFormat:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: A mime type that indicates the technical format of the target resources signed by the signature.
             sigFormat:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: A mime type that indicates the technical format of the signature. Important mime types are application/signature+xml for X ML DigSig, application/jose for JWS, and image/* for a graphical image of a signature, etc.
             data:
               type: string
@@ -1871,7 +2339,7 @@ components:
               description: If present, indicates that the duration is a range &ndash; so to perform the action between [duration] and [durationMax] time length.
             durationUnit:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The units of time for the duration, in UCUM units.
             frequency:
               type: integer
@@ -1889,13 +2357,13 @@ components:
               description: If present, indicates that the period is a range from [period] to [periodMax], allowing expressing concepts such as "do this once every 3&ndash;5 days.
             periodUnit:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The units of time for the period in UCUM units.
             dayOfWeek:
               type: array
               items:
                 type: string
-                pattern: '[^\s]+(\s[^\s]+)*'
+                pattern: "[^\\s]+(\\s[^\\s]+)*"
                 description: If one or more days of week is provided, then the action happens only on the specified day(s).
             timeOfDay:
               type: array
@@ -1907,7 +2375,7 @@ components:
               type: array
               items:
                 type: string
-                pattern: '[^\s]+(\s[^\s]+)*'
+                pattern: "[^\\s]+(\\s[^\\s]+)*"
                 description: An approximate time period during the day, potentially linked to an event of daily living that indicates when the action should occur.
             offset:
               type: integer
@@ -1920,7 +2388,7 @@ components:
           properties:
             name:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: The name of an individual to contact.
             telecom:
               type: array
@@ -1934,19 +2402,19 @@ components:
           properties:
             type:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The type of relationship to the related artifact.
             label:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A short label that can be used to reference the citation from elsewhere in the containing artifact, such as a footnote index.
             display:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A brief description of the document or knowledge resource being referenced, suitable for display to a consumer.
             citation:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: A bibliographic citation for the related artifact. This text SHOULD be formatted according to an accepted citation format.
             url:
               type: string
@@ -1990,7 +2458,7 @@ components:
           properties:
             versionId:
               type: string
-              pattern: '[A-Za-z0-9\-\.]{1,64}'
+              pattern: "[A-Za-z0-9\\-\\.]{1,64}"
               description: The version specific identifier, as it appears in the version portion of the URL. This value changes when the resource is created, updated, or deleted.
             lastUpdated:
               type: string
@@ -2023,7 +2491,7 @@ components:
           properties:
             status:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: The status of the narrative &ndash; whether it's entirely generated (from just the defined data or the extensions too), or whether a human authored it and it may contain additional data.
             div:
               type: string
@@ -2053,7 +2521,7 @@ components:
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueCode:
               type: string
-              pattern: '[^\s]+(\s[^\s]+)*'
+              pattern: "[^\\s]+(\\s[^\\s]+)*"
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueDate:
               type: string
@@ -2068,7 +2536,7 @@ components:
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueId:
               type: string
-              pattern: '[A-Za-z0-9\-\.]{1,64}'
+              pattern: "[A-Za-z0-9\\-\\.]{1,64}"
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueInstant:
               type: string
@@ -2080,7 +2548,7 @@ components:
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueMarkdown:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueOid:
               type: string
@@ -2092,7 +2560,7 @@ components:
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueString:
               type: string
-              pattern: '[ \r\n\t\S]+'
+              pattern: "[ \\r\\n\\t\\S]+"
               description: Value of extension &ndash; must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).
             valueTime:
               type: string

--- a/swagger/consumer-static/header.yaml
+++ b/swagger/consumer-static/header.yaml
@@ -13,12 +13,10 @@ servers:
   - url: https://api.service.nhs.uk/nrl-consumer-api/FHIR/R4
     description: Production environment.
 tags:
-  - name: NRLF Consumer
 paths:
   /DocumentReference:
     get:
       tags:
-        - NRLF Consumer
       summary: Search for DocumentReference resources
       operationId: searchDocumentReference
       parameters:
@@ -55,7 +53,6 @@ paths:
   /DocumentReference/_search:
     post:
       tags:
-        - NRLF Consumer
       summary: Search for DocumentReference resources
       operationId: searchPostDocumentReference
       parameters:
@@ -93,7 +90,6 @@ paths:
   /DocumentReference/{id}:
     get:
       tags:
-        - NRLF Consumer
       summary: Read a DocumentReference resource
       operationId: readDocumentReference
       parameters:

--- a/swagger/consumer-static/narrative.yaml
+++ b/swagger/consumer-static/narrative.yaml
@@ -10,36 +10,55 @@ info:
     email: api.management@nhs.net
   description: |
     ## Overview
-    The National Record Locator (NRL) is a service that holds pointers to data held in local provider systems.
 
-    The service facilitates national sharing, removing the need for organisations to create duplicate copies of information across systems and organisations, by enabling access to up-to-date information directly from the source.
+    The National Record Locator (NRL) enables organisations to share Patient data nationwide.  It acts as an Index, or Directory, of patient data.  Rather than handling the data itself it shares pointers held in partner systems, using the FHIR R4 DocumentReference standard.
+
+    Users of the service fall into the categories of:
+
+    * Producers - capable of creating and managing pointers
+    * Consumers - capable of searching and reading pointers
+
+    The service removes the need for organisations to create duplicate copies of information across systems and organisations, by enabling access to up-to-date information directly from the source.
 
     It can be used to store and publish pointers to patient data held in health systems across England and to look up where relevant patient data is held.
 
-    As a "consumer" of pointers relating to citizens, you can:
-
-    -Search a pointer, where you are authorised to do so, for a given patient
-    -Read a pointer, where you are authorised to do so, for a given patient
-
-    This service is a new version of the NRL moving to R4 from STU3, more information on the existing STU3 NRL service can be found on the following page, [National Record Locator (NRL)](https://digital.nhs.uk/services/national-record-locator).
-
     There is a growing list of health and social care organisations authorised to share records using NRL.
 
+    ### As a Consumer
+
+    * Search for pointers, restricted to a single Patient at a time
+    * Read a specific pointer
+    * Operations are restricted to document types agreed during the on-boarding process
+
+    ### What has changed?
+
+    This service is a replacement for the existing [National Record Locator (NRL)](https://digital.nhs.uk/services/national-record-locator).
+
+    * Upgraded from FHIR STU3 to R4.
+    * Improved performance and scalability.
+    * Improved on-boarding experience.
+    * Authenticated using [signed JWT](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation/application-restricted-restful-apis-signed-jwt-authentication) rather than mTLS
+    * Greater flexibility, by wider support of the FHIR R4 DocumentReference resource.
+
     ### Data availability, timing and quality
+
     Pointers are available to be consumed almost immediately after they have been produced by the provider.
 
     ## Who can use this API
+
     This API:
-    - is only for use by patient-facing applications
-    - is only for non-clinical use
-    - can only be used where there is a legal basis to do so
+
+    * is only for use by patient-facing applications
+    * is only for non-clinical use
+    * can only be used where there is a legal basis to do so
 
     You can not currently use this API to retrieve pointers for:
-    - mental health crisis plans
-    - end of life plans
-    - emergency care plans (eRedbags)
-    - national early warning scores (NEWS)
-    - urgent care plan
+
+    * mental health crisis plans
+    * end of life plans
+    * emergency care plans (eRedbags)
+    * national early warning scores (NEWS)
+    * urgent care plan
 
     Make sure you have a valid use case before you go too far with your development.
     To do this, [contact us](https://digital.nhs.uk/developer/help-and-support).
@@ -47,6 +66,7 @@ info:
     You must do this before you can go live (see ‘Onboarding’ below).
 
     ## API status and roadmap
+
     This API is [in development](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#statuses).
 
     To see our roadmap, or to suggest, comment or vote on features for this API, see our [interactive product backlog](https://nhs-digital-api-management.featureupvote.com/?tag=national-record-locator-api).
@@ -60,6 +80,7 @@ info:
     For more details, see [service levels](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#service-levels).
 
     ## Technology
+
     This API is [RESTful](https://digital.nhs.uk/developer/guides-and-documentation/our-api-technologies#basic-rest).
 
     It conforms to the [FHIR](https://digital.nhs.uk/developer/guides-and-documentation/our-api-technologies#fhir) global standard for health care data exchange, specifically to [FHIR R4 (v4.0.1)](https://hl7.org/fhir/r4/), except that it does not support the [capabilities](http://hl7.org/fhir/R4/http.html#capabilities) interaction.
@@ -67,10 +88,12 @@ info:
     It includes some country-specific FHIR extensions, which conform to [FHIR UK Core](https://digital.nhs.uk/services/fhir-uk-core), specifically [fhir.r4.ukcore.stu1 0.5.1](https://simplifier.net/packages/fhir.r4.ukcore.stu1/0.5.1).
 
     You do not need to know much about FHIR to use this API - FHIR APIs are just RESTful APIs that follow specific rules.
+
     In particular:
-    - resource names are capitalised and singular, and use US spellings, for example `/Immunization` not `/immunisations`
-    - array names are singular, for example `entry` not `entries` for address lines
-    - data items that are country-specific and thus not included in the FHIR global base resources are usually wrapped in an `extension` object
+
+    * resource names are capitalised and singular, and use US spellings, for example `/Immunization` not `/immunisations`
+    * array names are singular, for example `entry` not `entries` for address lines
+    * data items that are country-specific and thus not included in the FHIR global base resources are usually wrapped in an `extension` object
 
     There are [libraries and SDKs available](https://digital.nhs.uk/developer/guides-and-documentation/api-technologies-at-nhs-digital#fhir-libraries-and-sdks) to help with FHIR API integration.
 
@@ -82,16 +105,11 @@ info:
     ## Security and authorisation
 
     This API uses the following access modes:
-    * application-restricted access
 
-    ### Application-restricted access
-
-    This access mode is [application-restricted](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation#application-restricted-apis), meaning we authenticate the calling application but not the end user.
-
-    To use this access mode, use the following security pattern:
     * [Application-restricted RESTful API - signed JWT authentication](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation/application-restricted-restful-apis-signed-jwt-authentication)
 
     ## Environments and testing
+
     | Environment       | Base URL                                                               |
     | ----------------- | ---------------------------------------------------------------------- |
     | Sandbox           | `https://sandbox.api.service.nhs.uk/nrl-consumer-api/FHIR/R4/`     |
@@ -99,6 +117,7 @@ info:
     | Production        | `https://api.service.nhs.uk/nrl-consumer-api/FHIR/R4/`             |
 
     ### Sandbox testing
+
     Our [sandbox environment](https://digital.nhs.uk/developer/guides-and-documentation/testing#sandbox-testing):
     * is for early developer testing
     * only covers a limited set of scenarios
@@ -111,7 +130,9 @@ info:
     [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/TBC)
 
     ### Integration testing
+
     Our [integration test environment](https://digital.nhs.uk/developer/guides-and-documentation/testing#integration-testing):
+
     * is for formal integration testing
     * includes authorisation
 
@@ -120,6 +141,7 @@ info:
     For more details see [integration testing with our RESTful APIs](https://digital.nhs.uk/developer/guides-and-documentation/testing#integration-testing-with-our-restful-apis).
 
     ## Onboarding
+
     You need to get your software approved by us before it can go live with this API. We call this onboarding. The onboarding process can sometimes be quite long, so it’s worth planning well ahead.
 
     This API uses our online digital onboarding process.
@@ -134,7 +156,7 @@ paths:
     get:
       summary: Search (GET)
       description: |
-        Perform a Search using GET query string parameters
+        Search a single Patient's records.
       responses:
         "200":
           description: Search successful response
@@ -236,7 +258,13 @@ paths:
     post:
       summary: Search (POST)
       description: |
-        Same as above but a POST to avoid URL length limits
+        Search a single Patient's records, but implemented as a POST operation
+        because of limitations associated with GET:
+
+        * query string parameters are visible on the network and in logs, and may have privacy implications for consumers.
+        * GET operations can be cached by intermediary network infrastructure, such as CDNs, routers and proxies.
+        * URLs have a maximum length of 2,048 characters which complex searches can exceed.  NRL does not currently exceed this limit, but may evolve in the future.
+
       responses:
         "200":
           description: Search successful response
@@ -334,7 +362,7 @@ paths:
     get:
       summary: Read
       description: |
-        Read a single DocumentReference record
+        Read a single DocumentReference record using the `DocumentReference.id`
       responses:
         "200":
           description: Search successful response

--- a/swagger/consumer-static/status.yaml
+++ b/swagger/consumer-static/status.yaml
@@ -2,7 +2,6 @@ paths:
   /_status:
     get:
       tags:
-        - NRLF Consumer
       summary: _status endpoint for APIGEE integration
       operationId: status
       responses:

--- a/swagger/producer-static/header.yaml
+++ b/swagger/producer-static/header.yaml
@@ -13,12 +13,10 @@ servers:
   - url: https://api.service.nhs.uk/nrl-producer-api/FHIR/R4
     description: Production environment.
 tags:
-  - name: NRLF Producer
 paths:
   /DocumentReference:
     get:
       tags:
-        - NRLF Producer
       summary: Search for DocumentReference resources
       operationId: searchDocumentReference
       parameters:
@@ -54,7 +52,6 @@ paths:
         contentHandling: CONVERT_TO_TEXT
     post:
       tags:
-        - NRLF Producer
       summary: Create a DocumentReference resource
       operationId: createDocumentReference
       parameters:
@@ -80,7 +77,6 @@ paths:
   /DocumentReference/{id}:
     get:
       tags:
-        - NRLF Producer
       summary: Read a DocumentReference resource
       operationId: readDocumentReference
       parameters:
@@ -113,7 +109,6 @@ paths:
         contentHandling: CONVERT_TO_TEXT
     put:
       tags:
-        - NRLF Producer
       summary: Update an existing DocumentReference resource
       operationId: updateDocumentReference
       parameters:
@@ -141,7 +136,6 @@ paths:
         contentHandling: CONVERT_TO_TEXT
     delete:
       tags:
-        - NRLF Producer
       summary: Delete a DocumentReference resource
       operationId: deleteDocumentReference
       parameters:
@@ -168,7 +162,6 @@ paths:
   /DocumentReference/_search:
     post:
       tags:
-        - NRLF Producer
       summary: Search for DocumentReference resources
       operationId: searchPostDocumentReference
       parameters:

--- a/swagger/producer-static/narrative.yaml
+++ b/swagger/producer-static/narrative.yaml
@@ -10,30 +10,47 @@ info:
     email: api.management@nhs.net
   description: |
     ## Overview
-    The National Record Locator (NRL) is a service that holds pointers to data held in local provider systems.
 
-    The service facilitates national sharing, removing the need for organisations to create duplicate copies of information across systems and organisations, by enabling access to up-to-date information directly from the source.
+    The National Record Locator (NRL) enables organisations to share Patient data nationwide.  It acts as an Index, or Directory, of patient data.  Rather than handling the data itself it shares pointers held in partner systems, using the FHIR R4 DocumentReference standard.
+
+    Users of the service fall into the categories of:
+
+    * Producers - capable of creating and managing pointers
+    * Consumers - capable of searching and reading pointers
+
+    The service removes the need for organisations to create duplicate copies of information across systems and organisations, by enabling access to up-to-date information directly from the source.
 
     It can be used to store and publish pointers to patient data held in health systems across England and to look up where relevant patient data is held.
 
-    As a "provider" who holds information about patients, you can:
-
-    -create a pointer in the NRL to your information
-    -replace your NRL pointer with a newer pointer, superseding the old one
-    -update some of the metadata associated with your pointer
-    -delete your NRL pointer
-    -Search and read pointers, where you are authorised to do so, for a given patient
-    -Search and read all pointers you have provided
-
-    This service is new version of the NRL moving to R4 from STU3, more information on the existing STU3 NRL service can be found on the following page, [National Record Locator (NRL)](https://digital.nhs.uk/services/national-record-locator).
-
     There is a growing list of health and social care organisations authorised to share records using NRL.
 
+    ### As a Producer
+
+    * Create pointers, restricted to document types agreed during the on-boarding process
+    * Replace your pointers with a newer versions, superseding the old one
+    * Update the metadata associated with your pointers
+    * Delete pointers
+    * Search all pointers you created
+    * Read any pointer you created
+
+    ### What has changed?
+
+    This service is a replacement for the existing [National Record Locator (NRL)](https://digital.nhs.uk/services/national-record-locator).
+
+    * Upgraded from FHIR STU3 to R4.
+    * Improved performance and scalability.
+    * Improved on-boarding experience.
+    * Authenticated using [signed JWT](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation/application-restricted-restful-apis-signed-jwt-authentication) rather than mTLS
+    * Greater flexibility, by wider support of the FHIR R4 DocumentReference resource.
+
     ### Data availability, timing and quality
+
     Pointers are available to be consumed almost immediately after they have been produced by the provider.
 
     Pointers are immediately available to authorised providers and consumers after successful creation.
+
     ## Who can use this API
+
     This API:
     - is only for use by patient-facing applications
     - is only for non-clinical use
@@ -52,6 +69,7 @@ info:
     You must do this before you can go live (see ‘Onboarding’ below).
 
     ## API status and roadmap
+
     This API is [in development](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#statuses).
 
     To see our roadmap, or to suggest, comment or vote on features for this API, see our [interactive product backlog](https://nhs-digital-api-management.featureupvote.com/?tag=national-record-locator-api).
@@ -59,11 +77,13 @@ info:
     If you have any other queries, [contact us](https://digital.nhs.uk/developer/help-and-support).
 
     ## Service level
+
     This API is a bronze service, meaning it is operational and supported only during business hours (8am to 6pm), Monday to Friday excluding bank holidays.
 
     For more details, see [service levels](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#service-levels).
 
     ## Technology
+
     This API is [RESTful](https://digital.nhs.uk/developer/guides-and-documentation/our-api-technologies#basic-rest).
 
     It conforms to the [FHIR](https://digital.nhs.uk/developer/guides-and-documentation/our-api-technologies#fhir) global standard for health care data exchange, specifically to [FHIR R4 (v4.0.1)](https://hl7.org/fhir/r4/), except that it does not support the [capabilities](http://hl7.org/fhir/R4/http.html#capabilities) interaction.
@@ -71,14 +91,17 @@ info:
     It includes some country-specific FHIR extensions, which conform to [FHIR UK Core](https://digital.nhs.uk/services/fhir-uk-core), specifically [fhir.r4.ukcore.stu1 0.5.1](https://simplifier.net/packages/fhir.r4.ukcore.stu1/0.5.1).
 
     You do not need to know much about FHIR to use this API - FHIR APIs are just RESTful APIs that follow specific rules.
+
     In particular:
-    - resource names are capitalised and singular, and use US spellings, for example `/Immunization` not `/immunisations`
-    - array names are singular, for example `entry` not `entries` for address lines
-    - data items that are country-specific and thus not included in the FHIR global base resources are usually wrapped in an `extension` object
+
+    * resource names are capitalised and singular, and use US spellings, for example `/Immunization` not `/immunisations`
+    * array names are singular, for example `entry` not `entries` for address lines
+    * data items that are country-specific and thus not included in the FHIR global base resources are usually wrapped in an `extension` object
 
     There are [libraries and SDKs available](https://digital.nhs.uk/developer/guides-and-documentation/api-technologies-at-nhs-digital#fhir-libraries-and-sdks) to help with FHIR API integration.
 
     ## Network access
+
     This API is available on the internet and, indirectly, on the [Health and Social Care Network (HSCN)](https://digital.nhs.uk/services/health-and-social-care-network).
 
     For more details see [Network access for APIs](https://digital.nhs.uk/developer/guides-and-documentation/network-access-for-apis).
@@ -86,16 +109,11 @@ info:
     ## Security and authorisation
 
     This API uses the following access modes:
-    * application-restricted access
 
-    ### Application-restricted access
-
-    This access mode is [application-restricted](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation#application-restricted-apis), meaning we authenticate the calling application but not the end user.
-
-    To use this access mode, use the following security pattern:
     * [Application-restricted RESTful API - signed JWT authentication](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation/application-restricted-restful-apis-signed-jwt-authentication)
 
     ## Environments and testing
+
     | Environment       | Base URL                                                               |
     | ----------------- | ---------------------------------------------------------------------- |
     | Sandbox           | `https://sandbox.api.service.nhs.uk/nrl-producer-api/FHIR/R4/`     |
@@ -103,6 +121,7 @@ info:
     | Production        | `https://api.service.nhs.uk/nrl-producer-api/FHIR/R4/`             |
 
     ### Sandbox testing
+
     Our [sandbox environment](https://digital.nhs.uk/developer/guides-and-documentation/testing#sandbox-testing):
     * is for early developer testing
     * only covers a limited set of scenarios
@@ -115,6 +134,7 @@ info:
     [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/TBC)
 
     ### Integration testing
+
     Our [integration test environment](https://digital.nhs.uk/developer/guides-and-documentation/testing#integration-testing):
     * is for formal integration testing
     * includes authorisation
@@ -124,6 +144,7 @@ info:
     For more details see [integration testing with our RESTful APIs](https://digital.nhs.uk/developer/guides-and-documentation/testing#integration-testing-with-our-restful-apis).
 
     ## Onboarding
+
     You need to get your software approved by us before it can go live with this API. We call this onboarding. The onboarding process can sometimes be quite long, so it’s worth planning well ahead.
 
     This API uses our online digital onboarding process.
@@ -139,64 +160,513 @@ paths:
     post:
       summary: Create / Supersede
       description: |
-        TBC
+        Create new Pointers, or Supersede existing ones.
+
+        * `id` is a composite of the ODS Code and an identifier that is locally unique to your system.  NRL does not generate globally unique ids, instead relies on producers to provide a locally unique id prefixed with their ODS code, making it globally unique.
+        * `subject` MUST be a `Patient` reference.
+        * `custodian` MUST be an `Organization` reference, and must match the `NHSD-End-User-Organisation-ODS`
+        * `type` MUST match one of the Document Types agreed during on-boarding.
+        * `content` MUST have at least one entry.
+        * `content[].format[]` SHOULD indicate the mechanism for accessing documents, e.g.
+          * `{ "code": "ssp", "display": "Spine Secure Proxy" }`
+          * Further standards to be agreed.
+
+        To supersede existing pointers you must specify:
+        * at least one existing pointer in the `relatesTo` with a `target` or `replaces`.
+        * The following fields MUST match the pointers being superseded:
+          * `subject`
+          * `type`
+
+        This will cause a new pointer to be created and superseded pointers to be deleted.  Multiple documents can
+        be superseded.
+
       responses:
         "200":
           description: Create / Supersede successful response
           content:
             application/fhir+json:
               example:
-                TBC: true
+                resourceType: OperationOutcome
+                id: 76db24dc-324a-468a-bf02-c06e82279488
+                meta:
+                  profile:
+                    - https://fhir.nhs.uk/StructureDefinition/NHSDigital-OperationOutcome
+                issue:
+                  - severity: information
+                    code: informational
+                    details:
+                      coding:
+                        - system: https://fhir.nhs.uk/CodeSystem/NRLF-SuccessCode
+                          code: RESOURCE_CREATED
+                          display: Resource created
+                    diagnostics: Resource created
 
     get:
       summary: Search (GET)
       description: |
-        Perform a Search using GET query string parameters
+        Perform a Search using GET query string parameters.
+
+        Results are restricted to pointers you created.
+
+        Results are limited to 20 records, further results are
       responses:
         "200":
           description: Search successful response
           content:
             application/fhir+json:
               example:
-                TBC: true
+                resourceType: Bundle
+                type: searchset
+                total: 2
+                entry:
+                  - resource:
+                      resourceType: DocumentReference
+                      id: Y05868-1834567891
+                      meta:
+                        profile:
+                          - http://fhir.nhs.net/StructureDefinition/nrls-documentreference-1-0
+                      masterIdentifier:
+                        system: urn:ietf:rfc:3986
+                        value: urn:oid:1.3.6.1.4.1.21367.2004.3.7
+                      identifier:
+                        - system: urn:ietf:rfc:3986
+                          value: urn:oid:1.3.6.1.4.1.21367.2005.3.7.1134
+                      status: current
+                      docStatus: "preliminary "
+                      type:
+                        coding:
+                          - system: http://snomed.info/sct
+                            code: "1363501000000100"
+                            display:
+                              Royal College of Physicians NEWS2 (National Early Warning Score 2)
+                              chart
+                      category:
+                        - coding:
+                            - system: http://loinc.org
+                              code: 34769-0
+                              display: General medicine Physician attending Note
+                      subject:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/nhs-number
+                          value: "3495456481"
+                      date: "2022-12-22T11:45:41+11:00"
+                      author:
+                        - identifier:
+                            value: Practitioner/A782161SZ
+                      authenticator:
+                        identifier:
+                          value: Organization/Y05868
+                      custodian:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/ods-organization-code
+                          value: Y05868
+                      securityLabel:
+                        - coding:
+                            - system: http://terminology.hl7.org/CodeSystem/v3-Confidentiality
+                              code: V
+                              display: very restricted
+                      content:
+                        - attachment:
+                            contentType: application/pdf
+                            language: en-US
+                            url: https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/EPAACS/PhysicianNote.pdf
+                            creation: "2022-12-22T09:45:41+11:00"
+                          format:
+                            system: urn:oid:1.3.6.1.4.1.19376.1.2.3
+                            code: urn:ihe:pcc:handp:2008
+                            display: History and Physical Specification
+                      context:
+                        encounter:
+                          - identifier:
+                              value: Encounter/3495456481
+                        event:
+                          - coding:
+                              - system: http://snomed.info/sct
+                                code: "445627002"
+                                display: Assessment using adult early warning scoring system
+                        period:
+                          start: "2022-12-20T09:00:41+11:00"
+                          end: "2022-12-20T09:45:41+11:00"
+                        facilityType:
+                          coding:
+                            - system: http://snomed.info/sct
+                              code: "273580000"
+                              display: London hospital pain chart assessment
+                        related:
+                          - identifier:
+                              system: https://fhir.nhs.uk/Id/ods-organization-code
+                              value: ROYAL COLLEGE OF PHYSICIANS OF LONDON
+                  - resource:
+                      resourceType: DocumentReference
+                      id: Y05868-1234567891
+                      meta:
+                        profile:
+                          - http://fhir.nhs.net/StructureDefinition/nrls-documentreference-1-0
+                      masterIdentifier:
+                        system: urn:ietf:rfc:3986
+                        value: urn:oid:1.3.6.1.4.1.21367.2005.3.7
+                      identifier:
+                        - system: urn:ietf:rfc:3986
+                          value: urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234
+                      status: current
+                      docStatus: final
+                      type:
+                        coding:
+                          - system: http://snomed.info/sct
+                            code: "861421000000109"
+                            display: End of life care coordination summary
+                      category:
+                        - coding:
+                            - system: http://loinc.org
+                              code: 55112-7
+                              display: Document summary
+                      subject:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/nhs-number
+                          value: "3495456481"
+                      date: "2022-12-21T10:45:41+11:00"
+                      author:
+                        - identifier:
+                            value: Practitioner/A985657ZA
+                      authenticator:
+                        identifier:
+                          value: Organization/Y05868
+                      custodian:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/ods-organization-code
+                          value: Y05868
+                      description: Physical
+                      securityLabel:
+                        - coding:
+                            - system: http://terminology.hl7.org/CodeSystem/v3-Confidentiality
+                              code: V
+                              display: very restricted
+                      content:
+                        - attachment:
+                            contentType: application/pdf
+                            language: en-US
+                            url: https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/EPAACS/EOLSummaryReport.pdf
+                            size: 3654
+                            hash: 2jmj7l5rSw0yVb/vlWAYkK/YBwk=
+                            title: Physical
+                            creation: "2022-12-21T10:45:41+11:00"
+                          format:
+                            system: urn:oid:1.3.6.1.4.1.19376.1.2.3
+                            code: urn:ihe:pcc:cm:2008
+                            display: Care Management
+                      context:
+                        encounter:
+                          - identifier:
+                              value: Encounter/3495456481
+                        event:
+                          - coding:
+                              - system: http://snomed.info/sct
+                                code: "713058002"
+                                display: End of life care planning
+                        period:
+                          start: "2022-12-21T09:00:41+11:00"
+                          end: "2022-12-21T10:45:41+11:00"
+                        facilityType:
+                          coding:
+                            - system: http://snomed.info/sct
+                              code: "73770003"
+                              display: Hospital-based outpatient emergency care center
+                        sourcePatientInfo:
+                          identifier:
+                            value: Patient/3495456481
+                        related:
+                          - identifier:
+                              system: https://fhir.nhs.uk/Id/ods-organization-code
+                              value: TRAFFORD GENERAL HOSPITAL
 
   /DocumentReference/_search:
     post:
       summary: Search (POST)
       description: |
-        Same as above but a POST to avoid URL length limits
+        Search Producer records, but implemented as a POST operation
+        because of limitations associated with GET:
+
+        * query string parameters are visible on the network and in logs, and may have privacy implications for consumers.
+        * GET operations can be cached by intermediary network infrastructure, such as CDNs, routers and proxies.
+        * URLs have a maximum length of 2,048 characters which complex searches can exceed.  NRL does not currently exceed this limit, but may evolve in the future.
       responses:
         "200":
           description: Search successful response
           content:
             application/fhir+json:
               example:
-                TBC: true
+                resourceType: Bundle
+                type: searchset
+                total: 2
+                entry:
+                  - resource:
+                      resourceType: DocumentReference
+                      id: Y05868-1834567891
+                      meta:
+                        profile:
+                          - http://fhir.nhs.net/StructureDefinition/nrls-documentreference-1-0
+                      masterIdentifier:
+                        system: urn:ietf:rfc:3986
+                        value: urn:oid:1.3.6.1.4.1.21367.2004.3.7
+                      identifier:
+                        - system: urn:ietf:rfc:3986
+                          value: urn:oid:1.3.6.1.4.1.21367.2005.3.7.1134
+                      status: current
+                      docStatus: "preliminary "
+                      type:
+                        coding:
+                          - system: http://snomed.info/sct
+                            code: "1363501000000100"
+                            display:
+                              Royal College of Physicians NEWS2 (National Early Warning Score 2)
+                              chart
+                      category:
+                        - coding:
+                            - system: http://loinc.org
+                              code: 34769-0
+                              display: General medicine Physician attending Note
+                      subject:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/nhs-number
+                          value: "3495456481"
+                      date: "2022-12-22T11:45:41+11:00"
+                      author:
+                        - identifier:
+                            value: Practitioner/A782161SZ
+                      authenticator:
+                        identifier:
+                          value: Organization/Y05868
+                      custodian:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/ods-organization-code
+                          value: Y05868
+                      securityLabel:
+                        - coding:
+                            - system: http://terminology.hl7.org/CodeSystem/v3-Confidentiality
+                              code: V
+                              display: very restricted
+                      content:
+                        - attachment:
+                            contentType: application/pdf
+                            language: en-US
+                            url: https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/EPAACS/PhysicianNote.pdf
+                            creation: "2022-12-22T09:45:41+11:00"
+                          format:
+                            system: urn:oid:1.3.6.1.4.1.19376.1.2.3
+                            code: urn:ihe:pcc:handp:2008
+                            display: History and Physical Specification
+                      context:
+                        encounter:
+                          - identifier:
+                              value: Encounter/3495456481
+                        event:
+                          - coding:
+                              - system: http://snomed.info/sct
+                                code: "445627002"
+                                display: Assessment using adult early warning scoring system
+                        period:
+                          start: "2022-12-20T09:00:41+11:00"
+                          end: "2022-12-20T09:45:41+11:00"
+                        facilityType:
+                          coding:
+                            - system: http://snomed.info/sct
+                              code: "273580000"
+                              display: London hospital pain chart assessment
+                        related:
+                          - identifier:
+                              system: https://fhir.nhs.uk/Id/ods-organization-code
+                              value: ROYAL COLLEGE OF PHYSICIANS OF LONDON
+                  - resource:
+                      resourceType: DocumentReference
+                      id: Y05868-1234567891
+                      meta:
+                        profile:
+                          - http://fhir.nhs.net/StructureDefinition/nrls-documentreference-1-0
+                      masterIdentifier:
+                        system: urn:ietf:rfc:3986
+                        value: urn:oid:1.3.6.1.4.1.21367.2005.3.7
+                      identifier:
+                        - system: urn:ietf:rfc:3986
+                          value: urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234
+                      status: current
+                      docStatus: final
+                      type:
+                        coding:
+                          - system: http://snomed.info/sct
+                            code: "861421000000109"
+                            display: End of life care coordination summary
+                      category:
+                        - coding:
+                            - system: http://loinc.org
+                              code: 55112-7
+                              display: Document summary
+                      subject:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/nhs-number
+                          value: "3495456481"
+                      date: "2022-12-21T10:45:41+11:00"
+                      author:
+                        - identifier:
+                            value: Practitioner/A985657ZA
+                      authenticator:
+                        identifier:
+                          value: Organization/Y05868
+                      custodian:
+                        identifier:
+                          system: https://fhir.nhs.uk/Id/ods-organization-code
+                          value: Y05868
+                      description: Physical
+                      securityLabel:
+                        - coding:
+                            - system: http://terminology.hl7.org/CodeSystem/v3-Confidentiality
+                              code: V
+                              display: very restricted
+                      content:
+                        - attachment:
+                            contentType: application/pdf
+                            language: en-US
+                            url: https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/EPAACS/EOLSummaryReport.pdf
+                            size: 3654
+                            hash: 2jmj7l5rSw0yVb/vlWAYkK/YBwk=
+                            title: Physical
+                            creation: "2022-12-21T10:45:41+11:00"
+                          format:
+                            system: urn:oid:1.3.6.1.4.1.19376.1.2.3
+                            code: urn:ihe:pcc:cm:2008
+                            display: Care Management
+                      context:
+                        encounter:
+                          - identifier:
+                              value: Encounter/3495456481
+                        event:
+                          - coding:
+                              - system: http://snomed.info/sct
+                                code: "713058002"
+                                display: End of life care planning
+                        period:
+                          start: "2022-12-21T09:00:41+11:00"
+                          end: "2022-12-21T10:45:41+11:00"
+                        facilityType:
+                          coding:
+                            - system: http://snomed.info/sct
+                              code: "73770003"
+                              display: Hospital-based outpatient emergency care center
+                        sourcePatientInfo:
+                          identifier:
+                            value: Patient/3495456481
+                        related:
+                          - identifier:
+                              system: https://fhir.nhs.uk/Id/ods-organization-code
+                              value: TRAFFORD GENERAL HOSPITAL
 
   /DocumentReference/{id}:
     get:
       summary: Read
       description: |
-        Read a single DocumentReference record
+        Read a single pointer you created
       responses:
         "200":
           description: Read successful response
           content:
             application/fhir+json:
               example:
-                TBC: true
+                resourceType: DocumentReference
+                id: Y05868-1234567892
+                status: current
+                docStatus: final
+                type:
+                  coding:
+                    - system: http://snomed.info/sct
+                      code: "887701000000100"
+                      display: Emergency health care plan
+                category:
+                  - coding:
+                      - system: http://loinc.org
+                        code: 68552-9
+                        display: Emergency medicine Emergency department Admission evaluation note
+                subject:
+                  identifier:
+                    system: https://fhir.nhs.uk/Id/nhs-number
+                    value: "4409815415"
+                date: "2022-12-22T11:45:41+11:00"
+                author:
+                  - identifier:
+                      value: Practitioner/A985657ZA
+                authenticator:
+                  identifier:
+                    value: Organization/Y05868
+                custodian:
+                  identifier:
+                    system: https://fhir.nhs.uk/Id/ods-organization-code
+                    value: Y05868
+                securityLabel:
+                  - coding:
+                      - system: http://terminology.hl7.org/CodeSystem/v3-Confidentiality
+                        code: V
+                        display: very restricted
+                content:
+                  - attachment:
+                      contentType: application/pdf
+                      language: en-US
+                      url: https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/EPAACS/EmergencyCarPlan.pdf
+                      creation: "2022-12-22T09:45:41+11:00"
+                    format:
+                      system: urn:oid:1.3.6.1.4.1.19376.1.2.3
+                      code: urn:ihe:pcc:handp:2008
+                      display: History and Physical Specification
+                context:
+                  encounter:
+                    - identifier:
+                        value: Encounter/4409815415
+                  event:
+                    - coding:
+                        - system: http://snomed.info/sct
+                          code: "702779007"
+                          display: Emergency health care plan agreed
+                  period:
+                    start: "2022-12-20T09:00:41+11:00"
+                    end: "2022-12-20T09:45:41+11:00"
+                  facilityType:
+                    coding:
+                      - system: http://snomed.info/sct
+                        code: "453121000124107"
+                        display: Emergency department healthcare professional
+                  related:
+                    - identifier:
+                        system: https://fhir.nhs.uk/Id/ods-organization-code
+                        value: EMERGENCY DEPT PRIMARY CARE STREAMING
 
     put:
       summary: Update
       description: |
-        Update a single DocumentReference record
+        Update a single pointer you created.
+
+        Note that the following fields are immutable:
+        * `id`
+        * `subject`
+        * `custodian`
+        * `type`
+
       responses:
         "200":
           description: Update successful response
           content:
             application/fhir+json:
               example:
-                TBC: true
+                resourceType: OperationOutcome
+                id: fc39effb-144c-4342-bdf2-4214f0cb728b
+                meta:
+                  profile:
+                    - https://fhir.nhs.uk/StructureDefinition/NHSDigital-OperationOutcome
+                issue:
+                  - severity: information
+                    code: informational
+                    details:
+                      coding:
+                        - system: https://fhir.nhs.uk/CodeSystem/NRLF-SuccessCode
+                          code: RESOURCE_UPDATED
+                          display: Resource updated
+                    diagnostics: Resource updated
 
     delete:
       summary: Delete
@@ -208,7 +678,20 @@ paths:
           content:
             application/fhir+json:
               example:
-                TBC: true
+                resourceType: OperationOutcome
+                id: c6113a50-70bf-436e-b417-7c8024d2e8bf
+                meta:
+                  profile:
+                    - https://fhir.nhs.uk/StructureDefinition/NHSDigital-OperationOutcome
+                issue:
+                  - severity: information
+                    code: informational
+                    details:
+                      coding:
+                        - system: https://fhir.nhs.uk/CodeSystem/NRLF-SuccessCode
+                          code: RESOURCE_REMOVED
+                          display: Resource removed
+                    diagnostics: Resource removed
 
 components:
   schemas:
@@ -218,6 +701,10 @@ components:
       example: "https://fhir.nhs.uk/Id/ods-organization-code|Y05868"
     RequestQueryType:
       example: "http://snomed.info/sct|736253002"
+    RequestHeaderRequestId:
+      example: 60E0B220-8136-4CA5-AE46-1D97EF59D068
+    RequestHeaderCorrelationId:
+      example: 11C46F5F-CDEF-4865-94B2-0EE0EDCC26DA
 
   parameters:
     id:
@@ -272,3 +759,15 @@ components:
         invalid:
           summary: Unknown
           value: http://snomed.info/sct|410970009
+
+  headers:
+    CorrelationId:
+      schema:
+        example: 11C46F5F-CDEF-4865-94B2-0EE0EDCC26DA
+        description: |
+          The X-Correlation-ID from the request header, if supplied, mirrored back.
+    RequestId:
+      schema:
+        example: 60E0B220-8136-4CA5-AE46-1D97EF59D068
+        description: |
+          The X-Request-ID from the request header, if supplied, mirrored back.

--- a/swagger/producer-static/status.yaml
+++ b/swagger/producer-static/status.yaml
@@ -1,8 +1,6 @@
 paths:
   /_status:
     get:
-      tags:
-        - NRLF Producer
       summary: _status endpoint for APIGEE integration
       operationId: status
       responses:


### PR DESCRIPTION
1. Remove `tags` so that API catalogue shows `Endpoints` and not `Endpoints: NRLFProducer` and `Endpoints: NRLFConsumer`
1. Standardise around double quotes, to stop unnecessary diffs.