### PR TITLE
Feature/nrlf 642 feature tests

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,7 @@
+awscli latest
+poetry 1.5.1
+jq latest
+python 3.9.15
+terraform 1.3.4
+java zulu-jre-17.42.19
+yq latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2023-08-03a
+
+- NRLF-491 - Implement int-sandbox splunk environment
+- NRLF-525 - Add versioning to firehose S3 bucket
+- NRLF-529 - ASDF Tool manager
+- NRLF-613 - Increase lambda memory size
+- NRLF-638 - Can create documents with contact details
+- NRLF-658 - Consumer S3 Auth
+
 ## 2023-07-27
 
 - NRLF-526 - CIS2

--- a/README.md
+++ b/README.md
@@ -10,7 +10,16 @@ This project uses the `nrlf.sh` script to build, test and deploy. This script wi
 
 1. [Setup](#setup)
    1. [Prerequisites](#1-prerequisites)
-   2. [Install python dependencies](#2-install-python-dependencies)
+      1. [ASDF Tool Manager](#1-asdf-tool-manager)
+      2. [If you prefer to get your local machine running manually the requirements are...](#2-if-you-prefer-to-get-your-local-machine-running-manually-the-requirements-are)
+   2. [Linux set up](#2-linux-set-up)
+      1. [Java:](#1-java)
+      2. [Poetry:](#2-poetry)
+      3. [pyenv:](#3-pyenv)
+      4. [terraform](#4-terraform)
+      5. [tfenv:](#5-tfenv)
+      6. [yq:](#6-yq)
+   3. [Install python dependencies](#2-install-python-dependencies)
 2. [Initialise shell environment](#initialise-shell-environment)
 3. [Login to AWS](#login-to-aws)
 4. [Build, Test & Run the API](#build-test--run-the-api)
@@ -35,10 +44,20 @@ Before you tackle this guide, there are some more instructions here on the [Deve
 
 ### 1. Prerequisites
 
-- [poetry](https://python-poetry.org/docs/) (this repository uses poetry ^1.2)
+#### 1. ASDF Tool Manager
+
+For an easy way to make sure your local system matches the requirements needed you can use `asdf tool manager`. This tool fetches the required versions of the libraries needed and sets the directory to use that version instead of your system's default version. To get it up and running,
+
+- Install `asdf` using the instructions given here. https://asdf-vm.com/guide/getting-started.html. You can check it installed properly by using the command `asdf --version`
+- Install the dependencies using the `nrlf-dependencies.sh` bash script. `bash nrlf-dependencies.sh`
+- You should be good to go.
+
+#### 2. If you prefer to get your local machine running manually the requirements are...
+
+- [poetry](https://python-poetry.org/docs/) (this repository uses poetry ^1.5.1)
 - [pyenv](https://github.com/pyenv/pyenv) (this repository uses python ^3.9.15)
 - jq
-- terraform
+- terraform (this repository uses terraform ^1.3.4)
 - [tfenv](https://github.com/tfutils/tfenv) (this repository uses terraform 1.3.4)
 - coreutils
 

--- a/changelog/2023-08-03a.md
+++ b/changelog/2023-08-03a.md
@@ -1,0 +1,6 @@
+- NRLF-491 - Implement int-sandbox splunk environment
+- NRLF-525 - Add versioning to firehose S3 bucket
+- NRLF-529 - ASDF Tool manager
+- NRLF-613 - Increase lambda memory size
+- NRLF-638 - Can create documents with contact details
+- NRLF-658 - Consumer S3 Auth

--- a/feature_tests/features/producer/producer-createDocumentPointer-success.feature
+++ b/feature_tests/features/producer/producer-createDocumentPointer-success.feature
@@ -74,6 +74,84 @@ Feature: Producer Create Success scenarios
         "date": "$date"
       }
       """
+    Given template DOCUMENT_WITH_CONTACT
+      """
+      {
+        "resourceType": "DocumentReference",
+        "id": "$custodian-$identifier",
+        "custodian": {
+          "identifier": {
+            "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+            "value": "$custodian"
+          }
+        },
+        "subject": {
+          "identifier": {
+            "system": "https://fhir.nhs.uk/Id/nhs-number",
+            "value": "$subject"
+          }
+        },
+        "type": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "$type"
+            }
+          ]
+        },
+        "content": [
+          {
+            "attachment": {
+              "contentType": "$contentType",
+              "url": "$url"
+            }
+          },
+          {
+            "attachment": {
+              "contentType": "text/html",
+              "url": "$contactUrl"
+            }
+          }
+        ],
+        "status": "current"
+      }
+      """
+    Given template DOCUMENT_WITH_CONTACT_ONLY
+      """
+      {
+        "resourceType": "DocumentReference",
+        "id": "$custodian-$identifier",
+        "custodian": {
+          "identifier": {
+            "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+            "value": "$custodian"
+          }
+        },
+        "subject": {
+          "identifier": {
+            "system": "https://fhir.nhs.uk/Id/nhs-number",
+            "value": "$subject"
+          }
+        },
+        "type": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "$type"
+            }
+          ]
+        },
+        "content": [
+          {
+            "attachment": {
+              "contentType": "text/html",
+              "url": "$contactUrl"
+            }
+          }
+        ],
+        "status": "current"
+      }
+      """
     And template OUTCOME
       """
       {
@@ -208,6 +286,60 @@ Feature: Producer Create Success scenarios
       | updated_on  | NULL                                    |
       | document    | <document>                              |
       | created_on  | <timestamp>                             |
+
+  Scenario: Successfully create a Document Pointer with content and contact details
+    Given Producer "Aaron Court Mental Health NH" (Organisation ID "8FW23") is requesting to create Document Pointers
+    And Producer "Aaron Court Mental Health NH" is registered in the system for application "DataShare" (ID "z00z-y11y-x22x") with pointer types
+      | system                 | value     |
+      | http://snomed.info/sct | 736253002 |
+    When Producer "Aaron Court Mental Health NH" creates a Document Reference from DOCUMENT_WITH_CONTACT template
+      | property    | value                               |
+      | identifier  | 1234567890                          |
+      | type        | 736253002                           |
+      | custodian   | 8FW23                               |
+      | subject     | 9278693472                          |
+      | contentType | application/pdf                     |
+      | url         | https://example.org/my-doc.pdf      |
+      | contactUrl  | https://example.org/my-contact.html |
+    Then the operation is successful
+    And the status is 201
+    And Document Pointer "8FW23-1234567890" exists
+      | property    | value                             |
+      | id          | 8FW23-1234567890                  |
+      | nhs_number  | 9278693472                        |
+      | producer_id | 8FW23                             |
+      | type        | http://snomed.info/sct\|736253002 |
+      | source      | NRLF                              |
+      | version     | 1                                 |
+      | updated_on  | NULL                              |
+      | document    | <document>                        |
+      | created_on  | <timestamp>                       |
+
+  Scenario: Successfully create a Document Pointer with contact details only
+    Given Producer "Aaron Court Mental Health NH" (Organisation ID "8FW23") is requesting to create Document Pointers
+    And Producer "Aaron Court Mental Health NH" is registered in the system for application "DataShare" (ID "z00z-y11y-x22x") with pointer types
+      | system                 | value     |
+      | http://snomed.info/sct | 736253002 |
+    When Producer "Aaron Court Mental Health NH" creates a Document Reference from DOCUMENT_WITH_CONTACT_ONLY template
+      | property   | value                               |
+      | identifier | 1234567890                          |
+      | type       | 736253002                           |
+      | custodian  | 8FW23                               |
+      | subject    | 9278693472                          |
+      | contactUrl | https://example.org/my-contact.html |
+    Then the operation is successful
+    And the status is 201
+    And Document Pointer "8FW23-1234567890" exists
+      | property    | value                             |
+      | id          | 8FW23-1234567890                  |
+      | nhs_number  | 9278693472                        |
+      | producer_id | 8FW23                             |
+      | type        | http://snomed.info/sct\|736253002 |
+      | source      | NRLF                              |
+      | version     | 1                                 |
+      | updated_on  | NULL                              |
+      | document    | <document>                        |
+      | created_on  | <timestamp>                       |
 
   Scenario: Successfully create a Document Pointer when the producer has an extension code
     Given Producer "BaRS (EMIS)" (Organisation ID "V4T0L.YGMMC") is requesting to create Document Pointers

--- a/feature_tests/features/producer/producer-nrlToR4Conversion-fullRecord.success.feature
+++ b/feature_tests/features/producer/producer-nrlToR4Conversion-fullRecord.success.feature
@@ -1,7 +1,7 @@
 Feature: Producer Create NRL-to-R4 Conversion
 
   Background:
-    Given version "0.0.7" of "nrlf-converter" has been installed
+    Given version "0.0.8" of "nrlf-converter" has been installed
     And template NRL_DOCUMENT_POINTER
       """
       {
@@ -23,8 +23,8 @@ Feature: Producer Create NRL-to-R4 Conversion
                       "system": "http://snomed.info/sct",
                       "code": "$classCode",
                       "display": "$classDisplay",
-                      "userSelected": true,
-                      "version": "$classVersion"
+                      "version": "$classVersion",
+                      "userSelected": true
                   }
               ]
           },
@@ -291,32 +291,32 @@ Feature: Producer Create NRL-to-R4 Conversion
       | typeCode               | 718377777                                                                            |
       | typeDisplay            | Another Test data                                                                    |
     When Producer "Data Sync" uses "nrlf-converter" to convert NRL_DOCUMENT_POINTER with NHS Number "9278693472" and ASID "230811201350" into a DocumentReference according to the DOCUMENT_REFERENCE template
-      | property               | value                                                                                |
-      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
-      | nhsNumber              | 9278693472                                                                           |
-      | asid                   | 230811201350                                                                         |
-      | attachmentContentType  | application/pdf                                                                      |
-      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                            |
-      | attachmentUrl          | https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
-      | attachmentHash         | 2jmj7l5rSw0yVb/vlWAYkK/YBwk=                                                         |
-      | attachmentLanguage     | en-US                                                                                |
-      | attachmentTitle        | Mental health Crisis Plan Report                                                     |
-      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                         |
-      | classCode              | 734163000                                                                            |
-      | classDisplay           | Care plan                                                                            |
-      | classVersion           | 1                                                                                    |
-      | userSelected           | True                                                                                 |
-      | custodian              | 8FW23                                                                                |
-      | indexed                | 2022-08-23T14:45:17+00:00                                                            |
-      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                        |
-      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                            |
-      | periodStart            | 2023-01-01T20:01:44Z                                                                 |
-      | periodEnd              | 2023-11-12T20:01:44Z                                                                 |
-      | practiceSettingCode    | 310167005                                                                            |
-      | practiceSettingDisplay | Urology service                                                                      |
-      | typeCode               | 718377777                                                                            |
-      | typeDisplay            | Another Test data                                                                    |
-      | typeSystem             | http://snomed.info/sct                                                               |
+      | property               | value                                                                              |
+      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
+      | nhsNumber              | 9278693472                                                                         |
+      | asid                   | 230811201350                                                                       |
+      | attachmentContentType  | application/pdf                                                                    |
+      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                          |
+      | attachmentUrl          | ssp://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
+      | attachmentHash         | 2jmj7l5rSw0yVb/vlWAYkK/YBwk=                                                       |
+      | attachmentLanguage     | en-US                                                                              |
+      | attachmentTitle        | Mental health Crisis Plan Report                                                   |
+      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                       |
+      | classCode              | 734163000                                                                          |
+      | classDisplay           | Care plan                                                                          |
+      | classVersion           | 1                                                                                  |
+      | userSelected           | True                                                                               |
+      | custodian              | 8FW23                                                                              |
+      | indexed                | 2022-08-23T14:45:17+00:00                                                          |
+      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                      |
+      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                          |
+      | periodStart            | 2023-01-01T20:01:44Z                                                               |
+      | periodEnd              | 2023-11-12T20:01:44Z                                                               |
+      | practiceSettingCode    | 310167005                                                                          |
+      | practiceSettingDisplay | Urology service                                                                    |
+      | typeCode               | 718377777                                                                          |
+      | typeDisplay            | Another Test data                                                                  |
+      | typeSystem             | http://snomed.info/sct                                                             |
     Then the operation is successful
     When Producer "Data Sync" creates a Document Reference from DOCUMENT_REFERENCE template
     Then the operation is successful
@@ -346,32 +346,32 @@ Feature: Producer Create NRL-to-R4 Conversion
       | system                 | value     |
       | http://snomed.info/sct | 718377777 |
     And a Document Pointer exists in the system with the below values for DOCUMENT_REFERENCE template
-      | property               | value                                                                                |
-      | id                     | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
-      | nhsNumber              | 9278693472                                                                           |
-      | attachmentContentType  | application/pdf                                                                      |
-      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                            |
-      | attachmentUrl          | https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
-      | attachmentHash         | 2jmj7l5rSw0yVb/vlWAYkK/YBwk=                                                         |
-      | attachmentLanguage     | en-US                                                                                |
-      | attachmentTitle        | Mental health Crisis Plan Report                                                     |
-      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                         |
-      | classCode              | 734163000                                                                            |
-      | classDisplay           | Care plan                                                                            |
-      | classVersion           | 1                                                                                    |
-      | custodian              | 8FW23                                                                                |
-      | indexed                | 2022-08-23T14:45:17+00:00                                                            |
-      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                        |
-      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                            |
-      | masterIdentifierSystem | urn:ietf:rfc:395                                                                     |
-      | masterIdentifierValue  | urn:oid:1.3.6.1.4.1.21367.2005.47481.7                                               |
-      | periodStart            | 2023-01-01T20:01:44Z                                                                 |
-      | periodEnd              | 2023-11-12T20:01:44Z                                                                 |
-      | practiceSettingCode    | 310167005                                                                            |
-      | practiceSettingDisplay | Urology service                                                                      |
-      | typeCode               | 718377777                                                                            |
-      | typeDisplay            | Another Test data                                                                    |
-      | typeSystem             | http://snomed.info/sct                                                               |
+      | property               | value                                                                              |
+      | id                     | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
+      | nhsNumber              | 9278693472                                                                         |
+      | attachmentContentType  | application/pdf                                                                    |
+      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                          |
+      | attachmentUrl          | ssp://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
+      | attachmentHash         | 2jmj7l5rSw0yVb/vlWAYkK/YBwk=                                                       |
+      | attachmentLanguage     | en-US                                                                              |
+      | attachmentTitle        | Mental health Crisis Plan Report                                                   |
+      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                       |
+      | classCode              | 734163000                                                                          |
+      | classDisplay           | Care plan                                                                          |
+      | classVersion           | 1                                                                                  |
+      | custodian              | 8FW23                                                                              |
+      | indexed                | 2022-08-23T14:45:17+00:00                                                          |
+      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                      |
+      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                          |
+      | masterIdentifierSystem | urn:ietf:rfc:395                                                                   |
+      | masterIdentifierValue  | urn:oid:1.3.6.1.4.1.21367.2005.47481.7                                             |
+      | periodStart            | 2023-01-01T20:01:44Z                                                               |
+      | periodEnd              | 2023-11-12T20:01:44Z                                                               |
+      | practiceSettingCode    | 310167005                                                                          |
+      | practiceSettingDisplay | Urology service                                                                    |
+      | typeCode               | 718377777                                                                          |
+      | typeDisplay            | Another Test data                                                                  |
+      | typeSystem             | http://snomed.info/sct                                                             |
     And Producer "Data Sync" has an NRL Document Pointer from NRL_DOCUMENT_POINTER template
       | property               | value                                                                                                              |
       | attachmentContentType  | application/pdf                                                                                                    |
@@ -399,32 +399,32 @@ Feature: Producer Create NRL-to-R4 Conversion
       | typeCode               | 718377777                                                                                                          |
       | typeDisplay            | Another Test data                                                                                                  |
     When Producer "Data Sync" uses "nrl-to-r4" to convert NRL_DOCUMENT_POINTER with NHS Number "9278693472" and ASID "230811201350" into a DocumentReference according to the DOCUMENT_REFERENCE template
-      | property               | value                                                                                |
-      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
-      | nhsNumber              | 9278693472                                                                           |
-      | asid                   | 230811201350                                                                         |
-      | attachmentContentType  | application/pdf                                                                      |
-      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                            |
-      | attachmentUrl          | https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
-      | attachmentHash         | 2jmj7l5rSw0yVb/vlWAYkK/YBwk=                                                         |
-      | attachmentLanguage     | en-US                                                                                |
-      | attachmentTitle        | Mental health Crisis Plan Report                                                     |
-      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                         |
-      | classCode              | 734163000                                                                            |
-      | classDisplay           | Care plan                                                                            |
-      | classVersion           | 1                                                                                    |
-      | custodian              | 8FW23                                                                                |
-      | indexed                | 2022-08-23T14:45:17+00:00                                                            |
-      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                        |
-      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                            |
-      | periodStart            | 2023-01-01T20:01:44Z                                                                 |
-      | periodEnd              | 2023-11-12T20:01:44Z                                                                 |
-      | practiceSettingCode    | 310167005                                                                            |
-      | practiceSettingDisplay | Urology service                                                                      |
-      | typeCode               | 718377777                                                                            |
-      | typeDisplay            | Another Test data                                                                    |
-      | typeSystem             | http://snomed.info/sct                                                               |
-      | target                 | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
+      | property               | value                                                                              |
+      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
+      | nhsNumber              | 9278693472                                                                         |
+      | asid                   | 230811201350                                                                       |
+      | attachmentContentType  | application/pdf                                                                    |
+      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                          |
+      | attachmentUrl          | ssp://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
+      | attachmentHash         | 2jmj7l5rSw0yVb/vlWAYkK/YBwk=                                                       |
+      | attachmentLanguage     | en-US                                                                              |
+      | attachmentTitle        | Mental health Crisis Plan Report                                                   |
+      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                       |
+      | classCode              | 734163000                                                                          |
+      | classDisplay           | Care plan                                                                          |
+      | classVersion           | 1                                                                                  |
+      | custodian              | 8FW23                                                                              |
+      | indexed                | 2022-08-23T14:45:17+00:00                                                          |
+      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                      |
+      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                          |
+      | periodStart            | 2023-01-01T20:01:44Z                                                               |
+      | periodEnd              | 2023-11-12T20:01:44Z                                                               |
+      | practiceSettingCode    | 310167005                                                                          |
+      | practiceSettingDisplay | Urology service                                                                    |
+      | typeCode               | 718377777                                                                          |
+      | typeDisplay            | Another Test data                                                                  |
+      | typeSystem             | http://snomed.info/sct                                                             |
+      | target                 | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
     Then the operation is successful
     When Producer "Data Sync" creates a Document Reference from DOCUMENT_REFERENCE template
     Then the operation is successful

--- a/feature_tests/features/producer/producer-nrlToR4Conversion.failure.feature
+++ b/feature_tests/features/producer/producer-nrlToR4Conversion.failure.feature
@@ -1,7 +1,7 @@
 Feature: Producer NRL-to-R4 Conversion Failures
 
   Background:
-    Given version "0.0.7" of "nrlf-converter" has been installed
+    Given version "0.0.8" of "nrlf-converter" has been installed
     And template NRL_DOCUMENT_POINTER
       """
       {

--- a/feature_tests/features/producer/producer-nrlToR4Conversion.success.feature
+++ b/feature_tests/features/producer/producer-nrlToR4Conversion.success.feature
@@ -1,7 +1,7 @@
 Feature: Producer Create NRL-to-R4 Conversion
 
   Background:
-    Given version "0.0.7" of "nrlf-converter" has been installed
+    Given version "0.0.8" of "nrlf-converter" has been installed
     And template NRL_DOCUMENT_POINTER
       """
       {
@@ -47,6 +47,87 @@ Feature: Producer Create NRL-to-R4 Conversion
                   ]
               }
           },
+          "custodian": {
+              "reference": "$custodian"
+          },
+          "format": {
+              "code": "urn:nhs-ic:unstructured",
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/NRL-FormatCode-1",
+              "display": "Unstructured Document"
+          },
+          "indexed": "$indexed",
+          "lastModified": "$lastModified",
+          "logicalIdentifier": {
+              "logicalId": "$logicalId"
+          },
+          "meta": {
+              "versionId": "1",
+              "profile": [
+                  "https://fhir.nhs.uk/STU3/StructureDefinition/NRL-DocumentReference-1"
+              ],
+              "lastUpdated": "Tue, 23 Aug 2022 14:45:17 GMT"
+          },
+          "relatesTo": {
+              "code": "$relatesToCode",
+              "target": {
+                  "reference": "$relatesToTarget",
+                  "identifier": {
+                      "value": "$relatesToIdentifier",
+                      "system": "$relatesToSystem"
+                  }
+              }
+          },
+          "removed": false,
+          "stability": {
+              "coding": [
+                  {
+                      "code": "dynamic",
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/NRL-ContentStability-1",
+                      "display": "Dynamic"
+                  }
+              ]
+          },
+          "status": "current",
+          "type": {
+              "code": "$typeCode",
+              "display": "$typeDisplay"
+          }
+      }
+      """
+    And template NRL_DOCUMENT_POINTER_WITHOUT_CONTEXT
+      """
+      {
+          "attachment": {
+              "url": "https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf",
+              "creation": "2021-03-08T15:26:00+01:00",
+              "contentType": "application/pdf"
+          },
+          "author": {
+              "reference": "https://directory.spineservices.nhs.uk/STU3/Organization/RAE"
+          },
+          "class": {
+              "coding": [
+                  {
+                      "system": "http://snomed.info/sct",
+                      "code": "$classCode",
+                      "display": "$classDisplay"
+                  }
+              ]
+          },
+          "content": [
+              {
+                  "attachment": {
+                      "url": "$attachmentUrl",
+                      "contentType": "$attachmentContentType",
+                      "creation": "$attachmentCreation"
+                  },
+                  "format": {
+                      "code": "urn:nhs-ic:unstructured",
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/NRL-FormatCode-1",
+                      "display": "Unstructured Document"
+                  }
+              }
+          ],
           "custodian": {
               "reference": "$custodian"
           },
@@ -152,8 +233,8 @@ Feature: Producer Create NRL-to-R4 Conversion
                   },
                   "format": {
                       "code": "urn:nhs-ic:unstructured",
-                      "display": "Unstructured Document",
-                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/NRL-FormatCode-1"
+                "display": "Unstructured Document",
+                "system": "https://fhir.nhs.uk/STU3/CodeSystem/NRL-FormatCode-1"
                   }
               }
           ],
@@ -168,6 +249,82 @@ Feature: Producer Create NRL-to-R4 Conversion
                   ]
               }
           },
+          "resourceType": "DocumentReference",
+          "relatesTo": [
+              {
+                  "code": "replaces",
+                  "target": {
+                      "identifier": {
+                          "value": "$target"
+                      }
+                  }
+              }
+          ]
+      }
+      """
+    And template DOCUMENT_REFERENCE_WITHOUT_CONTEXT
+      """
+      {
+          "id": "$id",
+          "status": "current",
+          "type": {
+              "coding": [
+                  {
+                      "code": "$typeCode",
+                      "display": "$typeDisplay",
+                      "system": "$typeSystem"
+                  }
+              ]
+          },
+          "category": [
+              {
+                  "coding": [
+                      {
+                          "code": "$classCode",
+                          "display": "$classDisplay",
+                          "system": "http://snomed.info/sct"
+                      }
+                  ]
+              }
+          ],
+          "subject": {
+              "identifier": {
+                  "value": "$nhsNumber",
+                  "system": "https://fhir.nhs.uk/Id/nhs-number"
+              }
+          },
+          "date": "$indexed",
+          "author": [
+              {
+                  "identifier": {
+                      "value": "$asid",
+                      "system": "https://fhir.nhs.uk/Id/nhsSpineASID"
+                  }
+              },
+              {
+                  "reference": "$author"
+              }
+          ],
+          "custodian": {
+              "identifier": {
+                  "value": "$custodian",
+                  "system": "https://fhir.nhs.uk/Id/ods-organization-code"
+              }
+          },
+          "content": [
+              {
+                  "attachment": {
+                      "url": "$attachmentUrl",
+                      "contentType": "$attachmentContentType",
+                      "creation": "$attachmentCreation"
+                  },
+                  "format": {
+                      "code": "urn:nhs-ic:unstructured",
+                      "display": "Unstructured Document",
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/NRL-FormatCode-1"
+                  }
+              }
+          ],
           "resourceType": "DocumentReference",
           "relatesTo": [
               {
@@ -237,25 +394,25 @@ Feature: Producer Create NRL-to-R4 Conversion
       | typeCode               | 718377777                                                                            |
       | typeDisplay            | Another Test data                                                                    |
     When Producer "Data Sync" uses "nrlf-converter" to convert NRL_DOCUMENT_POINTER with NHS Number "9278693472" and ASID "230811201350" into a DocumentReference according to the DOCUMENT_REFERENCE template
-      | property               | value                                                                                |
-      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
-      | nhsNumber              | 9278693472                                                                           |
-      | asid                   | 230811201350                                                                         |
-      | attachmentContentType  | application/pdf                                                                      |
-      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                            |
-      | attachmentUrl          | https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
-      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                         |
-      | classCode              | 734163000                                                                            |
-      | classDisplay           | Care plan                                                                            |
-      | custodian              | 8FW23                                                                                |
-      | indexed                | 2022-08-23T14:45:17+00:00                                                            |
-      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                        |
-      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                            |
-      | practiceSettingCode    | 310167005                                                                            |
-      | practiceSettingDisplay | Urology service                                                                      |
-      | typeCode               | 718377777                                                                            |
-      | typeDisplay            | Another Test data                                                                    |
-      | typeSystem             | http://snomed.info/sct                                                               |
+      | property               | value                                                                              |
+      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
+      | nhsNumber              | 9278693472                                                                         |
+      | asid                   | 230811201350                                                                       |
+      | attachmentContentType  | application/pdf                                                                    |
+      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                          |
+      | attachmentUrl          | ssp://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
+      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                       |
+      | classCode              | 734163000                                                                          |
+      | classDisplay           | Care plan                                                                          |
+      | custodian              | 8FW23                                                                              |
+      | indexed                | 2022-08-23T14:45:17+00:00                                                          |
+      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                      |
+      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                          |
+      | practiceSettingCode    | 310167005                                                                          |
+      | practiceSettingDisplay | Urology service                                                                    |
+      | typeCode               | 718377777                                                                          |
+      | typeDisplay            | Another Test data                                                                  |
+      | typeSystem             | http://snomed.info/sct                                                             |
     Then the operation is successful
     When Producer "Data Sync" creates a Document Reference from DOCUMENT_REFERENCE template
     Then the operation is successful
@@ -285,24 +442,24 @@ Feature: Producer Create NRL-to-R4 Conversion
       | system                 | value     |
       | http://snomed.info/sct | 718377777 |
     And a Document Pointer exists in the system with the below values for DOCUMENT_REFERENCE template
-      | property               | value                                                                                |
-      | id                     | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
-      | nhsNumber              | 9278693472                                                                           |
-      | attachmentContentType  | application/pdf                                                                      |
-      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                            |
-      | attachmentUrl          | https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
-      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                         |
-      | classCode              | 734163000                                                                            |
-      | classDisplay           | Care plan                                                                            |
-      | custodian              | 8FW23                                                                                |
-      | indexed                | 2022-08-23T14:45:17+00:00                                                            |
-      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                        |
-      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                            |
-      | practiceSettingCode    | 310167005                                                                            |
-      | practiceSettingDisplay | Urology service                                                                      |
-      | typeCode               | 718377777                                                                            |
-      | typeDisplay            | Another Test data                                                                    |
-      | typeSystem             | http://snomed.info/sct                                                               |
+      | property               | value                                                                              |
+      | id                     | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
+      | nhsNumber              | 9278693472                                                                         |
+      | attachmentContentType  | application/pdf                                                                    |
+      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                          |
+      | attachmentUrl          | ssp://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
+      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                       |
+      | classCode              | 734163000                                                                          |
+      | classDisplay           | Care plan                                                                          |
+      | custodian              | 8FW23                                                                              |
+      | indexed                | 2022-08-23T14:45:17+00:00                                                          |
+      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                      |
+      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                          |
+      | practiceSettingCode    | 310167005                                                                          |
+      | practiceSettingDisplay | Urology service                                                                    |
+      | typeCode               | 718377777                                                                          |
+      | typeDisplay            | Another Test data                                                                  |
+      | typeSystem             | http://snomed.info/sct                                                             |
     And Producer "Data Sync" has an NRL Document Pointer from NRL_DOCUMENT_POINTER template
       | property               | value                                                                                                              |
       | attachmentContentType  | application/pdf                                                                                                    |
@@ -324,26 +481,26 @@ Feature: Producer Create NRL-to-R4 Conversion
       | typeCode               | 718377777                                                                                                          |
       | typeDisplay            | Another Test data                                                                                                  |
     When Producer "Data Sync" uses "nrl-to-r4" to convert NRL_DOCUMENT_POINTER with NHS Number "9278693472" and ASID "230811201350" into a DocumentReference according to the DOCUMENT_REFERENCE template
-      | property               | value                                                                                |
-      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
-      | nhsNumber              | 9278693472                                                                           |
-      | asid                   | 230811201350                                                                         |
-      | attachmentContentType  | application/pdf                                                                      |
-      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                            |
-      | attachmentUrl          | https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
-      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                         |
-      | classCode              | 734163000                                                                            |
-      | classDisplay           | Care plan                                                                            |
-      | custodian              | 8FW23                                                                                |
-      | indexed                | 2022-08-23T14:45:17+00:00                                                            |
-      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                        |
-      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                            |
-      | practiceSettingCode    | 310167005                                                                            |
-      | practiceSettingDisplay | Urology service                                                                      |
-      | typeCode               | 718377777                                                                            |
-      | typeDisplay            | Another Test data                                                                    |
-      | typeSystem             | http://snomed.info/sct                                                               |
-      | target                 | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
+      | property               | value                                                                              |
+      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
+      | nhsNumber              | 9278693472                                                                         |
+      | asid                   | 230811201350                                                                       |
+      | attachmentContentType  | application/pdf                                                                    |
+      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                          |
+      | attachmentUrl          | ssp://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
+      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                       |
+      | classCode              | 734163000                                                                          |
+      | classDisplay           | Care plan                                                                          |
+      | custodian              | 8FW23                                                                              |
+      | indexed                | 2022-08-23T14:45:17+00:00                                                          |
+      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                      |
+      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                          |
+      | practiceSettingCode    | 310167005                                                                          |
+      | practiceSettingDisplay | Urology service                                                                    |
+      | typeCode               | 718377777                                                                          |
+      | typeDisplay            | Another Test data                                                                  |
+      | typeSystem             | http://snomed.info/sct                                                             |
+      | target                 | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
     Then the operation is successful
     When Producer "Data Sync" creates a Document Reference from DOCUMENT_REFERENCE template
     Then the operation is successful
@@ -395,26 +552,26 @@ Feature: Producer Create NRL-to-R4 Conversion
       | typeCode               | 718377777                                                                                                          |
       | typeDisplay            | Another Test data                                                                                                  |
     When Producer "Data Sync" uses "nrl-to-r4" to convert NRL_DOCUMENT_POINTER with NHS Number "9278693472" and ASID "230811201350" into a DocumentReference according to the DOCUMENT_REFERENCE template
-      | property               | value                                                                                |
-      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
-      | nhsNumber              | 9278693472                                                                           |
-      | asid                   | 230811201350                                                                         |
-      | attachmentContentType  | application/pdf                                                                      |
-      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                            |
-      | attachmentUrl          | https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
-      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                         |
-      | classCode              | 734163000                                                                            |
-      | classDisplay           | Care plan                                                                            |
-      | custodian              | 8FW23                                                                                |
-      | indexed                | 2022-08-23T14:45:17+00:00                                                            |
-      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                        |
-      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                            |
-      | practiceSettingCode    | 310167005                                                                            |
-      | practiceSettingDisplay | Urology service                                                                      |
-      | typeCode               | 718377777                                                                            |
-      | typeDisplay            | Another Test data                                                                    |
-      | typeSystem             | http://snomed.info/sct                                                               |
-      | target                 | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
+      | property               | value                                                                              |
+      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
+      | nhsNumber              | 9278693472                                                                         |
+      | asid                   | 230811201350                                                                       |
+      | attachmentContentType  | application/pdf                                                                    |
+      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                          |
+      | attachmentUrl          | ssp://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
+      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                       |
+      | classCode              | 734163000                                                                          |
+      | classDisplay           | Care plan                                                                          |
+      | custodian              | 8FW23                                                                              |
+      | indexed                | 2022-08-23T14:45:17+00:00                                                          |
+      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                      |
+      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                          |
+      | practiceSettingCode    | 310167005                                                                          |
+      | practiceSettingDisplay | Urology service                                                                    |
+      | typeCode               | 718377777                                                                          |
+      | typeDisplay            | Another Test data                                                                  |
+      | typeSystem             | http://snomed.info/sct                                                             |
+      | target                 | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
     Then the operation is successful
     When Producer "Data Sync" creates a Document Reference from DOCUMENT_REFERENCE template
     Then the operation is successful
@@ -466,26 +623,26 @@ Feature: Producer Create NRL-to-R4 Conversion
       | typeCode               | 718377777                                                                            |
       | typeDisplay            | Another Test data                                                                    |
     When Producer "Data Sync" uses "nrl-to-r4" to convert NRL_DOCUMENT_POINTER with NHS Number "9278693472" and ASID "230811201350" into a DocumentReference according to the DOCUMENT_REFERENCE template
-      | property               | value                                                                                |
-      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
-      | nhsNumber              | 9278693472                                                                           |
-      | asid                   | 230811201350                                                                         |
-      | attachmentContentType  | application/pdf                                                                      |
-      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                            |
-      | attachmentUrl          | https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
-      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                         |
-      | classCode              | 734163000                                                                            |
-      | classDisplay           | Care plan                                                                            |
-      | custodian              | 8FW23                                                                                |
-      | indexed                | 2022-08-23T14:45:17+00:00                                                            |
-      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                        |
-      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                            |
-      | practiceSettingCode    | 310167005                                                                            |
-      | practiceSettingDisplay | Urology service                                                                      |
-      | typeCode               | 718377777                                                                            |
-      | typeDisplay            | Another Test data                                                                    |
-      | typeSystem             | http://snomed.info/sct                                                               |
-      | target                 | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
+      | property               | value                                                                              |
+      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
+      | nhsNumber              | 9278693472                                                                         |
+      | asid                   | 230811201350                                                                       |
+      | attachmentContentType  | application/pdf                                                                    |
+      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                          |
+      | attachmentUrl          | ssp://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
+      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                       |
+      | classCode              | 734163000                                                                          |
+      | classDisplay           | Care plan                                                                          |
+      | custodian              | 8FW23                                                                              |
+      | indexed                | 2022-08-23T14:45:17+00:00                                                          |
+      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                      |
+      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                          |
+      | practiceSettingCode    | 310167005                                                                          |
+      | practiceSettingDisplay | Urology service                                                                    |
+      | typeCode               | 718377777                                                                          |
+      | typeDisplay            | Another Test data                                                                  |
+      | typeSystem             | http://snomed.info/sct                                                             |
+      | target                 | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
     Then the operation is successful
     When Producer "Data Sync" creates a Document Reference from DOCUMENT_REFERENCE template
     Then the operation is successful
@@ -509,3 +666,137 @@ Feature: Producer Create NRL-to-R4 Conversion
       | document    | <document>                                                      |
       | created_on  | <timestamp>                                                     |
     And Document Pointer "8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851" does not exist
+
+  Scenario: NRL can Create a DocumentReference from an NRL Document Pointer with No Attachment
+    Given Producer "Data Sync" (Organisation ID "8FW23") is requesting to create Document Pointers
+    And Producer "Data Sync" is registered in the system for application "DataShare" (ID "z00z-y11y-x22x") with pointer types
+      | system                 | value     |
+      | http://snomed.info/sct | 718377777 |
+    And Producer "Data Sync" has the permission "audit-dates-from-payload"
+    And Producer "Data Sync" has an NRL Document Pointer from NRL_DOCUMENT_POINTER template
+      | property               | value                                                          |
+      | attachmentContentType  | text/html                                                      |
+      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                      |
+      | attachmentUrl          | https://spine-proxy.national.ncrs.nhs.uk/                      |
+      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE   |
+      | classCode              | 734163000                                                      |
+      | classDisplay           | Care plan                                                      |
+      | custodian              | https://directory.spineservices.nhs.uk/STU3/Organization/8FW23 |
+      | indexed                | 2022-08-23T14:45:17+00:00                                      |
+      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                  |
+      | logicalId              | a18af9ab-32b7-11ee-87e3-067a0214ca1a-58394e47453659524c33      |
+      | practiceSettingCode    | 310167005                                                      |
+      | practiceSettingDisplay | Urology service                                                |
+      | relatesToCode          |                                                                |
+      | relatesToIdentifier    |                                                                |
+      | relatesToTarget        |                                                                |
+      | relatesToSystem        |                                                                |
+      | typeCode               | 718377777                                                      |
+      | typeDisplay            | Another Test data                                              |
+    When Producer "Data Sync" uses "nrlf-converter" to convert NRL_DOCUMENT_POINTER with NHS Number "9693893158" and ASID "230811201350" into a DocumentReference according to the DOCUMENT_REFERENCE template
+      | property               | value                                                           |
+      | id                     | 8FW23-a18af9ab-32b7-11ee-87e3-067a0214ca1a-58394e47453659524c33 |
+      | nhsNumber              | 9693893158                                                      |
+      | asid                   | 230811201350                                                    |
+      | attachmentContentType  | text/html                                                       |
+      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                       |
+      | attachmentUrl          | ssp://spine-proxy.national.ncrs.nhs.uk/                         |
+      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE    |
+      | classCode              | 734163000                                                       |
+      | classDisplay           | Care plan                                                       |
+      | custodian              | 8FW23                                                           |
+      | indexed                | 2022-08-23T14:45:17+00:00                                       |
+      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                   |
+      | logicalId              | a18af9ab-32b7-11ee-87e3-067a0214ca1a-58394e47453659524c33       |
+      | practiceSettingCode    | 310167005                                                       |
+      | practiceSettingDisplay | Urology service                                                 |
+      | typeCode               | 718377777                                                       |
+      | typeDisplay            | Another Test data                                               |
+      | typeSystem             | http://snomed.info/sct                                          |
+    Then the operation is successful
+    When Producer "Data Sync" creates a Document Reference from DOCUMENT_REFERENCE template
+    Then the operation is successful
+    And the status is 201
+    And the response is an OperationOutcome according to the OUTCOME template with the below values
+      | property          | value            |
+      | issue_type        | informational    |
+      | issue_level       | information      |
+      | issue_code        | RESOURCE_CREATED |
+      | issue_description | Resource created |
+      | message           | Resource created |
+    And Document Pointer "8FW23-a18af9ab-32b7-11ee-87e3-067a0214ca1a-58394e47453659524c33" exists
+      | property    | value                                                           |
+      | id          | 8FW23-a18af9ab-32b7-11ee-87e3-067a0214ca1a-58394e47453659524c33 |
+      | nhs_number  | 9693893158                                                      |
+      | producer_id | 8FW23                                                           |
+      | type        | http://snomed.info/sct\|718377777                               |
+      | source      | NRLF                                                            |
+      | version     | 1                                                               |
+      | updated_on  | NULL                                                            |
+      | document    | <document>                                                      |
+      | created_on  | <timestamp>                                                     |
+
+  Scenario: NRL can Create a DocumentReference from an NRL Document Pointer with No Context
+    Given Producer "Data Sync" (Organisation ID "8FW23") is requesting to create Document Pointers
+    And Producer "Data Sync" is registered in the system for application "DataShare" (ID "z00z-y11y-x22x") with pointer types
+      | system                 | value     |
+      | http://snomed.info/sct | 718377777 |
+    And Producer "Data Sync" has the permission "audit-dates-from-payload"
+    And Producer "Data Sync" has an NRL Document Pointer from NRL_DOCUMENT_POINTER_WITHOUT_CONTEXT template
+      | property              | value                                                          |
+      | attachmentContentType | text/html                                                      |
+      | attachmentCreation    | 2021-03-08T15:26:00+01:00                                      |
+      | attachmentUrl         | https://spine-proxy.national.ncrs.nhs.uk/                      |
+      | author                | https://directory.spineservices.nhs.uk/STU3/Organization/RAE   |
+      | classCode             | 734163000                                                      |
+      | classDisplay          | Care plan                                                      |
+      | custodian             | https://directory.spineservices.nhs.uk/STU3/Organization/8FW23 |
+      | indexed               | 2022-08-23T14:45:17+00:00                                      |
+      | lastModified          | Tue, 23 Aug 2022 14:45:17 GMT                                  |
+      | logicalId             | 16f1ba23-32bc-11ee-87e3-067a0214ca1a-58394e47453659524c33      |
+      | relatesToCode         |                                                                |
+      | relatesToIdentifier   |                                                                |
+      | relatesToTarget       |                                                                |
+      | relatesToSystem       |                                                                |
+      | typeCode              | 718377777                                                      |
+      | typeDisplay           | Another Test data                                              |
+    When Producer "Data Sync" uses "nrlf-converter" to convert NRL_DOCUMENT_POINTER_WITHOUT_CONTEXT with NHS Number "9693893158" and ASID "230811201350" into a DocumentReference according to the DOCUMENT_REFERENCE_WITHOUT_CONTEXT template
+      | property              | value                                                           |
+      | id                    | 8FW23-16f1ba23-32bc-11ee-87e3-067a0214ca1a-58394e47453659524c33 |
+      | nhsNumber             | 9693893158                                                      |
+      | asid                  | 230811201350                                                    |
+      | attachmentContentType | text/html                                                       |
+      | attachmentCreation    | 2021-03-08T15:26:00+01:00                                       |
+      | attachmentUrl         | ssp://spine-proxy.national.ncrs.nhs.uk/                         |
+      | author                | https://directory.spineservices.nhs.uk/STU3/Organization/RAE    |
+      | classCode             | 734163000                                                       |
+      | classDisplay          | Care plan                                                       |
+      | custodian             | 8FW23                                                           |
+      | indexed               | 2022-08-23T14:45:17+00:00                                       |
+      | lastModified          | Tue, 23 Aug 2022 14:45:17 GMT                                   |
+      | logicalId             | 16f1ba23-32bc-11ee-87e3-067a0214ca1a-58394e47453659524c33       |
+      | typeCode              | 718377777                                                       |
+      | typeDisplay           | Another Test data                                               |
+      | typeSystem            | http://snomed.info/sct                                          |
+    Then the operation is successful
+    When Producer "Data Sync" creates a Document Reference from DOCUMENT_REFERENCE_WITHOUT_CONTEXT template
+    Then the operation is successful
+    And the status is 201
+    And the response is an OperationOutcome according to the OUTCOME template with the below values
+      | property          | value            |
+      | issue_type        | informational    |
+      | issue_level       | information      |
+      | issue_code        | RESOURCE_CREATED |
+      | issue_description | Resource created |
+      | message           | Resource created |
+    And Document Pointer "8FW23-16f1ba23-32bc-11ee-87e3-067a0214ca1a-58394e47453659524c33" exists
+      | property    | value                                                           |
+      | id          | 8FW23-16f1ba23-32bc-11ee-87e3-067a0214ca1a-58394e47453659524c33 |
+      | nhs_number  | 9693893158                                                      |
+      | producer_id | 8FW23                                                           |
+      | type        | http://snomed.info/sct\|718377777                               |
+      | source      | NRLF                                                            |
+      | version     | 1                                                               |
+      | updated_on  | NULL                                                            |
+      | document    | <document>                                                      |
+      | created_on  | <timestamp>                                                     |

--- a/nrlf-dependencies.sh
+++ b/nrlf-dependencies.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+while read dep; do
+    lib="${dep% *}"
+    asdf plugin add ${lib}
+done < .tool-versions
+
+asdf install

--- a/terraform/infrastructure/lambda.tf
+++ b/terraform/infrastructure/lambda.tf
@@ -297,6 +297,7 @@ module "consumer__authoriser_lambda" {
     AUTH_STORE   = aws_s3_bucket.authorization-store.id
   }
   additional_policies = [
+    aws_iam_policy.read-authorization-store-s3.arn,
   ]
   firehose_subscriptions = [
     module.firehose__processor.firehose_subscription

--- a/terraform/infrastructure/locals.tf
+++ b/terraform/infrastructure/locals.tf
@@ -25,8 +25,7 @@ locals {
   dynamodb_timeout_seconds = "3"
   # Logic / vars for splunk environment
   persistent_environments = ["dev", "dev-sandbox", "ref", "ref-sandbox", "int", "int-sandbox", "prod"]
-  #environment_no_hyphen   = replace(local.environment, "-", "")
-  environment_no_hyphen = startswith(local.environment, "int") ? local.environment : replace(local.environment, "-", "")
-  splunk_environment    = contains(local.persistent_environments, local.environment) ? local.environment_no_hyphen : "dev" # dev is the default splunk env
-  splunk_index          = "aws_recordlocator_${local.splunk_environment}"
+  environment_no_hyphen   = replace(local.environment, "-", "")
+  splunk_environment      = contains(local.persistent_environments, local.environment) ? local.environment_no_hyphen : "dev" # dev is the default splunk env
+  splunk_index            = "aws_recordlocator_${local.splunk_environment}"
 }

--- a/terraform/infrastructure/modules/firehose/s3.tf
+++ b/terraform/infrastructure/modules/firehose/s3.tf
@@ -34,6 +34,14 @@ resource "aws_s3_bucket_lifecycle_configuration" "firehose" {
   }
 }
 
+resource "aws_s3_bucket_versioning" "firehose" {
+  bucket = aws_s3_bucket.firehose.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+
 
 resource "aws_iam_policy" "firehose-alert--s3-read" {
   name        = "${var.prefix}--firehose-alert--s3-read"

--- a/terraform/infrastructure/modules/lambda/lambda.tf
+++ b/terraform/infrastructure/modules/lambda/lambda.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_function" "lambda_function" {
   filename         = "${path.module}/../../../../${var.parent_path}/${var.name}/dist/${var.name}.zip"
   source_code_hash = filebase64sha256("${path.module}/../../../../${var.parent_path}/${var.name}/dist/${var.name}.zip")
   timeout          = local.lambda_timeout
-  memory_size      = 128
+  memory_size      = 512
 
   environment {
     variables = merge(var.environment_variables, { "SOURCE" : "${var.prefix}--${replace(var.parent_path, "/", "--")}--${var.name}" })

--- a/terraform/infrastructure/s3__permission_store.tf
+++ b/terraform/infrastructure/s3__permission_store.tf
@@ -33,8 +33,11 @@ resource "aws_s3_bucket_policy" "allow-authorizer-lambda-to-read" {
 data "aws_iam_policy_document" "allow-authorizer-lambda-to-read" {
   statement {
     principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.assume_account}:role/${module.producer__authoriser_lambda.lambda_role_name}"]
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${var.assume_account}:role/${module.producer__authoriser_lambda.lambda_role_name}",
+        "arn:aws:iam::${var.assume_account}:role/${module.consumer__authoriser_lambda.lambda_role_name}"
+      ]
     }
 
     actions = [


### PR DESCRIPTION
These changes are a result of Converter Changes on v0.0.8 and are changed Feature Files for NRLF-642 and NRLF-645:
- Updated Converter version from v0.0.7 to v0.0.8
- Changed R4 Document_Pointer expected values from https to ssp
- Added new Feature Test Scenario to cover Conversion with no SSP
- Added new Feature Test Scenario to cover Conversion of Pointer without optional 'context' block (NRLF-645)