### PR TITLE
NRLF-361 Renamed unknown parameter error message

### DIFF
--- a/feature_tests/features/consumer/consumer-searchDocumentPointer-failure.feature
+++ b/feature_tests/features/consumer/consumer-searchDocumentPointer-failure.feature
@@ -90,7 +90,7 @@ Feature: Consumer Search Failure scenarios
       | issue_level       | error                                                   |
       | issue_code        | VALIDATION_ERROR                                        |
       | issue_description | A parameter or value has resulted in a validation error |
-      | message           | Unexpected query parameters: extra                      |
+      | message           | Unexpected request parameters: extra                    |
 
   Scenario: Subject is required
     Given Consumer "Yorkshire Ambulance Service" (Organisation ID "RX898") is requesting to search Document Pointers

--- a/feature_tests/features/consumer/consumer-searchPostDocumentPointer-failure.feature
+++ b/feature_tests/features/consumer/consumer-searchPostDocumentPointer-failure.feature
@@ -91,7 +91,7 @@ Feature: Consumer POST Search Success scenarios
       | issue_level       | error                                                   |
       | issue_code        | VALIDATION_ERROR                                        |
       | issue_description | A parameter or value has resulted in a validation error |
-      | message           | Unexpected query parameters: extra                      |
+      | message           | Unexpected request parameters: extra                    |
 
   Scenario: Search by POST is unable to return Document Pointer
     Given Consumer "Yorkshire Ambulance Service" (Organisation ID "RX898") is requesting to search by POST for Document Pointers

--- a/feature_tests/features/producer/producer-searchDocumentPointer-failure.feature
+++ b/feature_tests/features/producer/producer-searchDocumentPointer-failure.feature
@@ -90,7 +90,7 @@ Feature: Producer Search Failure Scenarios
       | issue_level       | error                                                   |
       | issue_code        | VALIDATION_ERROR                                        |
       | issue_description | A parameter or value has resulted in a validation error |
-      | message           | Unexpected query parameters: extra                      |
+      | message           | Unexpected request parameters: extra                    |
 
   Scenario: Search fails to return a bundle when the next page key is incorrect
     Given Producer "Aaron Court Mental Health NH" (Organisation ID "8FW23") is requesting to search Document Pointers

--- a/feature_tests/features/producer/producer-searchPostDocumentPointer-failure.feature
+++ b/feature_tests/features/producer/producer-searchPostDocumentPointer-failure.feature
@@ -90,7 +90,7 @@ Feature: Basic failure Scenarios where producer is unable to search for Document
       | issue_level       | error                                                   |
       | issue_code        | VALIDATION_ERROR                                        |
       | issue_description | A parameter or value has resulted in a validation error |
-      | message           | Unexpected query parameters: extra                      |
+      | message           | Unexpected request parameters: extra                    |
 
   Scenario: Search by POST is unable to return Document Pointer
     Given Producer "Aaron Court Mental Health NH" (Organisation ID "8FW23") is requesting to search by POST for Document Pointers
@@ -116,7 +116,7 @@ Feature: Basic failure Scenarios where producer is unable to search for Document
       | issue_level       | error                                                   |
       | issue_code        | VALIDATION_ERROR                                        |
       | issue_description | A parameter or value has resulted in a validation error |
-      | message           | Unexpected query parameters: bad                        |
+      | message           | Unexpected request parameters: bad                      |
 
   Scenario: Search fails to return a bundle when the next page key is incorrect
     Given Producer "Aaron Court Mental Health NH" (Organisation ID "8FW23") is requesting to search by POST for Document Pointers

--- a/layer/nrlf/nrlf/core/errors.py
+++ b/layer/nrlf/nrlf/core/errors.py
@@ -1,9 +1,10 @@
 from typing import Union
 
 from nhs_number import is_valid as is_valid_nhs_number
+from pydantic import ValidationError
+
 from nrlf.core.nhsd_codings import SpineCoding
 from nrlf.producer.fhir.r4.model import RequestParams
-from pydantic import ValidationError
 
 
 class ItemNotFound(Exception):
@@ -93,5 +94,5 @@ def assert_no_extra_params(
     unknown_params = set(provided_params) - set(expected_params)
     if unknown_params:
         raise UnknownParameterError(
-            f"Unexpected query parameters: {', '.join(unknown_params)}"
+            f"Unexpected request parameters: {', '.join(unknown_params)}"
         )


### PR DESCRIPTION
[NRLF-361](https://nhsd-jira.digital.nhs.uk/browse/NRLF-361)

Changed the generic error message to make more sense for POST GETs