### PR TITLE
[NRLF-357] Successful Create operation returns a 201

### DIFF
--- a/api/producer/createDocumentReference/index.py
+++ b/api/producer/createDocumentReference/index.py
@@ -1,4 +1,5 @@
 import os
+from http import HTTPStatus
 
 from lambda_pipeline.types import LambdaContext
 from lambda_utils.pipeline import execute_steps, render_response
@@ -19,6 +20,11 @@ def handler(event: dict, context: LambdaContext = None) -> dict[str, str]:
         context = LambdaContext()
 
     status_code, result = execute_steps(
-        index_path=__file__, event=event, context=context, config=config, **dependencies
+        index_path=__file__,
+        event=event,
+        http_status_ok=HTTPStatus.CREATED,
+        context=context,
+        config=config,
+        **dependencies
     )
     return render_response(status_code, result)

--- a/api/producer/createDocumentReference/src/config.py
+++ b/api/producer/createDocumentReference/src/config.py
@@ -1,3 +1,5 @@
+from http import HTTPStatus
+
 import boto3
 from nrlf.core.model import DocumentPointer
 from nrlf.core.repository import Repository

--- a/feature_tests/common/models.py
+++ b/feature_tests/common/models.py
@@ -52,7 +52,7 @@ class Response:
     status_code: str = STATUS_CODE_200
 
     def success(self):
-        return self.status_code == STATUS_CODE_200
+        return 300 > int(self.status_code) >= int(STATUS_CODE_200)
 
     @property
     def operation_outcome_msg(self) -> str:

--- a/feature_tests/features/producer/producer-createDocumentPointer-success.feature
+++ b/feature_tests/features/producer/producer-createDocumentPointer-success.feature
@@ -80,6 +80,7 @@ Feature: Producer Create Success scenarios
       | contentType | application/pdf                |
       | url         | https://example.org/my-doc.pdf |
     Then the operation is successful
+    And the status is 201
     And Document Pointer "8FW23-1234567890" exists
       | property    | value                             |
       | id          | 8FW23-1234567890                  |
@@ -106,6 +107,7 @@ Feature: Producer Create Success scenarios
       | contentType | application/pdf                |
       | url         | https://example.org/my-doc.pdf |
     Then the operation is successful
+    And the status is 201
     And the response is an OperationOutcome according to the OUTCOME template with the below values
       | property          | value            |
       | issue_type        | informational    |

--- a/layer/lambda_utils/lambda_utils/pipeline.py
+++ b/layer/lambda_utils/lambda_utils/pipeline.py
@@ -31,9 +31,11 @@ def _get_steps(
     return versioned_steps[version]
 
 
-def _function_handler(fn, transaction_id: str, args, kwargs) -> tuple[HTTPStatus, any]:
+def _function_handler(
+    fn, status_code_ok: HTTPStatus, transaction_id: str, args, kwargs
+) -> tuple[HTTPStatus, any]:
     try:
-        status_code, result = HTTPStatus.OK, fn(*args, **kwargs)
+        status_code, result = status_code_ok, fn(*args, **kwargs)
     except Exception as exception:
         status_code, result = operation_outcome_not_ok(
             transaction_id=transaction_id, exception=exception
@@ -91,6 +93,7 @@ def execute_steps(
     index_path: str,
     event: dict,
     context: LambdaContext,
+    http_status_ok: HTTPStatus = HTTPStatus.OK,
     initial_pipeline_data={},
     **dependencies,
 ) -> tuple[HTTPStatus, dict]:
@@ -101,28 +104,31 @@ def execute_steps(
 
     status_code, response = _function_handler(
         _setup_logger,
+        status_code_ok=http_status_ok,
         transaction_id=transaction_id,
         args=(index_path, transaction_id, event),
         kwargs=dependencies,
     )
 
-    if status_code is not HTTPStatus.OK:
+    if status_code is not http_status_ok:
         return status_code, response
     logger = response
 
     status_code, response = _function_handler(
         _get_steps_for_version_header,
+        status_code_ok=http_status_ok,
         transaction_id=transaction_id,
         args=(index_path, event),
         kwargs={"logger": logger},
     )
 
-    if status_code is not HTTPStatus.OK:
+    if status_code is not http_status_ok:
         return status_code, response
     steps = response
 
     return _function_handler(
         _execute_steps,
+        status_code_ok=http_status_ok,
         transaction_id=transaction_id,
         args=(steps, event, context),
         kwargs={

--- a/layer/lambda_utils/lambda_utils/status_endpoint.py
+++ b/layer/lambda_utils/lambda_utils/status_endpoint.py
@@ -95,6 +95,7 @@ def execute_steps(
     index_path: str,
     event: dict,
     context: LambdaContext,
+    http_status: HTTPStatus = HTTPStatus.OK,
     initial_pipeline_data={},
     **dependencies,
 ) -> tuple[HTTPStatus, dict]:
@@ -107,6 +108,7 @@ def execute_steps(
 
     status_code, response = _function_handler(
         _setup_logger,
+        http_status,
         transaction_id=transaction_id,
         args=(index_path, transaction_id, event),
         kwargs=dependencies,
@@ -118,6 +120,7 @@ def execute_steps(
     steps = _get_steps()
     status_code, response = _function_handler(
         _execute_steps,
+        http_status,
         transaction_id=transaction_id,
         args=(steps, event, context),
         kwargs={

--- a/layer/lambda_utils/lambda_utils/tests/unit/status_test_utils.py
+++ b/layer/lambda_utils/lambda_utils/tests/unit/status_test_utils.py
@@ -42,3 +42,9 @@ OK = {
     "headers": {"Content-Type": "application/json", "Content-Length": 17},
     "body": '{"message": "OK"}',
 }
+
+CREATED = {
+    "statusCode": 201,
+    "headers": {"Content-Type": "application/json", "Content-Length": 17},
+    "body": '{"message": "CREATED"}',
+}


### PR DESCRIPTION
[NRLF-357](https://nhsd-jira.digital.nhs.uk/browse/NRLF-357) 

modified the pipeline so that it can accept a HTTP Status code as an argument and return the passed in status code if it's successful. Set the status code to default to 200 if it's not provided.