### PR TITLE
Release/2023-08-14

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,6 +82,15 @@ repos:
 
   - repo: local
     hooks:
+      - id: forbid_json_load
+        name: Don't use json.load - use json_load instead
+        entry: json\.load
+        language: pygrep
+        types: [python]
+        exclude: layer/nrlf/nrlf/core/validators.py|layer/psycopg2/.*|mi/.*
+
+  - repo: local
+    hooks:
       - id: create_changelog
         name: Create changelog from changelog files
         entry: changelog/scripts/changelog-pre-commit.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - NRLF-642 - Update converter to v0.0.8 in NRLF repository
 - NRLF-652 - Fix forward: Remove tags from security groups associations
 - NRLF-561 - Fix forward: Fix ASID url
+- NRLF-634 - Fix forward: Fix intermittent deploy contract test
 
 ## 2023-08-03a
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - NRLF-652 - Fix forward: Remove tags from security groups associations
 - NRLF-561 - Fix forward: Fix ASID url
 - NRLF-634 - Fix forward: Fix intermittent deploy contract test
+- NRLF-494 - Fix forward: Revert changes introduced by NRLF-494, due to being too restrictive for converter
 
 ## 2023-08-03a
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2023-08-14
+
+- NRLF-533 - 409 Conflict error not thrown on duplicate supersede request
+- NRLF-585 - Add Live URLs to API Catalogue
+- NRLF-652 - Producer MI - Add infrastructure for dynamodb streams
+- NRLF-561 - Build a an ASID specific document contract
+- NRLF-642 - Update converter to v0.0.8 in NRLF repository
+
 ## 2023-08-03a
 
 - NRLF-491 - Implement int-sandbox splunk environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@
 - NRLF-533 - 409 Conflict error not thrown on duplicate supersede request
 - NRLF-585 - Add Live URLs to API Catalogue
 - NRLF-652 - Producer MI - Add infrastructure for dynamodb streams
-- NRLF-561 - Build a an ASID specific document contract
+- NRLF-561 - Build an ASID specific document contract
+- NRLF-634 - Helper script to create Data Contracts
 - NRLF-642 - Update converter to v0.0.8 in NRLF repository
+- NRLF-652 - Fix forward: Remove tags from security groups associations
+- NRLF-561 - Fix forward: Fix ASID url
 
 ## 2023-08-03a
 

--- a/api/consumer/record-locator/consumer.yaml
+++ b/api/consumer/record-locator/consumer.yaml
@@ -137,8 +137,9 @@ info:
 
     | Environment       | Base URL                                                               |
     | ----------------- | ---------------------------------------------------------------------- |
-    | Sandbox           | `https://sandbox.api.service.nhs.uk/record-locator/consumer/FHIR/R4/`     |
-    | Integration test  | `https://int.api.service.nhs.uk/record-locator/consumer/FHIR/R4/`         |
+    | Sandbox           | `https://sandbox.api.service.nhs.uk/record-locator/consumer/FHIR/R4/`  |
+    | Integration test  | `https://int.api.service.nhs.uk/record-locator/consumer/FHIR/R4/`      |
+    | Production        | `https://api.service.nhs.uk/record-locator/consumer/FHIR/R4/`          |
 
     ### Sandbox testing
 

--- a/api/consumer/swagger.yaml
+++ b/api/consumer/swagger.yaml
@@ -137,8 +137,9 @@ info:
 
     | Environment       | Base URL                                                               |
     | ----------------- | ---------------------------------------------------------------------- |
-    | Sandbox           | `https://sandbox.api.service.nhs.uk/record-locator/consumer/FHIR/R4/`     |
-    | Integration test  | `https://int.api.service.nhs.uk/record-locator/consumer/FHIR/R4/`         |
+    | Sandbox           | `https://sandbox.api.service.nhs.uk/record-locator/consumer/FHIR/R4/`  |
+    | Integration test  | `https://int.api.service.nhs.uk/record-locator/consumer/FHIR/R4/`      |
+    | Production        | `https://api.service.nhs.uk/record-locator/consumer/FHIR/R4/`          |
 
     ### Sandbox testing
 

--- a/api/producer/record-locator/producer.yaml
+++ b/api/producer/record-locator/producer.yaml
@@ -1016,7 +1016,7 @@ components:
             - DocumentReference
         id:
           type: string
-          pattern: "^(?=.{1,64}$)[A-Za-z0-9\\.]+-[A-Za-z0-9]+[A-Za-z0-9\\_\\-]*$"
+          pattern: "[A-Za-z0-9\\-\\.]{1,64}"
           description: The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.
         meta:
           $ref: "#/components/schemas/Meta"

--- a/api/producer/record-locator/producer.yaml
+++ b/api/producer/record-locator/producer.yaml
@@ -127,8 +127,9 @@ info:
 
     | Environment       | Base URL                                                               |
     | ----------------- | ---------------------------------------------------------------------- |
-    | Sandbox           | `https://sandbox.api.service.nhs.uk/record-locator/producer/FHIR/R4/`     |
-    | Integration test  | `https://int.api.service.nhs.uk/record-locator/producer/FHIR/R4/`         |
+    | Sandbox           | `https://sandbox.api.service.nhs.uk/record-locator/producer/FHIR/R4/`  |
+    | Integration test  | `https://int.api.service.nhs.uk/record-locator/producer/FHIR/R4/`      |
+    | Production        | `https://api.service.nhs.uk/record-locator/producer/FHIR/R4/`          |
 
     ### Sandbox testing
 

--- a/api/producer/swagger.yaml
+++ b/api/producer/swagger.yaml
@@ -127,8 +127,9 @@ info:
 
     | Environment       | Base URL                                                               |
     | ----------------- | ---------------------------------------------------------------------- |
-    | Sandbox           | `https://sandbox.api.service.nhs.uk/record-locator/producer/FHIR/R4/`     |
-    | Integration test  | `https://int.api.service.nhs.uk/record-locator/producer/FHIR/R4/`         |
+    | Sandbox           | `https://sandbox.api.service.nhs.uk/record-locator/producer/FHIR/R4/`  |
+    | Integration test  | `https://int.api.service.nhs.uk/record-locator/producer/FHIR/R4/`      |
+    | Production        | `https://api.service.nhs.uk/record-locator/producer/FHIR/R4/`          |
 
     ### Sandbox testing
 

--- a/api/producer/swagger.yaml
+++ b/api/producer/swagger.yaml
@@ -1113,7 +1113,7 @@ components:
             - DocumentReference
         id:
           type: string
-          pattern: "^(?=.{1,64}$)[A-Za-z0-9\\.]+-[A-Za-z0-9]+[A-Za-z0-9\\_\\-]*$"
+          pattern: "[A-Za-z0-9\\-\\.]{1,64}"
           description: The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.
         meta:
           $ref: "#/components/schemas/Meta"

--- a/changelog/2023-08-14.md
+++ b/changelog/2023-08-14.md
@@ -1,5 +1,8 @@
 - NRLF-533 - 409 Conflict error not thrown on duplicate supersede request
 - NRLF-585 - Add Live URLs to API Catalogue
 - NRLF-652 - Producer MI - Add infrastructure for dynamodb streams
-- NRLF-561 - Build a an ASID specific document contract
+- NRLF-561 - Build an ASID specific document contract
+- NRLF-634 - Helper script to create Data Contracts
 - NRLF-642 - Update converter to v0.0.8 in NRLF repository
+- NRLF-652 - Fix forward: Remove tags from security groups associations
+- NRLF-561 - Fix forward: Fix ASID url

--- a/changelog/2023-08-14.md
+++ b/changelog/2023-08-14.md
@@ -6,3 +6,4 @@
 - NRLF-642 - Update converter to v0.0.8 in NRLF repository
 - NRLF-652 - Fix forward: Remove tags from security groups associations
 - NRLF-561 - Fix forward: Fix ASID url
+- NRLF-634 - Fix forward: Fix intermittent deploy contract test

--- a/changelog/2023-08-14.md
+++ b/changelog/2023-08-14.md
@@ -7,3 +7,4 @@
 - NRLF-652 - Fix forward: Remove tags from security groups associations
 - NRLF-561 - Fix forward: Fix ASID url
 - NRLF-634 - Fix forward: Fix intermittent deploy contract test
+- NRLF-494 - Fix forward: Revert changes introduced by NRLF-494, due to being too restrictive for converter

--- a/changelog/2023-08-14.md
+++ b/changelog/2023-08-14.md
@@ -1,0 +1,5 @@
+- NRLF-533 - 409 Conflict error not thrown on duplicate supersede request
+- NRLF-585 - Add Live URLs to API Catalogue
+- NRLF-652 - Producer MI - Add infrastructure for dynamodb streams
+- NRLF-561 - Build a an ASID specific document contract
+- NRLF-642 - Update converter to v0.0.8 in NRLF repository

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,13 @@
 # pytest configuration file
 
+import os
+
 import pytest
+from hypothesis import settings
+
+if os.getenv("RUNNING_IN_CI"):
+    settings.register_profile("ci", deadline=1000)  # max 1 second per test
+    settings.load_profile("ci")
 
 
 def pytest_addoption(parser):

--- a/cron/seed_sandbox/steps.py
+++ b/cron/seed_sandbox/steps.py
@@ -1,4 +1,3 @@
-import json
 from enum import Enum
 from logging import Logger
 from pathlib import Path
@@ -13,6 +12,7 @@ from cron.seed_sandbox.validators import validate_items
 from nrlf.core.dynamodb_types import to_dynamodb_dict
 from nrlf.core.model import DocumentPointer
 from nrlf.core.repository import Repository
+from nrlf.core.validators import json_load
 
 SANDBOX = "sandbox"
 TEMPLATE_PATH_TO_DATA = str(Path(__file__).parent / "data" / "{item_type_name}.json")
@@ -34,7 +34,7 @@ def _seed_step_factory(
     item_type_name = item_type.kebab()
     path_to_data = template_path_to_data.format(item_type_name=item_type_name)
     with open(path_to_data) as f:
-        raw_items = json.load(f)
+        raw_items = json_load(f)
     dynamodb_items = map(
         lambda raw_item: {k: to_dynamodb_dict(v) for k, v in raw_item.items()},
         raw_items,

--- a/data_contracts/deploy_contracts/constants.py
+++ b/data_contracts/deploy_contracts/constants.py
@@ -1,0 +1,27 @@
+import re
+from pathlib import Path
+from types import MappingProxyType
+
+from nrlf.core.constants import DbPrefix
+
+EMPTY_SCHEMA = MappingProxyType({})
+
+GLOBAL = "global"
+
+_PATH_TO_CONTRACTS_ROOT = Path(__file__).parent.parent
+PATHS_TO_CONTRACTS = list(_PATH_TO_CONTRACTS_ROOT.glob("**/*json"))
+PATH_PATTERNS = (
+    re.compile(
+        rf"(?:[a-zA-Z0-9_\-\/]*?){_PATH_TO_CONTRACTS_ROOT}\/{GLOBAL}\/(?P<name>[a-zA-Z0-9_\-]+)\.json$"
+    ),
+    re.compile(
+        rf"(?:[a-zA-Z0-9_\-\/]*?){_PATH_TO_CONTRACTS_ROOT}\/(?P<system>[a-zA-Z0-9_\-\/\.]+?)\/(?P<value>[a-zA-Z0-9_\-]+)\/(?P<name>[a-zA-Z0-9_\-]+)\.json$"
+    ),
+)
+CONTRACT_PK_WILDCARD = DbPrefix.Contract.value
+VERSION_SEPARATOR = "."
+
+HTTP_SUBS = {
+    "http/": "http://",
+    "https/": "https://",
+}

--- a/data_contracts/deploy_contracts/deploy_contracts.py
+++ b/data_contracts/deploy_contracts/deploy_contracts.py
@@ -1,0 +1,247 @@
+from collections import defaultdict
+from datetime import date
+from itertools import chain
+from pathlib import Path
+from string import ascii_lowercase
+from typing import Generator
+
+from fire import Fire
+
+from helpers.aws_session import new_session_from_env
+from nrlf.core.constants import KEY_SEPARATOR
+from nrlf.core.dynamodb_types import DynamoDbStringType
+from nrlf.core.json_schema import validate_json_schema
+from nrlf.core.model import Contract, key
+from nrlf.core.repository import Repository
+from nrlf.core.validators import json_load
+
+from .constants import (
+    CONTRACT_PK_WILDCARD,
+    EMPTY_SCHEMA,
+    PATHS_TO_CONTRACTS,
+    VERSION_SEPARATOR,
+)
+from .errors import BadActiveContract, BadVersionError, DeploymentExceptions
+from .model import ContractGroup
+
+GroupedContracts = dict[ContractGroup, list[Contract]]
+GroupedJsonSchemas = dict[ContractGroup, list[dict]]
+
+
+def _generate_calendar_version(today: date = None) -> str:
+    if today is None:
+        today = date.today()
+    return VERSION_SEPARATOR.join(
+        (f"{today.year:04d}", f"{today.month:02d}", f"{today.day:02d}")
+    )
+
+
+def _json_schema_from_file(path: str) -> dict:
+    with open(path) as f:
+        json_schema = json_load(f)
+    validate_json_schema(json_schema=json_schema, contract_name=path)
+    return json_schema
+
+
+def _get_contracts_from_db(repository: Repository[Contract]) -> list[Contract]:
+    return repository.query_gsi_1(pk=CONTRACT_PK_WILDCARD).items
+
+
+def _group_contracts(contracts: list[Contract]) -> GroupedContracts:
+    """
+    Maps the ContractGroup onto the Contracts from the database,
+    which enables easy comparison with GroupedJsonSchemas from the
+    local paths.
+    """
+    contracts_by_group: GroupedContracts = defaultdict(list[Contract])
+    for contract in contracts:
+        group = ContractGroup.from_contract(contract=contract)
+        contracts_by_group[group].append(contract)
+
+    for contract_group, _contracts in contracts_by_group.items():
+        # Active Contract should always be first
+        active_contract_sk = _contracts[0].sk.__root__
+        if active_contract_sk != contract_group.active_sk:
+            raise BadActiveContract(
+                f"The sort key of the active Contract '{contract_group.dict()}' "
+                "does not match the expected sort key of active Contracts for "
+                f"this group. Expected sort key: '{contract_group.active_sk}', "
+                f"got: '{active_contract_sk}'"
+            )
+
+    return contracts_by_group
+
+
+def _read_latest_json_schemas(paths: list[Path]) -> GroupedJsonSchemas:
+    """
+    Maps the ContractGroup onto the Json Schema for each path,
+    which enables easy comparison with GroupedContracts from the
+    database.
+    """
+    contracts_by_group: GroupedJsonSchemas = defaultdict(list)
+    for path in paths:
+        group = ContractGroup.from_path(path=path)
+        json_schema = _json_schema_from_file(path=path)
+        contracts_by_group[group].append(json_schema)
+    return contracts_by_group
+
+
+def _increment_contract_sk(sk: DynamoDbStringType) -> DynamoDbStringType:
+    prefix, inverse_version, name = sk.__root__.split(KEY_SEPARATOR)
+    incremented_inverse_version = f"{int(inverse_version) + 1}"
+    return DynamoDbStringType(__root__=key(prefix, incremented_inverse_version, name))
+
+
+def _split_core_from_patch_version(version: str):
+    parts = version.split(VERSION_SEPARATOR)
+    n_parts = len(parts)
+    if n_parts in (3, 4):
+        core_version = VERSION_SEPARATOR.join(parts[:3])
+        patch_version = None
+        if n_parts == 4:
+            patch_version = parts[-1]
+        return core_version, patch_version
+    raise BadVersionError(
+        f"Version expected to be in 3 or 4 parts, got '{version}' ({n_parts} parts)"
+    )
+
+
+def _increment_patch_version(patch_version: str):
+    if patch_version is None:
+        return ascii_lowercase[0]
+    if patch_version not in list(ascii_lowercase[:-1]):
+        raise BadVersionError(
+            f"Cannot increment patch version '{patch_version}', it must be one of {ascii_lowercase[:-1]}"
+        )
+    char_index = ascii_lowercase.index(patch_version)
+    return ascii_lowercase[char_index + 1]
+
+
+def _increment_latest_version_on_conflict(
+    contracts: list[Contract], latest_version: str
+) -> str:
+    active_contract = contracts[0] if contracts else None
+    core_latest_version, _ = _split_core_from_patch_version(version=latest_version)
+    if active_contract:
+        core_active_version, patch_active_version = _split_core_from_patch_version(
+            version=active_contract.version.__root__
+        )
+        if core_active_version == core_latest_version:
+            next_patch_version = _increment_patch_version(
+                patch_version=patch_active_version
+            )
+            return VERSION_SEPARATOR.join((core_latest_version, next_patch_version))
+    return latest_version
+
+
+def _increment_versions_of_contracts(contracts: list[Contract]) -> list[Contract]:
+    return [
+        contract.copy(update={"sk": _increment_contract_sk(sk=contract.sk)})
+        for contract in contracts
+    ]
+
+
+def _active_contract_is_latest(contracts: list[Contract], json_schema: dict):
+    active_contract = contracts[0] if contracts else None
+    return active_contract and (active_contract.json_schema.__root__ == json_schema)
+
+
+def _get_contracts_to_deactivate(
+    grouped_db_contracts: GroupedContracts,
+    latest_groups: list[ContractGroup],
+    latest_version: str,
+) -> Generator[Contract, None, None]:
+    """
+    If any ContractGroup from the database is no longer present on disk,
+    then 'deactivate' the ContractGroup by creating a latest version
+    of the Contract with an empty JSON Schema.
+    """
+    for contract_group, contracts in grouped_db_contracts.items():
+        if contract_group in latest_groups:
+            continue
+        if _active_contract_is_latest(contracts=contracts, json_schema=EMPTY_SCHEMA):
+            # i.e. this ContractGroup has already been 'deactivated'
+            continue
+        _latest_version = _increment_latest_version_on_conflict(
+            contracts=contracts, latest_version=latest_version
+        )
+        yield contract_group.to_active_contract(
+            json_schema=EMPTY_SCHEMA, version=_latest_version
+        )
+        yield from _increment_versions_of_contracts(contracts=contracts)
+
+
+def _get_contracts_to_deploy(
+    grouped_db_contracts: GroupedContracts,
+    grouped_latest_json_schemas: GroupedJsonSchemas,
+    latest_version: str,
+) -> Generator[Contract, None, None]:
+    for contract_group, (json_schema,) in grouped_latest_json_schemas.items():
+        contracts = grouped_db_contracts.get(contract_group, [])
+        if _active_contract_is_latest(contracts=contracts, json_schema=json_schema):
+            continue
+        _latest_version = _increment_latest_version_on_conflict(
+            contracts=contracts, latest_version=latest_version
+        )
+        yield contract_group.to_active_contract(
+            json_schema=json_schema, version=_latest_version
+        )
+        yield from _increment_versions_of_contracts(contracts=contracts)
+
+
+def sync_contracts(
+    repository: Repository[Contract],
+    paths_to_json_schemas: str = PATHS_TO_CONTRACTS,
+    today: date = None,
+) -> bool:
+    calendar_version = _generate_calendar_version(today=today)
+    grouped_latest_json_schemas = _read_latest_json_schemas(paths=paths_to_json_schemas)
+
+    db_contracts = _get_contracts_from_db(repository=repository)
+    grouped_db_contracts = _group_contracts(contracts=db_contracts)
+
+    contracts_to_deactivate = _get_contracts_to_deactivate(
+        grouped_db_contracts=grouped_db_contracts,
+        latest_groups=grouped_latest_json_schemas.keys(),
+        latest_version=calendar_version,
+    )
+    contracts_to_deploy = _get_contracts_to_deploy(
+        grouped_db_contracts=grouped_db_contracts,
+        grouped_latest_json_schemas=grouped_latest_json_schemas,
+        latest_version=calendar_version,
+    )
+
+    contracts_to_put = list(chain(contracts_to_deactivate, contracts_to_deploy))
+    if contracts_to_put:
+        repository.upsert_many(items=contracts_to_put)
+    return bool(contracts_to_put)
+
+
+class NothingToDo(Exception):
+    pass
+
+
+def sync(environment: str, workspace: str):
+    environment_prefix = f"nhsd-nrlf--{workspace}--"
+
+    session = new_session_from_env(env=environment)
+    client = session.client("dynamodb")
+    repository = Repository(
+        item_type=Contract, client=client, environment_prefix=environment_prefix
+    )
+
+    if not sync_contracts(repository=repository):
+        raise NothingToDo
+
+
+if __name__ == "__main__":
+    try:
+        Fire(sync)
+    except DeploymentExceptions as err:
+        print(  # noqa: T201
+            "🚨 An Error Occurred 🚨", f"{err.__class__.__name__}: {err}", sep="\n"
+        )
+    except NothingToDo:
+        print("😐 Already synchronised: nothing to do 😐")  # noqa: T201
+    else:
+        print("✅ Data Contracts synchronised successfully ✅")  # noqa: T201

--- a/data_contracts/deploy_contracts/errors.py
+++ b/data_contracts/deploy_contracts/errors.py
@@ -1,0 +1,26 @@
+import botocore.exceptions
+
+
+class BadActiveContract(Exception):
+    pass
+
+
+class BadContractPath(Exception):
+    pass
+
+
+class BadContractGroup(Exception):
+    pass
+
+
+class BadVersionError(Exception):
+    pass
+
+
+DeploymentExceptions = (
+    botocore.exceptions.ClientError,
+    BadActiveContract,
+    BadContractGroup,
+    BadContractPath,
+    BadVersionError,
+)

--- a/data_contracts/deploy_contracts/model.py
+++ b/data_contracts/deploy_contracts/model.py
@@ -1,0 +1,103 @@
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from nrlf.core.constants import DbPrefix
+from nrlf.core.json_schema import DEFAULT_SYSTEM_VALUE
+from nrlf.core.model import Contract, key
+
+from .constants import GLOBAL, HTTP_SUBS, PATH_PATTERNS
+from .errors import BadContractGroup, BadContractPath
+
+
+def _substitute_http_from_system(system: str):
+    for path_system, url_system in HTTP_SUBS.items():
+        if path_system in system:
+            return system.replace(path_system, url_system)
+    return system
+
+
+def _strip_http_from_system(system: str):
+    for path_system, url_system in HTTP_SUBS.items():
+        if url_system in system:
+            return system.replace(url_system, path_system)
+    return system
+
+
+@dataclass
+class ContractGroup:
+    name: str
+    system: str = DEFAULT_SYSTEM_VALUE
+    value: str = DEFAULT_SYSTEM_VALUE
+
+    def __post_init__(self):
+        if (
+            self.system == DEFAULT_SYSTEM_VALUE or self.value == DEFAULT_SYSTEM_VALUE
+        ) and (self.system != self.value):
+            raise BadContractGroup(
+                f"system and value must both be equal to either be '{DEFAULT_SYSTEM_VALUE}' or "
+                f"otherwise neither must be equal to '{DEFAULT_SYSTEM_VALUE}'"
+            )
+
+    @property
+    def pk(self):
+        return key(DbPrefix.Contract, self.system, self.value)
+
+    @property
+    def active_sk(self):
+        return key(DbPrefix.Version, 0, self.name)
+
+    def __hash__(self):
+        return (self.system, self.value, self.name).__hash__()
+
+    def dict(self):
+        return asdict(self)
+
+    @classmethod
+    def from_contract(cls, contract: Contract) -> "ContractGroup":
+        """
+        Constructor method for building a ContractGroup a Contract object.
+        """
+        return cls(
+            system=contract.system.__root__,
+            value=contract.value.__root__,
+            name=contract.name.__root__,
+        )
+
+    def to_active_contract(self, version: str, json_schema: dict) -> Contract:
+        return Contract(
+            pk=self.pk,
+            sk=self.active_sk,
+            version=version,
+            json_schema=json_schema,
+            **self.dict(),
+        )
+
+    @classmethod
+    def from_path(cls, path: str) -> "ContractGroup":
+        """
+        Constructor method for building a ContractGroup from the filepath
+        of a JSON Schema, which must conform to one of PATH_PATTERNS.
+        """
+        for regex in PATH_PATTERNS:
+            match: re.Match = regex.match(str(path))
+            if match:
+                kwargs = match.groupdict()
+                system = kwargs.get("system")
+                if system:
+                    kwargs["system"] = _substitute_http_from_system(system=system)
+                return ContractGroup(**kwargs)
+
+        raise BadContractPath(
+            f"File path '{path}' not one of the expected formats: "
+            + " or ".join(regex.pattern for regex in PATH_PATTERNS)
+        )
+
+    def to_path(self, base_dir: str) -> Path:
+        """The compliment of the class method 'from_path'"""
+        if self.system == DEFAULT_SYSTEM_VALUE and self.value == DEFAULT_SYSTEM_VALUE:
+            base_path = (GLOBAL,)
+        else:
+            system = _strip_http_from_system(self.system)
+            base_path = (system, self.value)
+        return Path(base_dir).joinpath(*base_path, f"{self.name}.json")

--- a/data_contracts/deploy_contracts/tests/test_deploy_contract.py
+++ b/data_contracts/deploy_contracts/tests/test_deploy_contract.py
@@ -9,7 +9,7 @@ from tempfile import TemporaryDirectory
 from unittest import mock
 
 import pytest
-from hypothesis import given
+from hypothesis import assume, given
 from hypothesis.strategies import (
     builds,
     dates,
@@ -129,8 +129,7 @@ def test__substitute_http_from_path(system_in, system_out):
 
 @given(path=one_of(from_regex(regex, fullmatch=True) for regex in PATH_PATTERNS))
 def test__parse_contract_group_from_path_good_path(path: str):
-    while "//" in path:
-        path = path.replace("//", "/")
+    assume("//" not in path)
 
     group: ContractGroup = ContractGroup.from_path(path=path)
     _path = group.to_path(base_dir="")

--- a/data_contracts/deploy_contracts/tests/test_deploy_contract.py
+++ b/data_contracts/deploy_contracts/tests/test_deploy_contract.py
@@ -1,0 +1,982 @@
+import json
+from collections import ChainMap
+from dataclasses import dataclass
+from datetime import date
+from itertools import chain
+from pathlib import Path
+from string import ascii_letters, ascii_lowercase, ascii_uppercase, digits
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+import pytest
+from hypothesis import given
+from hypothesis.strategies import (
+    builds,
+    dates,
+    dictionaries,
+    from_regex,
+    integers,
+    just,
+    lists,
+    one_of,
+    sampled_from,
+    text,
+)
+
+from data_contracts.deploy_contracts.constants import (
+    _PATH_TO_CONTRACTS_ROOT,
+    PATH_PATTERNS,
+    PATHS_TO_CONTRACTS,
+    VERSION_SEPARATOR,
+)
+from data_contracts.deploy_contracts.deploy_contracts import (
+    GroupedContracts,
+    _active_contract_is_latest,
+    _generate_calendar_version,
+    _get_contracts_from_db,
+    _get_contracts_to_deactivate,
+    _get_contracts_to_deploy,
+    _group_contracts,
+    _increment_contract_sk,
+    _increment_latest_version_on_conflict,
+    _increment_patch_version,
+    _increment_versions_of_contracts,
+    _json_schema_from_file,
+    _read_latest_json_schemas,
+    _split_core_from_patch_version,
+    sync_contracts,
+)
+from data_contracts.deploy_contracts.errors import (
+    BadActiveContract,
+    BadContractPath,
+    BadVersionError,
+)
+from data_contracts.deploy_contracts.model import (
+    ContractGroup,
+    _strip_http_from_system,
+    _substitute_http_from_system,
+)
+from feature_tests.common.repository import FeatureTestRepository as Repository
+from feature_tests.common.utils import get_environment_prefix
+from helpers.aws_session import new_aws_session
+from nrlf.core.constants import DbPrefix
+from nrlf.core.dynamodb_types import (
+    DynamoDbStringType,
+    convert_dynamo_value_to_raw_value,
+)
+from nrlf.core.json_schema import DEFAULT_SYSTEM_VALUE
+from nrlf.core.model import Contract, DynamoDbModel, key
+
+MOCK_PATH = "data_contracts.deploy_contracts.deploy_contracts.{}"
+ASCII_TEXT = text(alphabet=ascii_letters + digits, min_size=1)
+PK_REGEX = from_regex(r"C#(\w+)#(\w+)")
+SK_REGEX = from_regex(r"V#(\d+)#(\w+)")
+
+
+def mock_patch(target, *args, **kwargs):
+    return mock.patch(MOCK_PATH.format(target), *args, **kwargs)
+
+
+@given(today=one_of(dates(), just(None)))
+def test__generate_calendar_version(today: date):
+    if today is None:
+        today = date.today()
+    version = _generate_calendar_version(today=today)
+    assert len(version) == 10
+
+    year, month, day = map(int, version.split("."))
+    assert today == date(year=year, month=month, day=day)
+
+
+def test_contracts_exist():
+    """
+    A number of the following tests explicitly require that
+    PATHS_TO_CONTRACTS is not empty - i.e. that there are
+    valid JSON Schemas in this code repository. This test
+    ensures that these exists, and the next test ensures
+    that they are all valid.
+    """
+    assert len(PATHS_TO_CONTRACTS) > 0
+
+
+@pytest.mark.parametrize("path", PATHS_TO_CONTRACTS)
+def test_all_paths_to_contracts_yield_valid_contracts(path: str):
+    """
+    A number of the following tests explicitly require the
+    JSON Schemas defined in PATHS_TO_CONTRACTS are valid,
+    which this test ensures.
+    """
+    _json_schema_from_file(path=path)  # will raise an error on failure
+
+
+@pytest.mark.parametrize("path", PATHS_TO_CONTRACTS)
+def test__parse_contract_group_from_path(path: Path):
+    group = ContractGroup.from_path(path=path)
+    assert group.to_path(base_dir=_PATH_TO_CONTRACTS_ROOT) == path
+
+
+@pytest.mark.parametrize(
+    ("system_in", "system_out"),
+    [
+        ("http/snomed.info/sct", "http://snomed.info/sct"),
+        ("https/snomed.info/sct", "https://snomed.info/sct"),
+    ],
+)
+def test__substitute_http_from_path(system_in, system_out):
+    assert _substitute_http_from_system(system=system_in) == system_out
+    assert _strip_http_from_system(system=system_out) == system_in
+
+
+@given(path=one_of(from_regex(regex, fullmatch=True) for regex in PATH_PATTERNS))
+def test__parse_contract_group_from_path_good_path(path: str):
+    while "//" in path:
+        path = path.replace("//", "/")
+
+    group: ContractGroup = ContractGroup.from_path(path=path)
+    _path = group.to_path(base_dir="")
+    _extra_base_dir = path.replace(str(_path), "")
+    assert str(
+        group.to_path(base_dir=_PATH_TO_CONTRACTS_ROOT / _extra_base_dir)
+    ) == str(_PATH_TO_CONTRACTS_ROOT / path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        (f"{_PATH_TO_CONTRACTS_ROOT}/http/snomed.info/sct/1213123/blah.json"),
+        (f"{_PATH_TO_CONTRACTS_ROOT}/https/snomed.info/sct/1213123/blah.json"),
+    ],
+)
+def test__parse_contract_group_from_path_url(path: str):
+    group: ContractGroup = ContractGroup.from_path(path=path)
+    _path = group.to_path(base_dir="")
+    _extra_base_dir = path.replace(str(_path), "")
+    assert str(
+        group.to_path(base_dir=_PATH_TO_CONTRACTS_ROOT / _extra_base_dir)
+    ) == str(_PATH_TO_CONTRACTS_ROOT / path)
+
+
+@given(path=text())
+def test__parse_contract_group_from_path_bad_path(path: str):
+    with pytest.raises(BadContractPath):
+        ContractGroup.from_path(path=path)
+
+
+global_contract = builds(
+    Contract,
+    pk=PK_REGEX,
+    sk=SK_REGEX,
+    system=just(DEFAULT_SYSTEM_VALUE),
+    value=just(DEFAULT_SYSTEM_VALUE),
+    name=ASCII_TEXT,
+    version=ASCII_TEXT,
+)
+local_contract = builds(
+    Contract,
+    pk=PK_REGEX,
+    sk=SK_REGEX,
+    system=ASCII_TEXT,
+    value=ASCII_TEXT,
+    name=ASCII_TEXT,
+    version=ASCII_TEXT,
+)
+contract_strategy = one_of(global_contract, local_contract)
+
+
+@given(contract=contract_strategy)
+def test__parse_contract_group_from_contract(contract: Contract):
+    group = ContractGroup.from_contract(contract=contract)
+    assert group.system == contract.system.__root__
+    assert group.value == contract.value.__root__
+    assert group.name == contract.name.__root__
+
+
+class DummyModel(DynamoDbModel):
+    pk: DynamoDbStringType
+    sk: DynamoDbStringType
+
+    @classmethod
+    def kebab(cls) -> str:
+        return "document-pointer"
+
+
+def _sort_contracts(contracts: list[Contract]) -> list[Contract]:
+    return sorted(
+        contracts,
+        key=lambda contract: (contract.pk.__root__, contract.sk.__root__),
+    )
+
+
+@pytest.mark.integration  # Query by PK doesn't work in moto, so test has to be integration
+def test__get_contracts_from_db():
+    """
+    Tests that only Contracts, not other objects e.g. 'Dummies' below
+    are not retrieved from the database.
+    """
+    prefix = get_environment_prefix(test_mode=None)
+    session = new_aws_session()
+    client = session.client("dynamodb")
+    contracts = [
+        Contract(
+            pk=f"C#{i}#{i}",
+            sk=f"V#{j}#{j}",
+            name="",
+            version="",
+            json_schema={},
+            system="",
+            value="",
+        )
+        for i in range(5)
+        for j in range(2)
+    ]
+
+    dummies = [
+        DummyModel(
+            pk=f"FOO#{i}#{i}",
+            sk=f"BAR#{j}#{j}",
+        )
+        for i in range(2)
+        for j in range(3)
+    ]
+
+    repository = Repository(
+        item_type=Contract, client=client, environment_prefix=prefix
+    )
+    repository.upsert_many(items=dummies + contracts)
+
+    # Check that only contracts retrieved
+    contracts_from_db = _get_contracts_from_db(repository=repository)
+    assert _sort_contracts(contracts_from_db) == _sort_contracts(contracts)
+
+
+@given(
+    contract_groups=lists(
+        builds(
+            ContractGroup,
+            system=sampled_from(("a", "b")),
+            value=sampled_from(("x", "y")),
+            name=sampled_from(("1", "2")),
+        ),
+    )
+)
+def test__group_contracts(contract_groups: list[ContractGroup]):
+    """
+    Tests that Contracts with the same system/value/name produce
+    the same ContractGroup
+    """
+    unique_groups = set()
+    contracts: list[Contract] = []
+    for group in contract_groups:
+        sk = key(DbPrefix.Version, 1, group.name)
+        if group not in unique_groups:
+            unique_groups.add(group)
+            sk = group.active_sk
+        contracts.append(
+            Contract(
+                pk=group.pk,
+                sk=sk,
+                json_schema={},
+                version="",
+                **group.dict(),
+            )
+        )
+
+    contracts_by_group = _group_contracts(contracts=contracts)
+    if contract_groups:
+        assert len(contracts_by_group) > 0
+    assert contracts_by_group.keys() == unique_groups
+
+    unpacked_grouped_contracts = chain.from_iterable(contracts_by_group.values())
+    assert _sort_contracts(unpacked_grouped_contracts) == _sort_contracts(contracts)
+
+
+@given(group=builds(ContractGroup))
+def test__group_contracts_bad_contracts(group: ContractGroup):
+    """
+    Tests that a list of Contracts can only be grouped
+    if the first Contract is the active Contract (SK starts with V#0)
+    """
+    contracts = [
+        Contract(
+            pk=group.pk,
+            sk=key(DbPrefix.Version, 1, group.name),
+            json_schema={},
+            version="",
+            **group.dict(),
+        )
+    ]
+    with pytest.raises(BadActiveContract):
+        _group_contracts(contracts=contracts)
+
+
+@mock_patch("ContractGroup")
+@mock_patch("_json_schema_from_file")
+@given(group_json_schema_pairs=dictionaries(keys=text(), values=text()))
+def test__read_latest_json_schemas(
+    mocked__json_schema_from_file,
+    mocked_ContractGroup: ContractGroup,
+    group_json_schema_pairs: dict[str, str],
+):
+    """
+    Tests that local JSON Schemas are 'grouped' into a mapping of
+    ContractGroup -> [JSON Schema], where each group is an array of size one
+    """
+    contract_groups_iter = iter(group_json_schema_pairs.keys())
+    json_schemas_iter = iter(group_json_schema_pairs.values())
+
+    mocked__json_schema_from_file.side_effect = lambda *args, **kwargs: next(
+        json_schemas_iter
+    )
+    mocked_ContractGroup.from_path.side_effect = lambda *args, **kwargs: next(
+        contract_groups_iter
+    )
+    n_schemas = len(group_json_schema_pairs)
+    assert _read_latest_json_schemas(paths=range(n_schemas)) == {
+        group: [json_schema] for group, json_schema in group_json_schema_pairs.items()
+    }
+
+
+@given(inverse_version=integers(), name=ASCII_TEXT, prefix=ASCII_TEXT)
+def test__increment_contract_sk(inverse_version: int, name: str, prefix: str):
+    sk_1 = DynamoDbStringType(__root__=f"{prefix}#{inverse_version}#{name}")
+    sk_2 = DynamoDbStringType(__root__=f"{prefix}#{inverse_version+1}#{name}")
+    assert _increment_contract_sk(sk=sk_1) == sk_2
+
+
+def test__increment_patch_version_default():
+    _next_patch_version = _increment_patch_version(patch_version=None)
+    assert _next_patch_version == "a"
+
+
+@pytest.mark.parametrize(
+    ["patch_version", "next_patch_version"],
+    zip(ascii_lowercase[:-1], ascii_lowercase[1:]),
+)
+def test__increment_patch_version_up_to_z(patch_version: str, next_patch_version: str):
+    _next_patch_version = _increment_patch_version(patch_version=patch_version)
+    assert _next_patch_version != patch_version
+    assert _next_patch_version == next_patch_version
+
+
+@pytest.mark.parametrize(
+    "patch_version", ["z", *map(str.upper, ascii_uppercase), *digits]
+)
+def test__increment_patch_version_fails_after_z(patch_version: str):
+    with pytest.raises(BadVersionError):
+        _increment_patch_version(patch_version=patch_version)
+
+
+def test__split_core_from_patch_version_3_parts():
+    version = VERSION_SEPARATOR.join(map(str, range(3)))
+    core_version, patch_version = _split_core_from_patch_version(version=version)
+    assert core_version == "0.1.2"
+    assert patch_version is None
+
+
+def test__split_core_from_patch_version_4_parts():
+    version = VERSION_SEPARATOR.join(map(str, range(4)))
+    core_version, patch_version = _split_core_from_patch_version(version=version)
+    assert core_version == "0.1.2"
+    assert patch_version == "3"
+
+
+@pytest.mark.parametrize("n_parts", (*range(2), *range(5, 10)))
+def test__split_core_from_patch_version_not_3_or_4_parts(n_parts):
+    version = VERSION_SEPARATOR.join(map(str, range(n_parts)))
+    with pytest.raises(BadVersionError):
+        _split_core_from_patch_version(version=version)
+
+
+@given(contract=builds(Contract, version=just("1.2.3.a")))
+def test__increment_version_on_conflict(contract: Contract):
+    _increment_latest_version_on_conflict(
+        contracts=[contract], latest_version="1.2.3.a"
+    ) == "1.2.3.b"
+
+
+@given(contract=builds(Contract, version=just("1.2.3.a")))
+def test__increment_version_on_conflict_no_conflict(contract: Contract):
+    _increment_latest_version_on_conflict(
+        contracts=[contract], latest_version="1.2.3.0"
+    ) == "1.2.3.a"
+
+
+@given(
+    contracts=lists(
+        builds(Contract, sk=from_regex(r"V#{\d+}#{\w+}")),
+        unique_by=lambda contract: contract.sk.__root__,
+    )
+)
+@mock_patch("_increment_contract_sk")
+def test__increment_versions_of_contracts(
+    mocked__increment_contract_sk, contracts: list[Contract]
+):
+    mocked__increment_contract_sk.side_effect = lambda sk: DynamoDbStringType(
+        __root__=sk.__root__ + "foo"
+    )
+
+    expected_contracts = []
+    for contract in contracts:
+        raw_contract = {
+            k: convert_dynamo_value_to_raw_value(v) for k, v in contract.dict().items()
+        }
+
+        raw_contract["sk"] = raw_contract["sk"] + "foo"
+        expected_contracts.append(Contract(**raw_contract))
+
+    assert _increment_versions_of_contracts(contracts=contracts) == expected_contracts
+
+
+@given(
+    contracts=lists(builds(Contract), min_size=1),
+    json_schema=dictionaries(keys=integers(), values=integers(), min_size=1),
+)
+def test__active_contract_is_latest(contracts: list[Contract], json_schema: dict):
+    contracts[0].json_schema.__root__ = json_schema
+    assert _active_contract_is_latest(contracts=contracts, json_schema=json_schema)
+
+
+@given(
+    json_schema=dictionaries(keys=integers(), values=integers(), min_size=1),
+)
+def test__active_contract_is_not_latest_when_empty(json_schema: dict):
+    assert not _active_contract_is_latest(contracts=[], json_schema=json_schema)
+
+
+@given(
+    contracts=lists(builds(Contract), min_size=1),
+    active_json_schema=dictionaries(keys=text(), values=text(), min_size=1),
+    json_schema=dictionaries(keys=integers(), values=integers(), min_size=1),
+)
+def test__active_contract_is_not_latest_when_json_schema_different(
+    contracts: list[Contract], active_json_schema: dict, json_schema: dict
+):
+    contracts[0].json_schema.__root__ = active_json_schema
+    assert not _active_contract_is_latest(contracts=contracts, json_schema=json_schema)
+
+
+def test__get_contracts_to_deactivate():
+    """
+    Test that contracts in grouped_db_contracts will be deactivated
+    if they don't exist in latest_groups
+    """
+    grouped_db_contracts = {
+        ContractGroup(system="snomed", value="123", name="foo"): [
+            Contract(
+                pk="C#snomed#123",
+                sk="V#0#foo",
+                system="snomed",
+                value="123",
+                name="foo",
+                version="0.0.0.3",
+                json_schema={"foo": "FOO3"},
+            ),
+            Contract(
+                pk="C#snomed#123",
+                sk="V#1#foo",
+                system="snomed",
+                value="123",
+                name="foo",
+                version="0.0.0.2",
+                json_schema={"foo": "FOO2"},
+            ),
+            Contract(
+                pk="C#snomed#123",
+                sk="V#2#foo",
+                system="snomed",
+                value="123",
+                name="foo",
+                version="0.0.0.1",
+                json_schema={"foo": "FOO1"},
+            ),
+        ],
+        ContractGroup(system="snomed", value="123", name="bar"): [
+            Contract(
+                pk="C#snomed#123",
+                sk="V#0#bar",
+                system="snomed",
+                value="123",
+                name="bar",
+                version="0.0.0.2",
+                json_schema={"bar": "BAR2"},
+            ),
+            Contract(
+                pk="C#snomed#123",
+                sk="V#1#bar",
+                system="snomed",
+                value="123",
+                name="bar",
+                version="0.0.0.1",
+                json_schema={"bar": "BAR1"},
+            ),
+        ],
+    }
+
+    latest_groups = [ContractGroup(system="snomed", value="123", name="bar")]
+    latest_version = "1.2.3.4"
+
+    contracts_to_deactivate = list(
+        _get_contracts_to_deactivate(
+            grouped_db_contracts=grouped_db_contracts,
+            latest_groups=latest_groups,
+            latest_version=latest_version,
+        )
+    )
+
+    assert contracts_to_deactivate == [
+        Contract(
+            pk="C#snomed#123",
+            sk="V#0#foo",
+            system="snomed",
+            value="123",
+            name="foo",
+            version=latest_version,
+            json_schema={},
+        ),
+        Contract(
+            pk="C#snomed#123",
+            sk="V#1#foo",
+            system="snomed",
+            value="123",
+            name="foo",
+            version="0.0.0.3",
+            json_schema={"foo": "FOO3"},
+        ),
+        Contract(
+            pk="C#snomed#123",
+            sk="V#2#foo",
+            system="snomed",
+            value="123",
+            name="foo",
+            version="0.0.0.2",
+            json_schema={"foo": "FOO2"},
+        ),
+        Contract(
+            pk="C#snomed#123",
+            sk="V#3#foo",
+            system="snomed",
+            value="123",
+            name="foo",
+            version="0.0.0.1",
+            json_schema={"foo": "FOO1"},
+        ),
+    ]
+
+
+def test__get_contracts_to_deploy():
+    """
+    Test that contracts not in grouped_db_contracts will be deployed
+    if they don't exist OR are out of step with those in latest_groups
+    """
+    grouped_db_contracts = {
+        ContractGroup(system="snomed", value="123", name="foo"): [
+            Contract(
+                pk="C#snomed#123",
+                sk="V#0#foo",
+                system="snomed",
+                value="123",
+                name="foo",
+                version="0.0.0.3",
+                json_schema={"foo": "FOO3"},
+            ),
+            Contract(
+                pk="C#snomed#123",
+                sk="V#1#foo",
+                system="snomed",
+                value="123",
+                name="foo",
+                version="0.0.0.2",
+                json_schema={"foo": "FOO2"},
+            ),
+            Contract(
+                pk="C#snomed#123",
+                sk="V#2#foo",
+                system="snomed",
+                value="123",
+                name="foo",
+                version="0.0.0.1",
+                json_schema={"foo": "FOO1"},
+            ),
+        ],
+        ContractGroup(system="snomed", value="123", name="bar"): [
+            Contract(
+                pk="C#snomed#123",
+                sk="V#0#bar",
+                system="snomed",
+                value="123",
+                name="bar",
+                version="0.0.0.2",
+                json_schema={"bar": "BAR2"},
+            ),
+            Contract(
+                pk="C#snomed#123",
+                sk="V#1#bar",
+                system="snomed",
+                value="123",
+                name="bar",
+                version="0.0.0.1",
+                json_schema={"bar": "BAR1"},
+            ),
+        ],
+    }
+
+    grouped_latest_json_schemas = {
+        ContractGroup(system="snomed", value="123", name="bar"): [{"bar": "BAR_X"}],
+        ContractGroup(system="snomed", value="123", name="foo"): [{"foo": "FOO_X"}],
+    }
+
+    latest_version = "1.2.3.4"
+
+    contracts_to_deploy = list(
+        _get_contracts_to_deploy(
+            grouped_db_contracts=grouped_db_contracts,
+            grouped_latest_json_schemas=grouped_latest_json_schemas,
+            latest_version=latest_version,
+        )
+    )
+
+    assert contracts_to_deploy == [
+        Contract(
+            pk="C#snomed#123",
+            sk="V#0#bar",
+            system="snomed",
+            value="123",
+            name="bar",
+            version=latest_version,
+            json_schema={"bar": "BAR_X"},
+        ),
+        Contract(
+            pk="C#snomed#123",
+            sk="V#1#bar",
+            system="snomed",
+            value="123",
+            name="bar",
+            version="0.0.0.2",
+            json_schema={"bar": "BAR2"},
+        ),
+        Contract(
+            pk="C#snomed#123",
+            sk="V#2#bar",
+            system="snomed",
+            value="123",
+            name="bar",
+            version="0.0.0.1",
+            json_schema={"bar": "BAR1"},
+        ),
+        Contract(
+            pk="C#snomed#123",
+            sk="V#0#foo",
+            system="snomed",
+            value="123",
+            name="foo",
+            version=latest_version,
+            json_schema={"foo": "FOO_X"},
+        ),
+        Contract(
+            pk="C#snomed#123",
+            sk="V#1#foo",
+            system="snomed",
+            value="123",
+            name="foo",
+            version="0.0.0.3",
+            json_schema={"foo": "FOO3"},
+        ),
+        Contract(
+            pk="C#snomed#123",
+            sk="V#2#foo",
+            system="snomed",
+            value="123",
+            name="foo",
+            version="0.0.0.2",
+            json_schema={"foo": "FOO2"},
+        ),
+        Contract(
+            pk="C#snomed#123",
+            sk="V#3#foo",
+            system="snomed",
+            value="123",
+            name="foo",
+            version="0.0.0.1",
+            json_schema={"foo": "FOO1"},
+        ),
+    ]
+
+
+@mock_patch("_generate_calendar_version")
+@mock_patch("_read_latest_json_schemas")
+@mock_patch("_get_contracts_from_db")
+@mock_patch("_group_contracts")
+@mock_patch("_get_contracts_to_deactivate", return_value=range(3))
+@mock_patch("_get_contracts_to_deploy", return_value=range(4))
+def test_sync_contracts(
+    _mock_generate, _mock_read, _mock_get, _mock_group, _mock_deactivate, _mock_deploy
+):
+    """
+    Test that 'sync_contracts' will concatenate the outputs of
+    _get_contracts_to_deactivate and _get_contracts_to_deploy
+    and pass them to repository.upsert_many
+    """
+    repository = mock.Mock(spec=Repository)
+
+    @dataclass
+    class Container:
+        items: list[int]
+
+        def upsert_many(self, items):
+            self.items = items
+
+    container = Container(items=None)
+    repository.upsert_many.side_effect = container.upsert_many
+
+    sync_contracts(repository=repository)
+
+    # i.e. the items from the above ranges
+    assert container.items == [0, 1, 2, 0, 1, 2, 3]
+
+
+def _create_contract_group(
+    suffix: str,
+    n_contracts: int,
+    json_schema: dict,
+    local_base_dir: Path = None,
+    local_json_schema: dict = None,
+) -> GroupedContracts:
+    """
+    Create a mapping of ContractGroup to Contracts in the database,
+    optionally creating a local json schema for that contract group
+    """
+    group = ContractGroup(
+        name=f"name_{suffix}", system=f"system_{suffix}", value=f"value_{suffix}"
+    )
+
+    if local_base_dir and local_json_schema:
+        path_to_json_schema_file = group.to_path(base_dir=local_base_dir)
+        path_to_json_schema_file.parent.mkdir(parents=True)
+        with open(file=path_to_json_schema_file, mode="w") as f:
+            f.write(json.dumps(local_json_schema))
+
+    return {
+        group: _sort_contracts(
+            Contract(
+                pk=f"C#{group.system}#{group.value}",
+                sk=f"V#{n_contracts-(i+1)}#{group.name}",
+                version=f"1900.01.{str(i).zfill(2)}",
+                json_schema=json_schema,
+                **group.dict(),
+            )
+            for i in range(n_contracts)
+        )
+    }
+
+
+@pytest.fixture(scope="function")
+def temp_dir() -> Path:
+    """
+    Create a temp directory for mocking data contracts,
+    with the root contract dir '_PATH_TO_CONTRACTS_ROOT' mocked
+    at the base of the temp directory
+    """
+    root_path_parts = filter(lambda x: x != "/", _PATH_TO_CONTRACTS_ROOT.parts)
+    with TemporaryDirectory() as dir:
+        absolute_dir = Path(dir).resolve()
+        _path = absolute_dir.joinpath(*root_path_parts)
+        assert str(_path).startswith(str(absolute_dir))
+
+        _path.mkdir(parents=True)
+        yield _path
+
+
+@pytest.mark.integration
+def test_sync_contracts_e2e(temp_dir):
+    """
+    Tests the behaviour of synchronising a initial state is entirely
+    deterministic. Read the comments for a walkthrough.
+    """
+    session = new_aws_session()
+    client = session.client("dynamodb")
+    environment_prefix = get_environment_prefix(None)
+    repository = Repository(
+        item_type=Contract, client=client, environment_prefix=environment_prefix
+    )
+
+    EMPTY_SCHEMA = {}
+    OLD_SCHEMA = {"name": "old schema"}
+    NEW_SCHEMA = {"name": "new schema"}
+
+    # Create a contract group without a local counterpart - to be deactivated by the sync
+    contracts_to_be_deactivated = _create_contract_group(
+        suffix="to_deactivate",
+        n_contracts=3,
+        json_schema=OLD_SCHEMA,
+    )
+
+    # Create a contract group without a local counterpart - which are already deactivated so to be skipped by the sync
+    contracts_already_deactivated = _create_contract_group(
+        suffix="already_deactivated",
+        n_contracts=2,
+        json_schema=EMPTY_SCHEMA,
+    )
+
+    # Create a contract group with a local counterpart - to be superseded by the sync
+    contracts_to_be_superseded = _create_contract_group(
+        suffix="to_supersede",
+        n_contracts=5,
+        json_schema=OLD_SCHEMA,
+        local_base_dir=temp_dir,
+        local_json_schema=NEW_SCHEMA,
+    )
+
+    # Create a contract group with a local counterpart - to be superseded by the sync
+    contracts_to_be_skipped = _create_contract_group(
+        suffix="to_skip",
+        n_contracts=3,
+        json_schema=OLD_SCHEMA,
+        local_base_dir=temp_dir,
+        local_json_schema=OLD_SCHEMA,
+    )
+
+    # Create a contract group without a db counterpart - to be created by the sync
+    contracts_to_be_created = _create_contract_group(
+        suffix="to_create",
+        n_contracts=0,
+        json_schema=None,
+        local_base_dir=temp_dir,
+        local_json_schema=NEW_SCHEMA,
+    )
+
+    initial_input_contracts = list(
+        chain.from_iterable(
+            ChainMap(
+                contracts_to_be_deactivated,
+                contracts_already_deactivated,
+                contracts_to_be_superseded,
+                contracts_to_be_skipped,
+            ).values()
+        )
+    )
+
+    repository.upsert_many(
+        items=initial_input_contracts
+    )  # Create items that should already exist
+
+    # Verify the initial state
+    initial_db_contracts = _get_contracts_from_db(repository=repository)
+    assert _sort_contracts(initial_input_contracts) == _sort_contracts(
+        initial_db_contracts
+    )
+
+    # Deploy the contracts
+    today = date(year=2000, month=1, day=1)
+    paths = list(Path(temp_dir).glob("**/*json"))
+    result = sync_contracts(
+        repository=repository, today=today, paths_to_json_schemas=paths
+    )
+    assert result is True
+
+    # Verify the state
+    synced_db_contracts = _get_contracts_from_db(repository=repository)
+    assert initial_db_contracts != synced_db_contracts  # i.e. an update has taken place
+    assert (
+        len(synced_db_contracts) == len(initial_db_contracts) + 3
+    )  # to_be_deactivated, to_be_superseded, to_be_created
+
+    # Get the groups that haven't changed
+    grouped_initial_contracts = _group_contracts(contracts=initial_db_contracts)
+    grouped_synced_contracts = _group_contracts(contracts=synced_db_contracts)
+
+    grouped_unchanged_contracts: GroupedContracts = {}
+    grouped_changed_contracts: GroupedContracts = {}
+    for group, _contracts in grouped_synced_contracts.items():
+        if _contracts == grouped_initial_contracts[group]:
+            grouped_unchanged_contracts[group] = _sort_contracts(_contracts)
+        else:
+            grouped_changed_contracts[group] = _sort_contracts(_contracts)
+
+    expected_grouped_unchanged_contracts = ChainMap(
+        contracts_already_deactivated,
+        contracts_to_be_skipped,
+    )
+    assert grouped_unchanged_contracts == expected_grouped_unchanged_contracts
+
+    assert grouped_changed_contracts[
+        ContractGroup(
+            name="name_to_deactivate",
+            system="system_to_deactivate",
+            value="value_to_deactivate",
+        )
+    ][0] == Contract(
+        pk=f"C#system_to_deactivate#value_to_deactivate",
+        sk=f"V#0#name_to_deactivate",
+        name="name_to_deactivate",
+        system="system_to_deactivate",
+        value="value_to_deactivate",
+        version="2000.01.01",
+        json_schema=EMPTY_SCHEMA,
+    )
+
+    assert grouped_changed_contracts[
+        ContractGroup(
+            name="name_to_supersede",
+            system="system_to_supersede",
+            value="value_to_supersede",
+        )
+    ][0] == Contract(
+        pk=f"C#system_to_supersede#value_to_supersede",
+        sk=f"V#0#name_to_supersede",
+        name="name_to_supersede",
+        system="system_to_supersede",
+        value="value_to_supersede",
+        version="2000.01.01",
+        json_schema=NEW_SCHEMA,
+    )
+
+    assert grouped_changed_contracts[
+        ContractGroup(
+            name="name_to_create",
+            system="system_to_create",
+            value="value_to_create",
+        )
+    ][0] == Contract(
+        pk=f"C#system_to_create#value_to_create",
+        sk=f"V#0#name_to_create",
+        name="name_to_create",
+        system="system_to_create",
+        value="value_to_create",
+        version="2000.01.01",
+        json_schema=NEW_SCHEMA,
+    )
+
+    # Verify nothing done after initial
+    result = sync_contracts(
+        repository=repository, today=today, paths_to_json_schemas=paths
+    )
+    assert result is False
+
+    repository.delete_all()
+
+
+@pytest.mark.integration
+def test_sync_actual_contracts_e2e():
+    """Test that all of the contracts are synced even when they are symlinks"""
+    session = new_aws_session()
+    client = session.client("dynamodb")
+    environment_prefix = get_environment_prefix(None)
+    repository = Repository(
+        item_type=Contract, client=client, environment_prefix=environment_prefix
+    )
+
+    # Verify the initial state
+    initial_db_contracts = _get_contracts_from_db(repository=repository)
+    assert initial_db_contracts == []
+
+    # Deploy the contracts
+    today = date(year=2000, month=1, day=1)
+    result = sync_contracts(repository=repository, today=today)
+    assert result is True
+
+    # Verify the contracts have been deployed
+    synced_db_contracts = _get_contracts_from_db(repository=repository)
+    assert initial_db_contracts != synced_db_contracts  # i.e. an update has taken place
+    assert len(synced_db_contracts) == len(PATHS_TO_CONTRACTS)
+
+    repository.delete_all()

--- a/data_contracts/global/test-name.json
+++ b/data_contracts/global/test-name.json
@@ -1,0 +1,1 @@
+{ "name": "global-test" }

--- a/data_contracts/http/snomed.info/sct/000/test-name.json
+++ b/data_contracts/http/snomed.info/sct/000/test-name.json
@@ -1,0 +1,1 @@
+{ "name": "local-test" }

--- a/data_contracts/http/snomed.info/sct/1382601000000107/asidcheck-contract.json
+++ b/data_contracts/http/snomed.info/sct/1382601000000107/asidcheck-contract.json
@@ -1,0 +1,1 @@
+../736253002/asidcheck-contract.json

--- a/data_contracts/http/snomed.info/sct/325691000000100/asidcheck-contract.json
+++ b/data_contracts/http/snomed.info/sct/325691000000100/asidcheck-contract.json
@@ -1,0 +1,1 @@
+../736253002/asidcheck-contract.json

--- a/data_contracts/http/snomed.info/sct/736253002/asidcheck-contract.json
+++ b/data_contracts/http/snomed.info/sct/736253002/asidcheck-contract.json
@@ -1,0 +1,59 @@
+{
+  "anyOf": [
+    { "$ref": "#/schemas/has-no-ssp-content" },
+    { "$ref": "#/schemas/has-asid-author" }
+  ],
+  "schemas": {
+    "has-no-ssp-content": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "attachment": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "pattern": "^(?!ssp://).+"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "has-asid-author": {
+      "type": "object",
+      "properties": {
+        "author": {
+          "type": "array",
+          "contains": {
+            "type": "object",
+            "properties": {
+              "identifier": {
+                "type": "object",
+                "properties": {
+                  "system": {
+                    "type": "string",
+                    "enum": ["https://fhir.nhs.uk/Id/accredited-system-id"]
+                  },
+                  "value": {
+                    "type": "string",
+                    "pattern": "^\\d{12}$"
+                  }
+                },
+                "required": ["system", "value"]
+              }
+            },
+            "required": ["identifier"]
+          }
+        }
+      },
+      "required": ["author"]
+    }
+  }
+}

--- a/data_contracts/http/snomed.info/sct/736253002/asidcheck-contract.json
+++ b/data_contracts/http/snomed.info/sct/736253002/asidcheck-contract.json
@@ -39,7 +39,7 @@
                 "properties": {
                   "system": {
                     "type": "string",
-                    "enum": ["https://fhir.nhs.uk/Id/accredited-system-id"]
+                    "enum": ["https://fhir.nhs.uk/Id/nhsSpineASID"]
                   },
                   "value": {
                     "type": "string",

--- a/data_contracts/http/snomed.info/sct/736373009/asidcheck-contract.json
+++ b/data_contracts/http/snomed.info/sct/736373009/asidcheck-contract.json
@@ -1,0 +1,1 @@
+../736253002/asidcheck-contract.json

--- a/data_contracts/http/snomed.info/sct/861421000000109/asidcheck-contract.json
+++ b/data_contracts/http/snomed.info/sct/861421000000109/asidcheck-contract.json
@@ -1,0 +1,1 @@
+../736253002/asidcheck-contract.json

--- a/data_contracts/http/snomed.info/sct/887701000000100/asidcheck-contract.json
+++ b/data_contracts/http/snomed.info/sct/887701000000100/asidcheck-contract.json
@@ -1,0 +1,1 @@
+../736253002/asidcheck-contract.json

--- a/feature_tests/features/producer/producer-createDocumentPointer-failure.feature
+++ b/feature_tests/features/producer/producer-createDocumentPointer-failure.feature
@@ -437,12 +437,12 @@ Feature: Producer Create Failure Scenarios
     Then the operation is unsuccessful
     And the status is 400
     And the response is an OperationOutcome according to the OUTCOME template with the below values
-      | property          | value                                                   |
-      | issue_type        | processing                                              |
-      | issue_level       | error                                                   |
-      | issue_code        | VALIDATION_ERROR                                        |
-      | issue_description | A parameter or value has resulted in a validation error |
-      | message           | DocumentReference validation failure - Invalid id       |
+      | property          | value                                                     |
+      | issue_type        | processing                                                |
+      | issue_level       | error                                                     |
+      | issue_code        | VALIDATION_ERROR                                          |
+      | issue_description | A parameter or value has resulted in a validation error   |
+      | message           | Input is not composite of the form a-b: 8FW23\|1234567890 |
 
   Scenario: Unable to create a Document Pointer when custodian does not match
     Given Producer "Aaron Court Mental Health NH" (Organisation ID "8FW23") is requesting to create Document Pointers
@@ -506,12 +506,12 @@ Feature: Producer Create Failure Scenarios
     Then the operation is unsuccessful
     And the status is 400
     And the response is an OperationOutcome according to the OUTCOME template with the below values
-      | property          | value                                                   |
-      | issue_type        | processing                                              |
-      | issue_level       | error                                                   |
-      | issue_code        | VALIDATION_ERROR                                        |
-      | issue_description | A parameter or value has resulted in a validation error |
-      | message           | DocumentReference validation failure - Invalid id       |
+      | property          | value                                                      |
+      | issue_type        | processing                                                 |
+      | issue_level       | error                                                      |
+      | issue_code        | VALIDATION_ERROR                                           |
+      | issue_description | A parameter or value has resulted in a validation error    |
+      | message           | Provided custodian identifier system is not the ODS system |
 
   Scenario: Unable to create a Document Pointer when the producer is not the custodian
     Given Producer "BaRS (EMIS)" (Organisation ID "V4T0L.YGMMC") is requesting to create Document Pointers
@@ -619,56 +619,6 @@ Feature: Producer Create Failure Scenarios
       | issue_code        | VALIDATION_ERROR                                        |
       | issue_description | A parameter or value has resulted in a validation error |
       | message           | Empty value '' at 'date' is not valid FHIR              |
-
-  Scenario: Document created with an ID which includes special characters fails
-    Given Producer "Aaron Court Mental Health NH" (Organisation ID "8FW23") is requesting to create Document Pointers
-    And Producer "Aaron Court Mental Health NH" is registered in the system for application "DataShare" (ID "z00z-y11y-x22x") with pointer types
-      | system                 | value     |
-      | http://snomed.info/sct | 736253002 |
-    When Producer "Aaron Court Mental Health NH" creates a Document Reference from DOCUMENT template
-      | property    | value                             |
-      | identifier  | ####                              |
-      | type        | 736253002                         |
-      | custodian   | 8FW23                             |
-      | producer_id | 8FW23                             |
-      | subject     | 9278693472                        |
-      | contentType | application/pdf                   |
-      | url         | https://example.org/my-doc.pdf    |
-      | system      | https://fhir.nhs.uk/Id/nhs-number |
-    Then the operation is unsuccessful
-    And the status is 400
-    And the response is an OperationOutcome according to the OUTCOME template with the below values
-      | property          | value                                                   |
-      | issue_type        | processing                                              |
-      | issue_level       | error                                                   |
-      | issue_code        | VALIDATION_ERROR                                        |
-      | issue_description | A parameter or value has resulted in a validation error |
-      | message           | DocumentReference validation failure - Invalid id       |
-
-  Scenario: Document created with no identifier fails
-    Given Producer "Aaron Court Mental Health NH" (Organisation ID "8FW23") is requesting to create Document Pointers
-    And Producer "Aaron Court Mental Health NH" is registered in the system for application "DataShare" (ID "z00z-y11y-x22x") with pointer types
-      | system                 | value     |
-      | http://snomed.info/sct | 736253002 |
-    When Producer "Aaron Court Mental Health NH" creates a Document Reference from DOCUMENT template
-      | property    | value                             |
-      | identifier  |                                   |
-      | type        | 736253002                         |
-      | custodian   | 8FW23                             |
-      | producer_id | 8FW23                             |
-      | subject     | 9278693472                        |
-      | contentType | application/pdf                   |
-      | url         | https://example.org/my-doc.pdf    |
-      | system      | https://fhir.nhs.uk/Id/nhs-number |
-    Then the operation is unsuccessful
-    And the status is 400
-    And the response is an OperationOutcome according to the OUTCOME template with the below values
-      | property          | value                                                   |
-      | issue_type        | processing                                              |
-      | issue_level       | error                                                   |
-      | issue_code        | VALIDATION_ERROR                                        |
-      | issue_description | A parameter or value has resulted in a validation error |
-      | message           | DocumentReference validation failure - Invalid id       |
 
   @integration-only
   Scenario: Fail to validate a Document Pointer of type TEST_TYPE with bad URL

--- a/feature_tests/features/producer/producer-createDocumentPointer-success.feature
+++ b/feature_tests/features/producer/producer-createDocumentPointer-success.feature
@@ -110,7 +110,7 @@ Feature: Producer Create Success scenarios
         "author": [
           {
             "identifier": {
-              "system": "https://fhir.nhs.uk/Id/accredited-system-id",
+              "system": "https://fhir.nhs.uk/Id/nhsSpineASID",
               "value": "200000000610"
             }
           },

--- a/feature_tests/features/producer/producer-nrlToR4Conversion-fullRecord.success.feature
+++ b/feature_tests/features/producer/producer-nrlToR4Conversion-fullRecord.success.feature
@@ -1,7 +1,7 @@
 Feature: Producer Create NRL-to-R4 Conversion
 
   Background:
-    Given version "0.0.7" of "nrlf-converter" has been installed
+    Given version "0.0.8" of "nrlf-converter" has been installed
     And template NRL_DOCUMENT_POINTER
       """
       {
@@ -23,8 +23,8 @@ Feature: Producer Create NRL-to-R4 Conversion
                       "system": "http://snomed.info/sct",
                       "code": "$classCode",
                       "display": "$classDisplay",
-                      "userSelected": true,
-                      "version": "$classVersion"
+                      "version": "$classVersion",
+                      "userSelected": true
                   }
               ]
           },
@@ -291,32 +291,32 @@ Feature: Producer Create NRL-to-R4 Conversion
       | typeCode               | 718377777                                                                            |
       | typeDisplay            | Another Test data                                                                    |
     When Producer "Data Sync" uses "nrlf-converter" to convert NRL_DOCUMENT_POINTER with NHS Number "9278693472" and ASID "230811201350" into a DocumentReference according to the DOCUMENT_REFERENCE template
-      | property               | value                                                                                |
-      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
-      | nhsNumber              | 9278693472                                                                           |
-      | asid                   | 230811201350                                                                         |
-      | attachmentContentType  | application/pdf                                                                      |
-      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                            |
-      | attachmentUrl          | https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
-      | attachmentHash         | 2jmj7l5rSw0yVb/vlWAYkK/YBwk=                                                         |
-      | attachmentLanguage     | en-US                                                                                |
-      | attachmentTitle        | Mental health Crisis Plan Report                                                     |
-      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                         |
-      | classCode              | 734163000                                                                            |
-      | classDisplay           | Care plan                                                                            |
-      | classVersion           | 1                                                                                    |
-      | userSelected           | True                                                                                 |
-      | custodian              | 8FW23                                                                                |
-      | indexed                | 2022-08-23T14:45:17+00:00                                                            |
-      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                        |
-      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                            |
-      | periodStart            | 2023-01-01T20:01:44Z                                                                 |
-      | periodEnd              | 2023-11-12T20:01:44Z                                                                 |
-      | practiceSettingCode    | 310167005                                                                            |
-      | practiceSettingDisplay | Urology service                                                                      |
-      | typeCode               | 718377777                                                                            |
-      | typeDisplay            | Another Test data                                                                    |
-      | typeSystem             | http://snomed.info/sct                                                               |
+      | property               | value                                                                              |
+      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
+      | nhsNumber              | 9278693472                                                                         |
+      | asid                   | 230811201350                                                                       |
+      | attachmentContentType  | application/pdf                                                                    |
+      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                          |
+      | attachmentUrl          | ssp://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
+      | attachmentHash         | 2jmj7l5rSw0yVb/vlWAYkK/YBwk=                                                       |
+      | attachmentLanguage     | en-US                                                                              |
+      | attachmentTitle        | Mental health Crisis Plan Report                                                   |
+      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                       |
+      | classCode              | 734163000                                                                          |
+      | classDisplay           | Care plan                                                                          |
+      | classVersion           | 1                                                                                  |
+      | userSelected           | True                                                                               |
+      | custodian              | 8FW23                                                                              |
+      | indexed                | 2022-08-23T14:45:17+00:00                                                          |
+      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                      |
+      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                          |
+      | periodStart            | 2023-01-01T20:01:44Z                                                               |
+      | periodEnd              | 2023-11-12T20:01:44Z                                                               |
+      | practiceSettingCode    | 310167005                                                                          |
+      | practiceSettingDisplay | Urology service                                                                    |
+      | typeCode               | 718377777                                                                          |
+      | typeDisplay            | Another Test data                                                                  |
+      | typeSystem             | http://snomed.info/sct                                                             |
     Then the operation is successful
     When Producer "Data Sync" creates a Document Reference from DOCUMENT_REFERENCE template
     Then the operation is successful
@@ -346,32 +346,32 @@ Feature: Producer Create NRL-to-R4 Conversion
       | system                 | value     |
       | http://snomed.info/sct | 718377777 |
     And a Document Pointer exists in the system with the below values for DOCUMENT_REFERENCE template
-      | property               | value                                                                                |
-      | id                     | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
-      | nhsNumber              | 9278693472                                                                           |
-      | attachmentContentType  | application/pdf                                                                      |
-      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                            |
-      | attachmentUrl          | https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
-      | attachmentHash         | 2jmj7l5rSw0yVb/vlWAYkK/YBwk=                                                         |
-      | attachmentLanguage     | en-US                                                                                |
-      | attachmentTitle        | Mental health Crisis Plan Report                                                     |
-      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                         |
-      | classCode              | 734163000                                                                            |
-      | classDisplay           | Care plan                                                                            |
-      | classVersion           | 1                                                                                    |
-      | custodian              | 8FW23                                                                                |
-      | indexed                | 2022-08-23T14:45:17+00:00                                                            |
-      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                        |
-      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                            |
-      | masterIdentifierSystem | urn:ietf:rfc:395                                                                     |
-      | masterIdentifierValue  | urn:oid:1.3.6.1.4.1.21367.2005.47481.7                                               |
-      | periodStart            | 2023-01-01T20:01:44Z                                                                 |
-      | periodEnd              | 2023-11-12T20:01:44Z                                                                 |
-      | practiceSettingCode    | 310167005                                                                            |
-      | practiceSettingDisplay | Urology service                                                                      |
-      | typeCode               | 718377777                                                                            |
-      | typeDisplay            | Another Test data                                                                    |
-      | typeSystem             | http://snomed.info/sct                                                               |
+      | property               | value                                                                              |
+      | id                     | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
+      | nhsNumber              | 9278693472                                                                         |
+      | attachmentContentType  | application/pdf                                                                    |
+      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                          |
+      | attachmentUrl          | ssp://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
+      | attachmentHash         | 2jmj7l5rSw0yVb/vlWAYkK/YBwk=                                                       |
+      | attachmentLanguage     | en-US                                                                              |
+      | attachmentTitle        | Mental health Crisis Plan Report                                                   |
+      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                       |
+      | classCode              | 734163000                                                                          |
+      | classDisplay           | Care plan                                                                          |
+      | classVersion           | 1                                                                                  |
+      | custodian              | 8FW23                                                                              |
+      | indexed                | 2022-08-23T14:45:17+00:00                                                          |
+      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                      |
+      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                          |
+      | masterIdentifierSystem | urn:ietf:rfc:395                                                                   |
+      | masterIdentifierValue  | urn:oid:1.3.6.1.4.1.21367.2005.47481.7                                             |
+      | periodStart            | 2023-01-01T20:01:44Z                                                               |
+      | periodEnd              | 2023-11-12T20:01:44Z                                                               |
+      | practiceSettingCode    | 310167005                                                                          |
+      | practiceSettingDisplay | Urology service                                                                    |
+      | typeCode               | 718377777                                                                          |
+      | typeDisplay            | Another Test data                                                                  |
+      | typeSystem             | http://snomed.info/sct                                                             |
     And Producer "Data Sync" has an NRL Document Pointer from NRL_DOCUMENT_POINTER template
       | property               | value                                                                                                              |
       | attachmentContentType  | application/pdf                                                                                                    |
@@ -399,32 +399,32 @@ Feature: Producer Create NRL-to-R4 Conversion
       | typeCode               | 718377777                                                                                                          |
       | typeDisplay            | Another Test data                                                                                                  |
     When Producer "Data Sync" uses "nrl-to-r4" to convert NRL_DOCUMENT_POINTER with NHS Number "9278693472" and ASID "230811201350" into a DocumentReference according to the DOCUMENT_REFERENCE template
-      | property               | value                                                                                |
-      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
-      | nhsNumber              | 9278693472                                                                           |
-      | asid                   | 230811201350                                                                         |
-      | attachmentContentType  | application/pdf                                                                      |
-      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                            |
-      | attachmentUrl          | https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
-      | attachmentHash         | 2jmj7l5rSw0yVb/vlWAYkK/YBwk=                                                         |
-      | attachmentLanguage     | en-US                                                                                |
-      | attachmentTitle        | Mental health Crisis Plan Report                                                     |
-      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                         |
-      | classCode              | 734163000                                                                            |
-      | classDisplay           | Care plan                                                                            |
-      | classVersion           | 1                                                                                    |
-      | custodian              | 8FW23                                                                                |
-      | indexed                | 2022-08-23T14:45:17+00:00                                                            |
-      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                        |
-      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                            |
-      | periodStart            | 2023-01-01T20:01:44Z                                                                 |
-      | periodEnd              | 2023-11-12T20:01:44Z                                                                 |
-      | practiceSettingCode    | 310167005                                                                            |
-      | practiceSettingDisplay | Urology service                                                                      |
-      | typeCode               | 718377777                                                                            |
-      | typeDisplay            | Another Test data                                                                    |
-      | typeSystem             | http://snomed.info/sct                                                               |
-      | target                 | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
+      | property               | value                                                                              |
+      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
+      | nhsNumber              | 9278693472                                                                         |
+      | asid                   | 230811201350                                                                       |
+      | attachmentContentType  | application/pdf                                                                    |
+      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                          |
+      | attachmentUrl          | ssp://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
+      | attachmentHash         | 2jmj7l5rSw0yVb/vlWAYkK/YBwk=                                                       |
+      | attachmentLanguage     | en-US                                                                              |
+      | attachmentTitle        | Mental health Crisis Plan Report                                                   |
+      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                       |
+      | classCode              | 734163000                                                                          |
+      | classDisplay           | Care plan                                                                          |
+      | classVersion           | 1                                                                                  |
+      | custodian              | 8FW23                                                                              |
+      | indexed                | 2022-08-23T14:45:17+00:00                                                          |
+      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                      |
+      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                          |
+      | periodStart            | 2023-01-01T20:01:44Z                                                               |
+      | periodEnd              | 2023-11-12T20:01:44Z                                                               |
+      | practiceSettingCode    | 310167005                                                                          |
+      | practiceSettingDisplay | Urology service                                                                    |
+      | typeCode               | 718377777                                                                          |
+      | typeDisplay            | Another Test data                                                                  |
+      | typeSystem             | http://snomed.info/sct                                                             |
+      | target                 | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
     Then the operation is successful
     When Producer "Data Sync" creates a Document Reference from DOCUMENT_REFERENCE template
     Then the operation is successful

--- a/feature_tests/features/producer/producer-nrlToR4Conversion.failure.feature
+++ b/feature_tests/features/producer/producer-nrlToR4Conversion.failure.feature
@@ -1,7 +1,7 @@
 Feature: Producer NRL-to-R4 Conversion Failures
 
   Background:
-    Given version "0.0.7" of "nrlf-converter" has been installed
+    Given version "0.0.8" of "nrlf-converter" has been installed
     And template NRL_DOCUMENT_POINTER
       """
       {

--- a/feature_tests/features/producer/producer-nrlToR4Conversion.success.feature
+++ b/feature_tests/features/producer/producer-nrlToR4Conversion.success.feature
@@ -1,7 +1,7 @@
 Feature: Producer Create NRL-to-R4 Conversion
 
   Background:
-    Given version "0.0.7" of "nrlf-converter" has been installed
+    Given version "0.0.8" of "nrlf-converter" has been installed
     And template NRL_DOCUMENT_POINTER
       """
       {
@@ -47,6 +47,87 @@ Feature: Producer Create NRL-to-R4 Conversion
                   ]
               }
           },
+          "custodian": {
+              "reference": "$custodian"
+          },
+          "format": {
+              "code": "urn:nhs-ic:unstructured",
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/NRL-FormatCode-1",
+              "display": "Unstructured Document"
+          },
+          "indexed": "$indexed",
+          "lastModified": "$lastModified",
+          "logicalIdentifier": {
+              "logicalId": "$logicalId"
+          },
+          "meta": {
+              "versionId": "1",
+              "profile": [
+                  "https://fhir.nhs.uk/STU3/StructureDefinition/NRL-DocumentReference-1"
+              ],
+              "lastUpdated": "Tue, 23 Aug 2022 14:45:17 GMT"
+          },
+          "relatesTo": {
+              "code": "$relatesToCode",
+              "target": {
+                  "reference": "$relatesToTarget",
+                  "identifier": {
+                      "value": "$relatesToIdentifier",
+                      "system": "$relatesToSystem"
+                  }
+              }
+          },
+          "removed": false,
+          "stability": {
+              "coding": [
+                  {
+                      "code": "dynamic",
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/NRL-ContentStability-1",
+                      "display": "Dynamic"
+                  }
+              ]
+          },
+          "status": "current",
+          "type": {
+              "code": "$typeCode",
+              "display": "$typeDisplay"
+          }
+      }
+      """
+    And template NRL_DOCUMENT_POINTER_WITHOUT_CONTEXT
+      """
+      {
+          "attachment": {
+              "url": "https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf",
+              "creation": "2021-03-08T15:26:00+01:00",
+              "contentType": "application/pdf"
+          },
+          "author": {
+              "reference": "https://directory.spineservices.nhs.uk/STU3/Organization/RAE"
+          },
+          "class": {
+              "coding": [
+                  {
+                      "system": "http://snomed.info/sct",
+                      "code": "$classCode",
+                      "display": "$classDisplay"
+                  }
+              ]
+          },
+          "content": [
+              {
+                  "attachment": {
+                      "url": "$attachmentUrl",
+                      "contentType": "$attachmentContentType",
+                      "creation": "$attachmentCreation"
+                  },
+                  "format": {
+                      "code": "urn:nhs-ic:unstructured",
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/NRL-FormatCode-1",
+                      "display": "Unstructured Document"
+                  }
+              }
+          ],
           "custodian": {
               "reference": "$custodian"
           },
@@ -152,8 +233,8 @@ Feature: Producer Create NRL-to-R4 Conversion
                   },
                   "format": {
                       "code": "urn:nhs-ic:unstructured",
-                      "display": "Unstructured Document",
-                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/NRL-FormatCode-1"
+                "display": "Unstructured Document",
+                "system": "https://fhir.nhs.uk/STU3/CodeSystem/NRL-FormatCode-1"
                   }
               }
           ],
@@ -168,6 +249,82 @@ Feature: Producer Create NRL-to-R4 Conversion
                   ]
               }
           },
+          "resourceType": "DocumentReference",
+          "relatesTo": [
+              {
+                  "code": "replaces",
+                  "target": {
+                      "identifier": {
+                          "value": "$target"
+                      }
+                  }
+              }
+          ]
+      }
+      """
+    And template DOCUMENT_REFERENCE_WITHOUT_CONTEXT
+      """
+      {
+          "id": "$id",
+          "status": "current",
+          "type": {
+              "coding": [
+                  {
+                      "code": "$typeCode",
+                      "display": "$typeDisplay",
+                      "system": "$typeSystem"
+                  }
+              ]
+          },
+          "category": [
+              {
+                  "coding": [
+                      {
+                          "code": "$classCode",
+                          "display": "$classDisplay",
+                          "system": "http://snomed.info/sct"
+                      }
+                  ]
+              }
+          ],
+          "subject": {
+              "identifier": {
+                  "value": "$nhsNumber",
+                  "system": "https://fhir.nhs.uk/Id/nhs-number"
+              }
+          },
+          "date": "$indexed",
+          "author": [
+              {
+                  "identifier": {
+                      "value": "$asid",
+                      "system": "https://fhir.nhs.uk/Id/nhsSpineASID"
+                  }
+              },
+              {
+                  "reference": "$author"
+              }
+          ],
+          "custodian": {
+              "identifier": {
+                  "value": "$custodian",
+                  "system": "https://fhir.nhs.uk/Id/ods-organization-code"
+              }
+          },
+          "content": [
+              {
+                  "attachment": {
+                      "url": "$attachmentUrl",
+                      "contentType": "$attachmentContentType",
+                      "creation": "$attachmentCreation"
+                  },
+                  "format": {
+                      "code": "urn:nhs-ic:unstructured",
+                      "display": "Unstructured Document",
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/NRL-FormatCode-1"
+                  }
+              }
+          ],
           "resourceType": "DocumentReference",
           "relatesTo": [
               {
@@ -237,25 +394,25 @@ Feature: Producer Create NRL-to-R4 Conversion
       | typeCode               | 718377777                                                                            |
       | typeDisplay            | Another Test data                                                                    |
     When Producer "Data Sync" uses "nrlf-converter" to convert NRL_DOCUMENT_POINTER with NHS Number "9278693472" and ASID "230811201350" into a DocumentReference according to the DOCUMENT_REFERENCE template
-      | property               | value                                                                                |
-      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
-      | nhsNumber              | 9278693472                                                                           |
-      | asid                   | 230811201350                                                                         |
-      | attachmentContentType  | application/pdf                                                                      |
-      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                            |
-      | attachmentUrl          | https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
-      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                         |
-      | classCode              | 734163000                                                                            |
-      | classDisplay           | Care plan                                                                            |
-      | custodian              | 8FW23                                                                                |
-      | indexed                | 2022-08-23T14:45:17+00:00                                                            |
-      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                        |
-      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                            |
-      | practiceSettingCode    | 310167005                                                                            |
-      | practiceSettingDisplay | Urology service                                                                      |
-      | typeCode               | 718377777                                                                            |
-      | typeDisplay            | Another Test data                                                                    |
-      | typeSystem             | http://snomed.info/sct                                                               |
+      | property               | value                                                                              |
+      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
+      | nhsNumber              | 9278693472                                                                         |
+      | asid                   | 230811201350                                                                       |
+      | attachmentContentType  | application/pdf                                                                    |
+      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                          |
+      | attachmentUrl          | ssp://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
+      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                       |
+      | classCode              | 734163000                                                                          |
+      | classDisplay           | Care plan                                                                          |
+      | custodian              | 8FW23                                                                              |
+      | indexed                | 2022-08-23T14:45:17+00:00                                                          |
+      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                      |
+      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                          |
+      | practiceSettingCode    | 310167005                                                                          |
+      | practiceSettingDisplay | Urology service                                                                    |
+      | typeCode               | 718377777                                                                          |
+      | typeDisplay            | Another Test data                                                                  |
+      | typeSystem             | http://snomed.info/sct                                                             |
     Then the operation is successful
     When Producer "Data Sync" creates a Document Reference from DOCUMENT_REFERENCE template
     Then the operation is successful
@@ -285,24 +442,24 @@ Feature: Producer Create NRL-to-R4 Conversion
       | system                 | value     |
       | http://snomed.info/sct | 718377777 |
     And a Document Pointer exists in the system with the below values for DOCUMENT_REFERENCE template
-      | property               | value                                                                                |
-      | id                     | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
-      | nhsNumber              | 9278693472                                                                           |
-      | attachmentContentType  | application/pdf                                                                      |
-      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                            |
-      | attachmentUrl          | https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
-      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                         |
-      | classCode              | 734163000                                                                            |
-      | classDisplay           | Care plan                                                                            |
-      | custodian              | 8FW23                                                                                |
-      | indexed                | 2022-08-23T14:45:17+00:00                                                            |
-      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                        |
-      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                            |
-      | practiceSettingCode    | 310167005                                                                            |
-      | practiceSettingDisplay | Urology service                                                                      |
-      | typeCode               | 718377777                                                                            |
-      | typeDisplay            | Another Test data                                                                    |
-      | typeSystem             | http://snomed.info/sct                                                               |
+      | property               | value                                                                              |
+      | id                     | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
+      | nhsNumber              | 9278693472                                                                         |
+      | attachmentContentType  | application/pdf                                                                    |
+      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                          |
+      | attachmentUrl          | ssp://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
+      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                       |
+      | classCode              | 734163000                                                                          |
+      | classDisplay           | Care plan                                                                          |
+      | custodian              | 8FW23                                                                              |
+      | indexed                | 2022-08-23T14:45:17+00:00                                                          |
+      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                      |
+      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                          |
+      | practiceSettingCode    | 310167005                                                                          |
+      | practiceSettingDisplay | Urology service                                                                    |
+      | typeCode               | 718377777                                                                          |
+      | typeDisplay            | Another Test data                                                                  |
+      | typeSystem             | http://snomed.info/sct                                                             |
     And Producer "Data Sync" has an NRL Document Pointer from NRL_DOCUMENT_POINTER template
       | property               | value                                                                                                              |
       | attachmentContentType  | application/pdf                                                                                                    |
@@ -324,26 +481,26 @@ Feature: Producer Create NRL-to-R4 Conversion
       | typeCode               | 718377777                                                                                                          |
       | typeDisplay            | Another Test data                                                                                                  |
     When Producer "Data Sync" uses "nrl-to-r4" to convert NRL_DOCUMENT_POINTER with NHS Number "9278693472" and ASID "230811201350" into a DocumentReference according to the DOCUMENT_REFERENCE template
-      | property               | value                                                                                |
-      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
-      | nhsNumber              | 9278693472                                                                           |
-      | asid                   | 230811201350                                                                         |
-      | attachmentContentType  | application/pdf                                                                      |
-      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                            |
-      | attachmentUrl          | https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
-      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                         |
-      | classCode              | 734163000                                                                            |
-      | classDisplay           | Care plan                                                                            |
-      | custodian              | 8FW23                                                                                |
-      | indexed                | 2022-08-23T14:45:17+00:00                                                            |
-      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                        |
-      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                            |
-      | practiceSettingCode    | 310167005                                                                            |
-      | practiceSettingDisplay | Urology service                                                                      |
-      | typeCode               | 718377777                                                                            |
-      | typeDisplay            | Another Test data                                                                    |
-      | typeSystem             | http://snomed.info/sct                                                               |
-      | target                 | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
+      | property               | value                                                                              |
+      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
+      | nhsNumber              | 9278693472                                                                         |
+      | asid                   | 230811201350                                                                       |
+      | attachmentContentType  | application/pdf                                                                    |
+      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                          |
+      | attachmentUrl          | ssp://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
+      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                       |
+      | classCode              | 734163000                                                                          |
+      | classDisplay           | Care plan                                                                          |
+      | custodian              | 8FW23                                                                              |
+      | indexed                | 2022-08-23T14:45:17+00:00                                                          |
+      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                      |
+      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                          |
+      | practiceSettingCode    | 310167005                                                                          |
+      | practiceSettingDisplay | Urology service                                                                    |
+      | typeCode               | 718377777                                                                          |
+      | typeDisplay            | Another Test data                                                                  |
+      | typeSystem             | http://snomed.info/sct                                                             |
+      | target                 | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
     Then the operation is successful
     When Producer "Data Sync" creates a Document Reference from DOCUMENT_REFERENCE template
     Then the operation is successful
@@ -395,26 +552,26 @@ Feature: Producer Create NRL-to-R4 Conversion
       | typeCode               | 718377777                                                                                                          |
       | typeDisplay            | Another Test data                                                                                                  |
     When Producer "Data Sync" uses "nrl-to-r4" to convert NRL_DOCUMENT_POINTER with NHS Number "9278693472" and ASID "230811201350" into a DocumentReference according to the DOCUMENT_REFERENCE template
-      | property               | value                                                                                |
-      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
-      | nhsNumber              | 9278693472                                                                           |
-      | asid                   | 230811201350                                                                         |
-      | attachmentContentType  | application/pdf                                                                      |
-      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                            |
-      | attachmentUrl          | https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
-      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                         |
-      | classCode              | 734163000                                                                            |
-      | classDisplay           | Care plan                                                                            |
-      | custodian              | 8FW23                                                                                |
-      | indexed                | 2022-08-23T14:45:17+00:00                                                            |
-      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                        |
-      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                            |
-      | practiceSettingCode    | 310167005                                                                            |
-      | practiceSettingDisplay | Urology service                                                                      |
-      | typeCode               | 718377777                                                                            |
-      | typeDisplay            | Another Test data                                                                    |
-      | typeSystem             | http://snomed.info/sct                                                               |
-      | target                 | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
+      | property               | value                                                                              |
+      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
+      | nhsNumber              | 9278693472                                                                         |
+      | asid                   | 230811201350                                                                       |
+      | attachmentContentType  | application/pdf                                                                    |
+      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                          |
+      | attachmentUrl          | ssp://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
+      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                       |
+      | classCode              | 734163000                                                                          |
+      | classDisplay           | Care plan                                                                          |
+      | custodian              | 8FW23                                                                              |
+      | indexed                | 2022-08-23T14:45:17+00:00                                                          |
+      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                      |
+      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                          |
+      | practiceSettingCode    | 310167005                                                                          |
+      | practiceSettingDisplay | Urology service                                                                    |
+      | typeCode               | 718377777                                                                          |
+      | typeDisplay            | Another Test data                                                                  |
+      | typeSystem             | http://snomed.info/sct                                                             |
+      | target                 | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
     Then the operation is successful
     When Producer "Data Sync" creates a Document Reference from DOCUMENT_REFERENCE template
     Then the operation is successful
@@ -466,26 +623,26 @@ Feature: Producer Create NRL-to-R4 Conversion
       | typeCode               | 718377777                                                                            |
       | typeDisplay            | Another Test data                                                                    |
     When Producer "Data Sync" uses "nrl-to-r4" to convert NRL_DOCUMENT_POINTER with NHS Number "9278693472" and ASID "230811201350" into a DocumentReference according to the DOCUMENT_REFERENCE template
-      | property               | value                                                                                |
-      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
-      | nhsNumber              | 9278693472                                                                           |
-      | asid                   | 230811201350                                                                         |
-      | attachmentContentType  | application/pdf                                                                      |
-      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                            |
-      | attachmentUrl          | https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
-      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                         |
-      | classCode              | 734163000                                                                            |
-      | classDisplay           | Care plan                                                                            |
-      | custodian              | 8FW23                                                                                |
-      | indexed                | 2022-08-23T14:45:17+00:00                                                            |
-      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                        |
-      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                            |
-      | practiceSettingCode    | 310167005                                                                            |
-      | practiceSettingDisplay | Urology service                                                                      |
-      | typeCode               | 718377777                                                                            |
-      | typeDisplay            | Another Test data                                                                    |
-      | typeSystem             | http://snomed.info/sct                                                               |
-      | target                 | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                      |
+      | property               | value                                                                              |
+      | id                     | 8FW23-341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
+      | nhsNumber              | 9278693472                                                                         |
+      | asid                   | 230811201350                                                                       |
+      | attachmentContentType  | application/pdf                                                                    |
+      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                                          |
+      | attachmentUrl          | ssp://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf |
+      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE                       |
+      | classCode              | 734163000                                                                          |
+      | classDisplay           | Care plan                                                                          |
+      | custodian              | 8FW23                                                                              |
+      | indexed                | 2022-08-23T14:45:17+00:00                                                          |
+      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                                      |
+      | logicalId              | 341ec927-22f2-11ed-bd8d-000c290de2c0-58504e523530384b5851                          |
+      | practiceSettingCode    | 310167005                                                                          |
+      | practiceSettingDisplay | Urology service                                                                    |
+      | typeCode               | 718377777                                                                          |
+      | typeDisplay            | Another Test data                                                                  |
+      | typeSystem             | http://snomed.info/sct                                                             |
+      | target                 | 8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851                    |
     Then the operation is successful
     When Producer "Data Sync" creates a Document Reference from DOCUMENT_REFERENCE template
     Then the operation is successful
@@ -509,3 +666,137 @@ Feature: Producer Create NRL-to-R4 Conversion
       | document    | <document>                                                      |
       | created_on  | <timestamp>                                                     |
     And Document Pointer "8FW23-e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851" does not exist
+
+  Scenario: NRL can Create a DocumentReference from an NRL Document Pointer with No Attachment
+    Given Producer "Data Sync" (Organisation ID "8FW23") is requesting to create Document Pointers
+    And Producer "Data Sync" is registered in the system for application "DataShare" (ID "z00z-y11y-x22x") with pointer types
+      | system                 | value     |
+      | http://snomed.info/sct | 718377777 |
+    And Producer "Data Sync" has the permission "audit-dates-from-payload"
+    And Producer "Data Sync" has an NRL Document Pointer from NRL_DOCUMENT_POINTER template
+      | property               | value                                                          |
+      | attachmentContentType  | text/html                                                      |
+      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                      |
+      | attachmentUrl          | https://spine-proxy.national.ncrs.nhs.uk/                      |
+      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE   |
+      | classCode              | 734163000                                                      |
+      | classDisplay           | Care plan                                                      |
+      | custodian              | https://directory.spineservices.nhs.uk/STU3/Organization/8FW23 |
+      | indexed                | 2022-08-23T14:45:17+00:00                                      |
+      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                  |
+      | logicalId              | a18af9ab-32b7-11ee-87e3-067a0214ca1a-58394e47453659524c33      |
+      | practiceSettingCode    | 310167005                                                      |
+      | practiceSettingDisplay | Urology service                                                |
+      | relatesToCode          |                                                                |
+      | relatesToIdentifier    |                                                                |
+      | relatesToTarget        |                                                                |
+      | relatesToSystem        |                                                                |
+      | typeCode               | 718377777                                                      |
+      | typeDisplay            | Another Test data                                              |
+    When Producer "Data Sync" uses "nrlf-converter" to convert NRL_DOCUMENT_POINTER with NHS Number "9693893158" and ASID "230811201350" into a DocumentReference according to the DOCUMENT_REFERENCE template
+      | property               | value                                                           |
+      | id                     | 8FW23-a18af9ab-32b7-11ee-87e3-067a0214ca1a-58394e47453659524c33 |
+      | nhsNumber              | 9693893158                                                      |
+      | asid                   | 230811201350                                                    |
+      | attachmentContentType  | text/html                                                       |
+      | attachmentCreation     | 2021-03-08T15:26:00+01:00                                       |
+      | attachmentUrl          | ssp://spine-proxy.national.ncrs.nhs.uk/                         |
+      | author                 | https://directory.spineservices.nhs.uk/STU3/Organization/RAE    |
+      | classCode              | 734163000                                                       |
+      | classDisplay           | Care plan                                                       |
+      | custodian              | 8FW23                                                           |
+      | indexed                | 2022-08-23T14:45:17+00:00                                       |
+      | lastModified           | Tue, 23 Aug 2022 14:45:17 GMT                                   |
+      | logicalId              | a18af9ab-32b7-11ee-87e3-067a0214ca1a-58394e47453659524c33       |
+      | practiceSettingCode    | 310167005                                                       |
+      | practiceSettingDisplay | Urology service                                                 |
+      | typeCode               | 718377777                                                       |
+      | typeDisplay            | Another Test data                                               |
+      | typeSystem             | http://snomed.info/sct                                          |
+    Then the operation is successful
+    When Producer "Data Sync" creates a Document Reference from DOCUMENT_REFERENCE template
+    Then the operation is successful
+    And the status is 201
+    And the response is an OperationOutcome according to the OUTCOME template with the below values
+      | property          | value            |
+      | issue_type        | informational    |
+      | issue_level       | information      |
+      | issue_code        | RESOURCE_CREATED |
+      | issue_description | Resource created |
+      | message           | Resource created |
+    And Document Pointer "8FW23-a18af9ab-32b7-11ee-87e3-067a0214ca1a-58394e47453659524c33" exists
+      | property    | value                                                           |
+      | id          | 8FW23-a18af9ab-32b7-11ee-87e3-067a0214ca1a-58394e47453659524c33 |
+      | nhs_number  | 9693893158                                                      |
+      | producer_id | 8FW23                                                           |
+      | type        | http://snomed.info/sct\|718377777                               |
+      | source      | NRLF                                                            |
+      | version     | 1                                                               |
+      | updated_on  | NULL                                                            |
+      | document    | <document>                                                      |
+      | created_on  | <timestamp>                                                     |
+
+  Scenario: NRL can Create a DocumentReference from an NRL Document Pointer with No Context
+    Given Producer "Data Sync" (Organisation ID "8FW23") is requesting to create Document Pointers
+    And Producer "Data Sync" is registered in the system for application "DataShare" (ID "z00z-y11y-x22x") with pointer types
+      | system                 | value     |
+      | http://snomed.info/sct | 718377777 |
+    And Producer "Data Sync" has the permission "audit-dates-from-payload"
+    And Producer "Data Sync" has an NRL Document Pointer from NRL_DOCUMENT_POINTER_WITHOUT_CONTEXT template
+      | property              | value                                                          |
+      | attachmentContentType | text/html                                                      |
+      | attachmentCreation    | 2021-03-08T15:26:00+01:00                                      |
+      | attachmentUrl         | https://spine-proxy.national.ncrs.nhs.uk/                      |
+      | author                | https://directory.spineservices.nhs.uk/STU3/Organization/RAE   |
+      | classCode             | 734163000                                                      |
+      | classDisplay          | Care plan                                                      |
+      | custodian             | https://directory.spineservices.nhs.uk/STU3/Organization/8FW23 |
+      | indexed               | 2022-08-23T14:45:17+00:00                                      |
+      | lastModified          | Tue, 23 Aug 2022 14:45:17 GMT                                  |
+      | logicalId             | 16f1ba23-32bc-11ee-87e3-067a0214ca1a-58394e47453659524c33      |
+      | relatesToCode         |                                                                |
+      | relatesToIdentifier   |                                                                |
+      | relatesToTarget       |                                                                |
+      | relatesToSystem       |                                                                |
+      | typeCode              | 718377777                                                      |
+      | typeDisplay           | Another Test data                                              |
+    When Producer "Data Sync" uses "nrlf-converter" to convert NRL_DOCUMENT_POINTER_WITHOUT_CONTEXT with NHS Number "9693893158" and ASID "230811201350" into a DocumentReference according to the DOCUMENT_REFERENCE_WITHOUT_CONTEXT template
+      | property              | value                                                           |
+      | id                    | 8FW23-16f1ba23-32bc-11ee-87e3-067a0214ca1a-58394e47453659524c33 |
+      | nhsNumber             | 9693893158                                                      |
+      | asid                  | 230811201350                                                    |
+      | attachmentContentType | text/html                                                       |
+      | attachmentCreation    | 2021-03-08T15:26:00+01:00                                       |
+      | attachmentUrl         | ssp://spine-proxy.national.ncrs.nhs.uk/                         |
+      | author                | https://directory.spineservices.nhs.uk/STU3/Organization/RAE    |
+      | classCode             | 734163000                                                       |
+      | classDisplay          | Care plan                                                       |
+      | custodian             | 8FW23                                                           |
+      | indexed               | 2022-08-23T14:45:17+00:00                                       |
+      | lastModified          | Tue, 23 Aug 2022 14:45:17 GMT                                   |
+      | logicalId             | 16f1ba23-32bc-11ee-87e3-067a0214ca1a-58394e47453659524c33       |
+      | typeCode              | 718377777                                                       |
+      | typeDisplay           | Another Test data                                               |
+      | typeSystem            | http://snomed.info/sct                                          |
+    Then the operation is successful
+    When Producer "Data Sync" creates a Document Reference from DOCUMENT_REFERENCE_WITHOUT_CONTEXT template
+    Then the operation is successful
+    And the status is 201
+    And the response is an OperationOutcome according to the OUTCOME template with the below values
+      | property          | value            |
+      | issue_type        | informational    |
+      | issue_level       | information      |
+      | issue_code        | RESOURCE_CREATED |
+      | issue_description | Resource created |
+      | message           | Resource created |
+    And Document Pointer "8FW23-16f1ba23-32bc-11ee-87e3-067a0214ca1a-58394e47453659524c33" exists
+      | property    | value                                                           |
+      | id          | 8FW23-16f1ba23-32bc-11ee-87e3-067a0214ca1a-58394e47453659524c33 |
+      | nhs_number  | 9693893158                                                      |
+      | producer_id | 8FW23                                                           |
+      | type        | http://snomed.info/sct\|718377777                               |
+      | source      | NRLF                                                            |
+      | version     | 1                                                               |
+      | updated_on  | NULL                                                            |
+      | document    | <document>                                                      |
+      | created_on  | <timestamp>                                                     |

--- a/feature_tests/features/producer/producer-supersedeDocumentPointer-failure.feature
+++ b/feature_tests/features/producer/producer-supersedeDocumentPointer-failure.feature
@@ -405,12 +405,12 @@ Feature: Producer Supersede Failure scenarios
     Then the operation is unsuccessful
     And the status is 400
     And the response is an OperationOutcome according to the OUTCOME template with the below values
-      | property          | value                                                   |
-      | issue_type        | processing                                              |
-      | issue_level       | error                                                   |
-      | issue_code        | VALIDATION_ERROR                                        |
-      | issue_description | A parameter or value has resulted in a validation error |
-      | message           | DocumentReference validation failure - Invalid id       |
+      | property          | value                                                     |
+      | issue_type        | processing                                                |
+      | issue_level       | error                                                     |
+      | issue_code        | VALIDATION_ERROR                                          |
+      | issue_description | A parameter or value has resulted in a validation error   |
+      | message           | Input is not composite of the form a-b: 8FW23\|1234567890 |
 
   Scenario: Unable to supersede Document Pointer if the nhs number does not match
     Given Producer "Aaron Court Mental Health NH" (Organisation ID "8FW23") is requesting to create Document Pointers

--- a/feature_tests/features/producer/producer-supersedeDocumentPointer-failure.feature
+++ b/feature_tests/features/producer/producer-supersedeDocumentPointer-failure.feature
@@ -48,6 +48,42 @@ Feature: Producer Supersede Failure scenarios
         ]
       }
       """
+    Given template PLAIN_DOCUMENT
+      """
+      {
+        "resourceType": "DocumentReference",
+        "id": "$identifier",
+        "custodian": {
+          "identifier": {
+            "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+            "value": "$custodian"
+          }
+        },
+        "subject": {
+          "identifier": {
+            "system": "https://fhir.nhs.uk/Id/nhs-number",
+            "value": "$subject"
+          }
+        },
+        "type": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "$type"
+            }
+          ]
+        },
+        "content": [
+          {
+            "attachment": {
+              "contentType": "$contentType",
+              "url": "$url"
+            }
+          }
+        ],
+        "status": "current"
+      }
+      """
     And template BAD_DOCUMENT
       """
       {
@@ -658,3 +694,84 @@ Feature: Producer Supersede Failure scenarios
       | issue_code        | VALIDATION_ERROR                                                                                                                                         |
       | issue_description | A parameter or value has resulted in a validation error                                                                                                  |
       | message           | ValidationError raised from Data Contract 'Validate Content Url:1' at 'content[0].attachment.url': 'not-a-url' does not match '^https*://(www.)*\\w+.*$' |
+
+  Scenario: Supersede without 'supersede-ignore-delete-fail' permission a DocumentPointer that exists with invalid target
+    Given Producer "Data Sync" (Organisation ID "DS123") is requesting to create Document Pointers
+    And Producer "Data Sync" is registered in the system for application "DataShare" (ID "z00z-y11y-x22x") with pointer types stored in NRLF
+      | system                 | value     |
+      | http://snomed.info/sct | 736253002 |
+    And a Document Pointer exists in the system with the below values for PLAIN_DOCUMENT template
+      | property    | value                          |
+      | identifier  | DS123-ALREADY_EXISTS           |
+      | type        | 736253002                      |
+      | custodian   | DS123                          |
+      | producer_id | DS123                          |
+      | subject     | 9278693472                     |
+      | contentType | application/pdf                |
+      | url         | https://example.org/my-doc.pdf |
+    When Producer "Data Sync" creates a Document Reference from DOCUMENT template
+      | property    | value                          |
+      | identifier  | DS123-ALREADY_EXISTS           |
+      | target      | DS123-DOES_NOT_EXIST           |
+      | code        | replaces                       |
+      | type        | 736253002                      |
+      | custodian   | DS123                          |
+      | producer_id | DS123                          |
+      | subject     | 9278693472                     |
+      | contentType | application/pdf                |
+      | url         | https://example.org/my-doc.pdf |
+    Then the operation is unsuccessful
+    And the status is 400
+    And the response is an OperationOutcome according to the OUTCOME template with the below values
+      | property          | value                                                         |
+      | issue_type        | processing                                                    |
+      | issue_level       | error                                                         |
+      | issue_code        | VALIDATION_ERROR                                              |
+      | issue_description | A parameter or value has resulted in a validation error       |
+      | message           | Validation failure - relatesTo target document does not exist |
+    And Document Pointer "DS123-ALREADY_EXISTS" still exists
+
+  Scenario: Supersede without 'supersede-ignore-delete-fail' permission a DocumentPointer that exists with valid target
+    Given Producer "Data Sync" (Organisation ID "DS123") is requesting to create Document Pointers
+    And Producer "Data Sync" is registered in the system for application "DataShare" (ID "z00z-y11y-x22x") with pointer types stored in NRLF
+      | system                 | value     |
+      | http://snomed.info/sct | 736253002 |
+    And a Document Pointer exists in the system with the below values for PLAIN_DOCUMENT template
+      | property    | value                          |
+      | identifier  | DS123-ALREADY_EXISTS           |
+      | type        | 736253002                      |
+      | custodian   | DS123                          |
+      | producer_id | DS123                          |
+      | subject     | 9278693472                     |
+      | contentType | application/pdf                |
+      | url         | https://example.org/my-doc.pdf |
+    And a Document Pointer exists in the system with the below values for PLAIN_DOCUMENT template
+      | property    | value                          |
+      | identifier  | DS123-TARGET_EXISTS            |
+      | type        | 736253002                      |
+      | custodian   | DS123                          |
+      | producer_id | DS123                          |
+      | subject     | 9278693472                     |
+      | contentType | application/pdf                |
+      | url         | https://example.org/my-doc.pdf |
+    When Producer "Data Sync" creates a Document Reference from DOCUMENT template
+      | property    | value                          |
+      | identifier  | DS123-ALREADY_EXISTS           |
+      | target      | DS123-TARGET_EXISTS            |
+      | code        | replaces                       |
+      | type        | 736253002                      |
+      | custodian   | DS123                          |
+      | producer_id | DS123                          |
+      | subject     | 9278693472                     |
+      | contentType | application/pdf                |
+      | url         | https://example.org/my-doc.pdf |
+    Then the operation is unsuccessful
+    And the status is 409
+    And the response is an OperationOutcome according to the OUTCOME template with the below values
+      | property          | value                                   |
+      | issue_type        | processing                              |
+      | issue_level       | error                                   |
+      | issue_code        | INVALID_VALUE                           |
+      | issue_description | Invalid value                           |
+      | message           | Condition check failed - Duplicate item |
+    And Document Pointer "DS123-ALREADY_EXISTS" still exists

--- a/feature_tests/features/producer/producer-supersedeDocumentPointer-success.feature
+++ b/feature_tests/features/producer/producer-supersedeDocumentPointer-success.feature
@@ -398,19 +398,21 @@ Feature: Producer Supersede Success scenarios
     Given Producer "Aaron Court Mental Health NH" (Organisation ID "8FW23") is requesting to create Document Pointers
     And Producer "Aaron Court Mental Health NH" is registered in the system for application "DataShare" (ID "z00z-y11y-x22x") with pointer types
       | system                 | value     |
-      | http://snomed.info/sct | 736253002 |
+      | http://snomed.info/sct | TEST_TYPE |
+    # Remove the following line when NRLF-661 is implemented
+    And the Data Contracts are loaded from the database
     And a Data Contract is registered in the system
       | property             | value                  |
       | name                 | Validate Content Url   |
       | system               | http://snomed.info/sct |
-      | value                | 736253002              |
-      | version              | 1                      |
+      | value                | TEST_TYPE              |
+      | version              | 2000.01.01             |
       | inverse_version      | 0                      |
       | json_schema_template | JSON_SCHEMA            |
     And a Document Pointer exists in the system with the below values for DOCUMENT template
       | property    | value                          |
       | identifier  | 8FW23-1234567891               |
-      | type        | 736253002                      |
+      | type        | TEST_TYPE                      |
       | custodian   | 8FW23                          |
       | subject     | 9278693472                     |
       | contentType | application/pdf                |
@@ -419,7 +421,7 @@ Feature: Producer Supersede Success scenarios
       | property    | value                              |
       | identifier  | 8FW23-1234567892                   |
       | target      | 8FW23-1234567891                   |
-      | type        | 736253002                          |
+      | type        | TEST_TYPE                          |
       | custodian   | 8FW23                              |
       | subject     | 9278693472                         |
       | contentType | application/pdf                    |
@@ -434,15 +436,15 @@ Feature: Producer Supersede Success scenarios
       | issue_description | Resource created and Resource(s) deleted |
       | message           | Resource created and Resource(s) deleted |
     And Document Pointer "8FW23-1234567892" exists
-      | property    | value                             |
-      | id          | 8FW23-1234567892                  |
-      | nhs_number  | 9278693472                        |
-      | producer_id | 8FW23                             |
-      | type        | http://snomed.info/sct\|736253002 |
-      | source      | NRLF                              |
-      | version     | 1                                 |
-      | schemas     | ["Validate Content Url:1"]        |
-      | updated_on  | NULL                              |
-      | document    | <document>                        |
-      | created_on  | <timestamp>                       |
+      | property    | value                                                       |
+      | id          | 8FW23-1234567892                                            |
+      | nhs_number  | 9278693472                                                  |
+      | producer_id | 8FW23                                                       |
+      | type        | http://snomed.info/sct\|TEST_TYPE                           |
+      | source      | NRLF                                                        |
+      | version     | 1                                                           |
+      | schemas     | ["test-name:2000.01.01", "Validate Content Url:2000.01.01"] |
+      | updated_on  | NULL                                                        |
+      | document    | <document>                                                  |
+      | created_on  | <timestamp>                                                 |
     And Document Pointer "8FW23-1234567891" does not exist

--- a/feature_tests/features/producer/producer-updateDocumentPointer-success.feature
+++ b/feature_tests/features/producer/producer-updateDocumentPointer-success.feature
@@ -100,6 +100,53 @@ Feature: Producer Update Success scenarios
          "description": "$description"
       }
       """
+    And template DOCUMENT_WITH_AUTHOR
+      """
+      {
+        "resourceType": "DocumentReference",
+        "id": "$custodian-$identifier",
+        "custodian": {
+          "identifier": {
+            "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+            "value": "$custodian"
+          }
+        },
+        "subject": {
+          "identifier": {
+            "system": "https://fhir.nhs.uk/Id/nhs-number",
+            "value": "$subject"
+          }
+        },
+        "type": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "$type"
+            }
+          ]
+        },
+        "content": [
+          {
+            "attachment": {
+              "contentType": "$contentType",
+              "url": "$url"
+            }
+          }
+        ],
+        "author": [
+          {
+            "identifier": {
+              "system": "https://fhir.nhs.uk/Id/accredited-system-id",
+              "value": "200000000610"
+            }
+          },
+          {
+            "reference": "https://directory.spineservices.nhs.uk/STU3/Organization/RAT"
+          }
+        ],
+        "status": "current"
+      }
+      """
     And template OUTCOME
       """
       {
@@ -318,20 +365,22 @@ Feature: Producer Update Success scenarios
   Scenario: Validate update operation against json schema
     Given Producer "Aaron Court Mental Health NH" (Organisation ID "8FW23") is requesting to update Document Pointers
     And Producer "Aaron Court Mental Health NH" is registered in the system for application "DataShare" (ID "z00z-y11y-x22x") with pointer types
-      | system                 | value           |
-      | http://snomed.info/sct | 887701000000100 |
+      | system                 | value     |
+      | http://snomed.info/sct | TEST_TYPE |
+    # Remove the following line when NRLF-661 is implemented
+    And the Data Contracts are loaded from the database
     And a Data Contract is registered in the system
       | property             | value                             |
       | name                 | Validate Content Attachment Title |
       | system               | http://snomed.info/sct            |
-      | value                | 887701000000100                   |
-      | version              | 1                                 |
+      | value                | TEST_TYPE                         |
+      | version              | 2000.01.01                        |
       | inverse_version      | 0                                 |
       | json_schema_template | JSON_SCHEMA                       |
     And a Document Pointer exists in the system with the below values for DOCUMENT_WITH_TITLE template
       | property    | value                          |
       | identifier  | 1234567890                     |
-      | type        | 887701000000100                |
+      | type        | TEST_TYPE                      |
       | custodian   | 8FW23                          |
       | subject     | 9278693472                     |
       | contentType | application/pdf                |
@@ -344,7 +393,7 @@ Feature: Producer Update Success scenarios
       | property    | value                                           |
       | identifier  | 1234567890                                      |
       | status      | current                                         |
-      | type        | 887701000000100                                 |
+      | type        | TEST_TYPE                                       |
       | custodian   | 8FW23                                           |
       | subject     | 9278693472                                      |
       | contentType | application/pdf                                 |
@@ -362,14 +411,60 @@ Feature: Producer Update Success scenarios
       | issue_description | Resource updated |
       | message           | Resource updated |
     And Document Pointer "8FW23-1234567890" exists
-      | property    | value                                   |
-      | id          | 8FW23-1234567890                        |
-      | nhs_number  | 9278693472                              |
-      | producer_id | 8FW23                                   |
-      | type        | http://snomed.info/sct\|887701000000100 |
-      | source      | NRLF                                    |
-      | version     | 1                                       |
-      | schemas     | ["Validate Content Attachment Title:1"] |
-      | document    | <document>                              |
-      | created_on  | <timestamp>                             |
-      | updated_on  | <timestamp>                             |
+      | property    | value                                                                    |
+      | id          | 8FW23-1234567890                                                         |
+      | nhs_number  | 9278693472                                                               |
+      | producer_id | 8FW23                                                                    |
+      | type        | http://snomed.info/sct\|TEST_TYPE                                        |
+      | source      | NRLF                                                                     |
+      | version     | 1                                                                        |
+      | schemas     | ["test-name:2000.01.01", "Validate Content Attachment Title:2000.01.01"] |
+      | document    | <document>                                                               |
+      | created_on  | <timestamp>                                                              |
+      | updated_on  | <timestamp>                                                              |
+
+  @integration-only
+  Scenario: Validate update Document Pointer when asid and update content to contact only
+    Given Producer "Aaron Court Mental Health NH" (Organisation ID "8FW23") is requesting to update Document Pointers
+    And Producer "Aaron Court Mental Health NH" is registered in the system for application "DataShare" (ID "z00z-y11y-x22x") with pointer types
+      | system                 | value     |
+      | http://snomed.info/sct | 736253002 |
+    And the Data Contracts are loaded from the database
+    And a Document Pointer exists in the system with the below values for DOCUMENT_WITH_AUTHOR template
+      | property    | value                        |
+      | identifier  | 1234567890                   |
+      | type        | 736253002                    |
+      | custodian   | 8FW23                        |
+      | subject     | 9278693472                   |
+      | contentType | application/pdf              |
+      | status      | current                      |
+      | url         | ssp://example.org/my-doc.pdf |
+    When Producer "Aaron Court Mental Health NH" updates Document Reference "8FW23-1234567890" from DOCUMENT_WITH_AUTHOR template
+      | property    | value                                    |
+      | identifier  | 1234567890                               |
+      | status      | current                                  |
+      | type        | 736253002                                |
+      | custodian   | 8FW23                                    |
+      | subject     | 9278693472                               |
+      | contentType | application/html                         |
+      | url         | https://example.org/contact-details.html |
+    Then the operation is successful
+    And the response is an OperationOutcome according to the OUTCOME template with the below values
+      | property          | value            |
+      | issue_type        | informational    |
+      | issue_level       | information      |
+      | issue_code        | RESOURCE_UPDATED |
+      | issue_description | Resource updated |
+      | message           | Resource updated |
+    And Document Pointer "8FW23-1234567890" exists
+      | property    | value                                                     |
+      | id          | 8FW23-1234567890                                          |
+      | nhs_number  | 9278693472                                                |
+      | producer_id | 8FW23                                                     |
+      | type        | http://snomed.info/sct\|736253002                         |
+      | source      | NRLF                                                      |
+      | version     | 1                                                         |
+      | schemas     | ["test-name:2000.01.01", "asidcheck-contract:2000.01.01"] |
+      | document    | <document>                                                |
+      | created_on  | <timestamp>                                               |
+      | updated_on  | <timestamp>                                               |

--- a/feature_tests/features/producer/producer-updateDocumentPointer-success.feature
+++ b/feature_tests/features/producer/producer-updateDocumentPointer-success.feature
@@ -136,7 +136,7 @@ Feature: Producer Update Success scenarios
         "author": [
           {
             "identifier": {
-              "system": "https://fhir.nhs.uk/Id/accredited-system-id",
+              "system": "https://fhir.nhs.uk/Id/nhsSpineASID",
               "value": "200000000610"
             }
           },

--- a/feature_tests/steps/_1_setup.py
+++ b/feature_tests/steps/_1_setup.py
@@ -1,7 +1,9 @@
 import json
+from datetime import date
 
 from behave import given as behave_given
 
+from data_contracts.deploy_contracts.deploy_contracts import sync_contracts
 from feature_tests.common.config_setup import register_application, request_setup
 from feature_tests.common.constants import DEFAULT_VERSION, WITH_WITHOUT_ANY, FhirType
 from feature_tests.common.decorators import given
@@ -190,7 +192,6 @@ def data_contract_registered_in_the_system(context: Context):
         test_config.templates[contract_kwargs.pop("json_schema_template")].raw
     )
     inverse_version = contract_kwargs.pop("inverse_version")
-    contract_kwargs["version"] = int(contract_kwargs["version"])
     contract = Contract(
         pk=key(DbPrefix.Contract, contract_kwargs["system"], contract_kwargs["value"]),
         sk=key(DbPrefix.Version, inverse_version, contract_kwargs["name"]),
@@ -198,3 +199,11 @@ def data_contract_registered_in_the_system(context: Context):
         **contract_kwargs,
     )
     test_config.repositories[Contract].create(item=contract)
+
+
+@given("the Data Contracts are loaded from the database")
+def load_data_contracts_from_database(context: Context):
+    test_config: TestConfig = context.test_config
+    sync_contracts(
+        test_config.repositories[Contract], today=date(year=2000, month=1, day=1)
+    )

--- a/helpers/helpers/firehose.py
+++ b/helpers/helpers/firehose.py
@@ -26,7 +26,7 @@ from nrlf.core.firehose.model import (
 )
 from nrlf.core.firehose.submission import FirehoseClient, _submit_records
 from nrlf.core.firehose.utils import load_json_gzip, name_from_arn
-from nrlf.core.validators import json_loads
+from nrlf.core.validators import json_load, json_loads
 
 S3_URI_COMPONENTS = re.compile("^s3://(?P<bucket_name>[^/]+)/(?P<file_key>.*?)$")
 DOT_FIREHOSE = ".firehose"
@@ -250,7 +250,7 @@ def validate_logs(logs: list):
 @log("{__result__}")
 def validate_line_by_line(local_path: str) -> str:
     with open(local_path) as f:
-        errors = list(validate_logs(logs=json.load(f)))
+        errors = list(validate_logs(logs=json_load(f)))
     msg = [NO_ERRORS_FOUND]
     if errors:
         msg = ["", f"{len(errors)} errors found in this file"]
@@ -289,7 +289,7 @@ def validate(local_path: str):
     msg = validate_line_by_line(local_path=local_path)
     if msg.startswith(NO_ERRORS_FOUND):
         with open(local_path) as f:
-            construct_cloudwatch_logs_data(messages=json.load(f))
+            construct_cloudwatch_logs_data(messages=json_load(f))
         return ALL_GOOD
     else:
         return FAILED_VALIDATION
@@ -333,7 +333,7 @@ def resubmit(local_path: str, s3_client, firehose_client):
         return FAILED_VALIDATION
 
     with open(local_path) as f:
-        cloudwatch_data = construct_cloudwatch_logs_data(messages=json.load(f))
+        cloudwatch_data = construct_cloudwatch_logs_data(messages=json_load(f))
     submit_cloudwatch_data_to_firehose(
         firehose_client=firehose_client,
         stream_arn=stream_arn,

--- a/helpers/helpers/tests/test_firehose.py
+++ b/helpers/helpers/tests/test_firehose.py
@@ -1,6 +1,5 @@
 import base64
 import gzip
-import json
 import os
 from contextlib import contextmanager
 from pathlib import Path
@@ -31,7 +30,7 @@ from helpers.firehose import (
     local_path_to_s3_components,
 )
 from nrlf.core.firehose.model import CloudwatchMessageType
-from nrlf.core.validators import json_loads
+from nrlf.core.validators import json_load, json_loads
 
 
 @given(
@@ -109,7 +108,7 @@ def test__write_s3_logs_to_local(logs):
         )
         assert _path == Path(dir) / "foo" / "bar.json"
         with open(_path) as f:
-            assert json.load(f) == logs
+            assert json_load(f) == logs
 
 
 @settings(deadline=3000, max_examples=10)
@@ -183,7 +182,7 @@ def test_fetch(mocked_fetch_logs_from_s3):
         )
         assert _path == Path(dir) / "foo" / "bar.json"
         with open(_path) as f:
-            assert json.load(f) == logs
+            assert json_load(f) == logs
 
 
 @given(

--- a/layer/nrlf/nrlf/core/dynamodb_types.py
+++ b/layer/nrlf/nrlf/core/dynamodb_types.py
@@ -66,7 +66,6 @@ def convert_value_to_dynamo_format(obj):
 
 def convert_dynamo_value_to_raw_value(obj: Union[DynamoDbType, dict]):
     _type = type(obj)
-
     if _type in (list, dict):
         ((dynamo_type, value),) = obj.items()
     else:

--- a/layer/nrlf/nrlf/core/model.py
+++ b/layer/nrlf/nrlf/core/model.py
@@ -318,7 +318,7 @@ class Contract(DynamoDbModel):
     pk: DynamoDbStringType
     sk: DynamoDbStringType
     name: DynamoDbStringType
-    version: DynamoDbIntType
+    version: DynamoDbStringType
     system: DynamoDbStringType
     value: DynamoDbStringType
     json_schema: DynamoDbDictType
@@ -330,3 +330,22 @@ class Contract(DynamoDbModel):
     @property
     def full_name(self):
         return f"{self.name.__root__}:{self.version.__root__}"
+
+    @property
+    def pk_1(self) -> DynamoDbStringType:
+        return DynamoDbStringType(__root__=DbPrefix.Contract.value)
+
+    @property
+    def sk_1(self) -> DynamoDbStringType:
+        return DynamoDbStringType(
+            __root__=f"{self.pk.__root__}{KEY_SEPARATOR}{self.sk.__root__}"
+        )
+
+    def dict(self, **kwargs):
+        return {
+            "pk": self.pk.dict(),
+            "sk": self.sk.dict(),
+            "pk_1": self.pk_1.dict(),
+            "sk_1": self.sk_1.dict(),
+            **super().dict(**kwargs),
+        }

--- a/layer/nrlf/nrlf/core/tests/test_json_schema.py
+++ b/layer/nrlf/nrlf/core/tests/test_json_schema.py
@@ -249,7 +249,7 @@ def test__get_contracts_from_db_returns_latest_versions(
                     pk=key(DbPrefix.Contract, system, value),
                     sk=key(DbPrefix.Version, inverse_version, f"name{i_name}"),
                     name=f"name{i_name}",
-                    version=version + 1,
+                    version=str(version + 1),
                     system=system,
                     value=value,
                     json_schema={
@@ -270,7 +270,7 @@ def test__get_contracts_from_db_returns_latest_versions(
             pk=key(DbPrefix.Contract, system, value),
             sk=key(DbPrefix.Version, MIN_VERSION, "name1"),
             name="name1",
-            version=N_VERSIONS,
+            version=str(N_VERSIONS),
             system=system,
             value=value,
             json_schema={
@@ -284,7 +284,7 @@ def test__get_contracts_from_db_returns_latest_versions(
             pk=key(DbPrefix.Contract, system, value),
             sk=key(DbPrefix.Version, MIN_VERSION, "name2"),
             name="name2",
-            version=N_VERSIONS,
+            version=str(N_VERSIONS),
             system=system,
             value=value,
             json_schema={
@@ -298,7 +298,7 @@ def test__get_contracts_from_db_returns_latest_versions(
             pk=key(DbPrefix.Contract, system, value),
             sk=key(DbPrefix.Version, MIN_VERSION, "name3"),
             name=f"name3",
-            version=N_VERSIONS,
+            version=str(N_VERSIONS),
             system=system,
             value=value,
             json_schema={

--- a/layer/nrlf/nrlf/core/tests/test_json_schema.py
+++ b/layer/nrlf/nrlf/core/tests/test_json_schema.py
@@ -52,7 +52,7 @@ SSP_JSON_SCHEMA = {
                         "properties": {
                             "system": {
                                 "type": "string",
-                                "enum": ["https://fhir.nhs.uk/Id/accredited-system-id"],
+                                "enum": ["https://fhir.nhs.uk/Id/nhsSpineASID"],
                             }
                         },
                     },
@@ -78,7 +78,7 @@ NOT_SSP_DATA = {
 
 HAS_SSP_DATA = {
     "author": [
-        {"system": "https://fhir.nhs.uk/Id/accredited-system-id", "value": "123"},
+        {"system": "https://fhir.nhs.uk/Id/nhsSpineASID", "value": "123"},
         {"system": "XXX", "value": "XYZ"},
     ],
     "content": [{"url": "ssp://foo.com"}, {"url": "http://foo.com"}],
@@ -92,7 +92,7 @@ HAS_SSP_NO_AUTHOR_DATA = {
 
 NOT_SSP_HAS_AUTHOR_DATA = {
     "author": [
-        {"system": "https://fhir.nhs.uk/Id/accredited-system-id", "value": "123"},
+        {"system": "https://fhir.nhs.uk/Id/nhsSpineASID", "value": "123"},
         {"system": "XXX", "value": "XYZ"},
     ],
     "content": [{"url": "http://foo.com"}, {"url": "http://foo.com"}],

--- a/layer/nrlf/nrlf/core/validators.py
+++ b/layer/nrlf/nrlf/core/validators.py
@@ -130,6 +130,10 @@ def json_loads(json_string):
     return json.loads(json_string, object_pairs_hook=dict_raise_on_duplicates)
 
 
+def json_load(json_file_obj):
+    return json.load(json_file_obj, object_pairs_hook=dict_raise_on_duplicates)
+
+
 def validate_producer_id(
     producer_id: str, custodian_id: str, custodian_suffix: str = None
 ):

--- a/layer/nrlf/nrlf/producer/fhir/r4/model.py
+++ b/layer/nrlf/nrlf/producer/fhir/r4/model.py
@@ -551,7 +551,7 @@ class DocumentReference(BaseModel):
         Optional[str],
         Field(
             description="The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-            regex="^(?=.{1,64}$)[A-Za-z0-9\\.]+-[A-Za-z0-9]+[A-Za-z0-9\\_\\-]*$",
+            regex="[A-Za-z0-9\\-\\.]{1,64}",
         ),
     ] = None
     meta: Annotated[

--- a/layer/nrlf/nrlf/producer/fhir/r4/tests/test_producer_nrlf_model.py
+++ b/layer/nrlf/nrlf/producer/fhir/r4/tests/test_producer_nrlf_model.py
@@ -1,10 +1,10 @@
-import json
 from copy import deepcopy
 from pathlib import Path
 
 import pydantic
 import pytest
 
+from nrlf.core.validators import json_load
 from nrlf.producer.fhir.r4.model import DocumentReference
 
 PATH_TO_TEST_DATA = Path(__file__).parent / "data"
@@ -15,7 +15,7 @@ def read_test_data(relative_path: str):
     with open(
         PATH_TO_TEST_DATA / relative_path / "documentreference-example.json"
     ) as f:
-        return json.load(f)
+        return json_load(f)
 
 
 @pytest.mark.parametrize("relative_path", TEST_DATA_RELATIVE_PATHS)

--- a/mi/stream_writer/index.py
+++ b/mi/stream_writer/index.py
@@ -1,0 +1,42 @@
+from typing import Union
+
+import boto3
+
+from mi.stream_writer.model import Environment, Outcome, Response, Status
+from mi.stream_writer.psycopg2 import connection, psycopg2
+
+
+def connect_to_database(**connect_kwargs) -> Union[connection, Response]:
+    try:
+        conn = psycopg2.connect(**connect_kwargs)
+        return conn
+    except Exception as err:
+        response = Response(
+            status=Status.ERROR, outcome=f"{err.__class__.__name__}: {err}"
+        )
+        return response
+
+
+def handler(event: dict, context=None):
+    # Parse and validate the event
+    environment = Environment.construct()
+    client = boto3.client("secretsmanager")
+    password = client.get_secret_value(SecretId=environment.POSTGRES_PASSWORD).get(
+        "SecretString"
+    )
+
+    conn = connect_to_database(
+        user=environment.POSTGRES_USERNAME,
+        password=password,
+        database=environment.POSTGRES_DATABASE_NAME,
+        host=environment.RDS_CLUSTER_HOST,
+        port=environment.RDS_CLUSTER_PORT,
+    )
+    if type(conn) is Response:
+        response = conn
+    else:
+        response = Response(status=Status.OK, outcome=Outcome.OPERATION_SUCCESSFUL)
+
+    rendered_response = response.dict(exclude_none=True)
+    print(rendered_response)  # noqa: T201
+    return rendered_response

--- a/mi/stream_writer/model.py
+++ b/mi/stream_writer/model.py
@@ -1,0 +1,31 @@
+import os
+from enum import Enum
+
+from pydantic import BaseModel
+
+
+class Status(str, Enum):
+    OK = "OK"
+    ERROR = "ERROR"
+
+
+class Outcome(str, Enum):
+    OPERATION_SUCCESSFUL = "Operation Successful"
+
+
+class Environment(BaseModel):
+    POSTGRES_DATABASE_NAME: str
+    RDS_CLUSTER_HOST: str
+    RDS_CLUSTER_PORT: int
+    POSTGRES_USERNAME: str
+    POSTGRES_PASSWORD: str
+
+    @classmethod
+    def construct(cls) -> "Environment":
+        return cls(**os.environ)
+
+
+class Response(BaseModel):
+    status: Status
+    outcome: str
+    results: list[tuple[object, ...]] = None

--- a/mi/stream_writer/psycopg2.py
+++ b/mi/stream_writer/psycopg2.py
@@ -1,0 +1,8 @@
+try:
+    import psycopg2
+    from psycopg2 import sql
+    from psycopg2._psycopg import connection
+except ModuleNotFoundError:
+    psycopg2 = None
+    sql = None
+    connection = None

--- a/mi/stream_writer/scripts/make.py
+++ b/mi/stream_writer/scripts/make.py
@@ -1,0 +1,4 @@
+from build_scripts.lambda_build import build
+
+if __name__ == "__main__":
+    build(__file__)

--- a/mi/stream_writer/scripts/make.sh
+++ b/mi/stream_writer/scripts/make.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+function _build() {
+    python make.py
+}
+
+function _clean() {
+    echo "Cleaning $(dirname "$(pwd)")"
+    rm -rf ../dist
+}
+
+command=$1
+
+case $command in
+    "build") _build ;;
+    "clean") _clean ;;
+    *) echo "Unhandled command ${command}" ;;
+esac

--- a/mi/stream_writer/tests/test_stream_writer_handler.py
+++ b/mi/stream_writer/tests/test_stream_writer_handler.py
@@ -1,0 +1,74 @@
+import json
+import os
+import string
+from unittest import mock
+
+from aws_lambda_powertools.utilities.parser.models import (
+    DynamoDBStreamChangedRecordModel,
+    DynamoDBStreamModel,
+    DynamoDBStreamRecordModel,
+)
+from hypothesis import given
+from hypothesis.strategies import builds, dictionaries, just, lists, text
+
+from mi.stream_writer.model import Environment
+from nrlf.core.validators import json_loads
+
+ASCII = list(string.ascii_lowercase + string.ascii_uppercase + string.digits)
+
+text_strategy = text(alphabet=ASCII, min_size=1)
+dict_strategy = dictionaries(keys=text_strategy, values=just("hi"))
+image_strategy = just({"custodian": {"S": "RJ11"}})
+keys_stategy = just({"sk": {"S": "D#RJ11#5"}})
+
+
+@mock.patch("mi.stream_writer.index.boto3")
+@mock.patch("mi.stream_writer.index.psycopg2")
+@given(
+    event=builds(
+        DynamoDBStreamModel,
+        Records=lists(
+            builds(
+                DynamoDBStreamRecordModel,
+                dynamodb=builds(
+                    DynamoDBStreamChangedRecordModel,
+                    NewImage=image_strategy,
+                    OldImage=image_strategy,
+                    Keys=keys_stategy,
+                ),
+            )
+        ),
+    ),
+    environment=builds(
+        Environment,
+        POSTGRES_DATABASE_NAME=text_strategy,
+        RDS_CLUSTER_HOST=text_strategy,
+        POSTGRES_PASSWORD=text_strategy,
+        POSTGRES_USERNAME=text_strategy,
+    ),
+)
+def test_handler_connection_fail(
+    event: DynamoDBStreamModel, environment: Environment, mocked_pg, mocked_boto3
+):
+    from mi.stream_writer.index import handler
+
+    class MyException(Exception):
+        pass
+
+    def _raise(*args, **kwargs):
+        raise MyException("raised!")
+
+    mocked_pg.connect.side_effect = _raise
+    mocked_boto3.client.return_value.get_secret_value.return_value = {
+        "SecretId": "oogly"  # pragma: allowlist secret
+    }
+
+    with mock.patch.dict(
+        os.environ, {k: str(v) for k, v in environment.dict().items()}, clear=True
+    ):
+        response = handler(event=event.dict())
+
+    assert json_loads(json.dumps(response)) == {
+        "status": "ERROR",
+        "outcome": "MyException: raised!",
+    }

--- a/nrlf.sh
+++ b/nrlf.sh
@@ -19,6 +19,8 @@ function _nrlf_commands_help() {
   echo "  make        - calls the make/build routines"
   echo "  doc         - publish documentation into confluence"
   echo "  oauth <env> - Generates an oauth token for the env [dev, ref, prod]"
+  echo "  firehose    - Commands for fixing failed Firehose events"
+  echo "  contracts   - Commands for syncing data contracts"
   echo "  swagger     - swagger generation commands"
   echo "  terraform   - terraform commands"
   echo "  test        - run tests"
@@ -50,6 +52,7 @@ function nrlf() {
     "truststore") _truststore "${@:2}" ;;
     "doc") _doc "${@:2}" ;;
     "firehose") _firehose "${@:2}" ;;
+    "contracts") python -m data_contracts.deploy_contracts.deploy_contracts "${@:2}" ;;
     "mi") _mi "${@:2}" ;;
     *) _nrlf_commands_help ;;
   esac

--- a/poetry.lock
+++ b/poetry.lock
@@ -2117,6 +2117,21 @@ docs = ["furo", "sphinx", "sphinx-copybutton", "sphinx-inline-tabs", "sphinx-not
 tests = ["pytest", "pytest-cov"]
 
 [[package]]
+name = "webcolors"
+version = "1.13"
+description = "A library for working with the color formats defined by HTML and CSS."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "webcolors-1.13-py3-none-any.whl", hash = "sha256:29bc7e8752c0a1bd4a1f03c14d6e6a72e93d82193738fa860cbff59d0fcc11bf"},
+    {file = "webcolors-1.13.tar.gz", hash = "sha256:c225b674c83fa923be93d235330ce0300373d02885cef23238813b0d5668304a"},
+]
+
+[package.extras]
+docs = ["furo", "sphinx", "sphinx-copybutton", "sphinx-inline-tabs", "sphinx-notfound-page", "sphinxext-opengraph"]
+tests = ["pytest", "pytest-cov"]
+
+[[package]]
 name = "werkzeug"
 version = "2.3.6"
 description = "The comprehensive WSGI web application library."

--- a/poetry.lock
+++ b/poetry.lock
@@ -1211,17 +1211,17 @@ url = "layer/nrlf"
 
 [[package]]
 name = "nrlf-converter"
-version = "0.0.7"
+version = "0.0.8"
 description = "NHS Clinicals Record Locator Document Pointer to HL7 FHIR R4 DocumentReference conversion"
 optional = false
 python-versions = ">=3.8,<4.0"
 files = [
-    {file = "nrlf_converter-0.0.7-py3-none-any.whl", hash = "sha256:f31daa3ffcf62b3a19b0347dd47b9ef5fbbd735fed40028d670fdb86935ed158"},
+    {file = "nrlf_converter-0.0.8-py3-none-any.whl", hash = "sha256:a636e273f7272406f00deb1a4492813537e23bf9e4da37883057768cbb52329c"},
 ]
 
 [package.source]
 type = "url"
-url = "https://github.com/NHSDigital/nrlf-converter/releases/download/0.0.7/nrlf_converter-0.0.7-py3-none-any.whl"
+url = "https://github.com/NHSDigital/nrlf-converter/releases/download/0.0.8/nrlf_converter-0.0.8-py3-none-any.whl"
 
 [[package]]
 name = "nrlf-lambda-pipeline"
@@ -2231,4 +2231,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "3c343dc7d8348bacd1aefc7474a103e4c12d5c0e08f0bf777f17895b7b2ff3b6"
+content-hash = "64d76e80e2b97e22a41b5e0954515a0aae2e9f455e546c60fe3ed173ec7a285d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ ez-setup = "^0.9"
 pygments = "^2.14.0"
 atlassian-python-api = "^3.39.0"
 hypothesis = "^6.81.2"
-nrlf-converter = {url = "https://github.com/NHSDigital/nrlf-converter/releases/download/0.0.7/nrlf_converter-0.0.7-py3-none-any.whl"}
+nrlf-converter = {url = "https://github.com/NHSDigital/nrlf-converter/releases/download/0.0.8/nrlf_converter-0.0.8-py3-none-any.whl"}
 
 [tool.poetry.group.legacy]
 optional = true

--- a/swagger/consumer-static/narrative.yaml
+++ b/swagger/consumer-static/narrative.yaml
@@ -141,8 +141,9 @@ info:
 
     | Environment       | Base URL                                                               |
     | ----------------- | ---------------------------------------------------------------------- |
-    | Sandbox           | `https://sandbox.api.service.nhs.uk/record-locator/consumer/FHIR/R4/`     |
-    | Integration test  | `https://int.api.service.nhs.uk/record-locator/consumer/FHIR/R4/`         |
+    | Sandbox           | `https://sandbox.api.service.nhs.uk/record-locator/consumer/FHIR/R4/`  |
+    | Integration test  | `https://int.api.service.nhs.uk/record-locator/consumer/FHIR/R4/`      |
+    | Production        | `https://api.service.nhs.uk/record-locator/consumer/FHIR/R4/`          |
 
     ### Sandbox testing
 

--- a/swagger/producer-static/narrative.yaml
+++ b/swagger/producer-static/narrative.yaml
@@ -131,8 +131,9 @@ info:
 
     | Environment       | Base URL                                                               |
     | ----------------- | ---------------------------------------------------------------------- |
-    | Sandbox           | `https://sandbox.api.service.nhs.uk/record-locator/producer/FHIR/R4/`     |
-    | Integration test  | `https://int.api.service.nhs.uk/record-locator/producer/FHIR/R4/`         |
+    | Sandbox           | `https://sandbox.api.service.nhs.uk/record-locator/producer/FHIR/R4/`  |
+    | Integration test  | `https://int.api.service.nhs.uk/record-locator/producer/FHIR/R4/`      |
+    | Production        | `https://api.service.nhs.uk/record-locator/producer/FHIR/R4/`          |
 
     ### Sandbox testing
 

--- a/terraform/account-wide-infrastructure/dev/rds-cluster-vpc.tf
+++ b/terraform/account-wide-infrastructure/dev/rds-cluster-vpc.tf
@@ -57,3 +57,30 @@ resource "aws_route_table_association" "private-dev" {
   subnet_id      = element(aws_subnet.private-subnet-dev, count.index).id
   route_table_id = aws_route_table.private-route-table-dev.id
 }
+
+#------------------------------------------------------------------------------
+# VPC endpoints
+#------------------------------------------------------------------------------
+
+resource "aws_vpc_endpoint" "secretsmanager" {
+  vpc_id              = aws_vpc.rds-cluster-vpc-dev.id
+  service_name        = "com.amazonaws.eu-west-2.secretsmanager"
+  subnet_ids          = aws_db_subnet_group.rds-cluster-subnet-group-dev.subnet_ids
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+
+  tags = {
+    Name        = "${local.project}-dev-secrets-vpc-endpoint"
+    Environment = local.environment
+  }
+}
+
+resource "aws_vpc_endpoint_security_group_association" "vpc_cluster_security_group_assoc" {
+  vpc_endpoint_id   = aws_vpc_endpoint.secretsmanager.id
+  security_group_id = aws_security_group.rds-cluster-sg-dev.id
+
+  tags = {
+    Name        = "${local.project}-dev-sg-association"
+    Environment = local.environment
+  }
+}

--- a/terraform/account-wide-infrastructure/dev/rds-cluster-vpc.tf
+++ b/terraform/account-wide-infrastructure/dev/rds-cluster-vpc.tf
@@ -78,9 +78,4 @@ resource "aws_vpc_endpoint" "secretsmanager" {
 resource "aws_vpc_endpoint_security_group_association" "vpc_cluster_security_group_assoc" {
   vpc_endpoint_id   = aws_vpc_endpoint.secretsmanager.id
   security_group_id = aws_security_group.rds-cluster-sg-dev.id
-
-  tags = {
-    Name        = "${local.project}-dev-sg-association"
-    Environment = local.environment
-  }
 }

--- a/terraform/account-wide-infrastructure/dev/security-groups.tf
+++ b/terraform/account-wide-infrastructure/dev/security-groups.tf
@@ -15,9 +15,25 @@ resource "aws_security_group" "rds-cluster-sg-dev" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  #SecretsManager vpc endpoint port
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   egress {
     from_port   = 5432
     to_port     = 5432
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  #SecretsManager vpc endpoint port
+  egress {
+    from_port   = 443
+    to_port     = 443
     protocol    = "TCP"
     cidr_blocks = ["0.0.0.0/0"]
   }

--- a/terraform/account-wide-infrastructure/prod/rds-cluster-vpc.tf
+++ b/terraform/account-wide-infrastructure/prod/rds-cluster-vpc.tf
@@ -78,9 +78,4 @@ resource "aws_vpc_endpoint" "secretsmanager" {
 resource "aws_vpc_endpoint_security_group_association" "vpc_cluster_security_group_assoc" {
   vpc_endpoint_id   = aws_vpc_endpoint.secretsmanager.id
   security_group_id = aws_security_group.rds-cluster-sg-prod.id
-
-  tags = {
-    Name        = "${local.project}-prod-sg-association"
-    Environment = local.environment
-  }
 }

--- a/terraform/account-wide-infrastructure/prod/rds-cluster-vpc.tf
+++ b/terraform/account-wide-infrastructure/prod/rds-cluster-vpc.tf
@@ -57,3 +57,30 @@ resource "aws_route_table_association" "private-prod" {
   subnet_id      = element(aws_subnet.private-subnet-prod, count.index).id
   route_table_id = aws_route_table.private-route-table-prod.id
 }
+
+#------------------------------------------------------------------------------
+# VPC endpoints
+#------------------------------------------------------------------------------
+
+resource "aws_vpc_endpoint" "secretsmanager" {
+  vpc_id              = aws_vpc.rds-cluster-vpc-prod.id
+  service_name        = "com.amazonaws.eu-west-2.secretsmanager"
+  subnet_ids          = aws_db_subnet_group.rds-cluster-subnet-group-prod.subnet_ids
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+
+  tags = {
+    Name        = "${local.project}-prod-secrets-vpc-endpoint"
+    Environment = local.environment
+  }
+}
+
+resource "aws_vpc_endpoint_security_group_association" "vpc_cluster_security_group_assoc" {
+  vpc_endpoint_id   = aws_vpc_endpoint.secretsmanager.id
+  security_group_id = aws_security_group.rds-cluster-sg-prod.id
+
+  tags = {
+    Name        = "${local.project}-prod-sg-association"
+    Environment = local.environment
+  }
+}

--- a/terraform/account-wide-infrastructure/prod/security-groups.tf
+++ b/terraform/account-wide-infrastructure/prod/security-groups.tf
@@ -22,6 +22,22 @@ resource "aws_security_group" "rds-cluster-sg-prod" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  #SecretsManager vpc endpoint port
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  #SecretsManager vpc endpoint port
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   tags = {
     Name        = "nhsd-nrlf-rds-cluster-sg-prod"
     Environment = "prod"

--- a/terraform/account-wide-infrastructure/test/rds-cluster-vpc.tf
+++ b/terraform/account-wide-infrastructure/test/rds-cluster-vpc.tf
@@ -107,7 +107,7 @@ resource "aws_route_table_association" "private-int" {
 # VPC endpoints
 #------------------------------------------------------------------------------
 
-resource "aws_vpc_endpoint" "secretsmanager" {
+resource "aws_vpc_endpoint" "secretsmanager-ref" {
   vpc_id              = aws_vpc.rds-cluster-vpc-ref.id
   service_name        = "com.amazonaws.eu-west-2.secretsmanager"
   subnet_ids          = aws_db_subnet_group.rds-cluster-subnet-group-ref.subnet_ids
@@ -120,14 +120,9 @@ resource "aws_vpc_endpoint" "secretsmanager" {
   }
 }
 
-resource "aws_vpc_endpoint_security_group_association" "vpc_cluster_security_group_assoc" {
-  vpc_endpoint_id   = aws_vpc_endpoint.secretsmanager.id
+resource "aws_vpc_endpoint_security_group_association" "vpc_cluster_security_group_assoc-ref" {
+  vpc_endpoint_id   = aws_vpc_endpoint.secretsmanager-ref.id
   security_group_id = aws_security_group.rds-cluster-sg-ref.id
-
-  tags = {
-    Name        = "${local.project}-ref-sg-association"
-    Environment = local.environment
-  }
 }
 
 resource "aws_vpc_endpoint" "secretsmanager" {
@@ -146,9 +141,4 @@ resource "aws_vpc_endpoint" "secretsmanager" {
 resource "aws_vpc_endpoint_security_group_association" "vpc_cluster_security_group_assoc" {
   vpc_endpoint_id   = aws_vpc_endpoint.secretsmanager.id
   security_group_id = aws_security_group.rds-cluster-sg-int.id
-
-  tags = {
-    Name        = "${local.project}-int-sg-association"
-    Environment = local.environment
-  }
 }

--- a/terraform/account-wide-infrastructure/test/rds-cluster-vpc.tf
+++ b/terraform/account-wide-infrastructure/test/rds-cluster-vpc.tf
@@ -102,3 +102,53 @@ resource "aws_route_table_association" "private-int" {
   subnet_id      = element(aws_subnet.private-subnet-int, count.index).id
   route_table_id = aws_route_table.private-route-table-int.id
 }
+
+#------------------------------------------------------------------------------
+# VPC endpoints
+#------------------------------------------------------------------------------
+
+resource "aws_vpc_endpoint" "secretsmanager" {
+  vpc_id              = aws_vpc.rds-cluster-vpc-ref.id
+  service_name        = "com.amazonaws.eu-west-2.secretsmanager"
+  subnet_ids          = aws_db_subnet_group.rds-cluster-subnet-group-ref.subnet_ids
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+
+  tags = {
+    Name        = "${local.project}-ref-secrets-vpc-endpoint"
+    Environment = local.environment
+  }
+}
+
+resource "aws_vpc_endpoint_security_group_association" "vpc_cluster_security_group_assoc" {
+  vpc_endpoint_id   = aws_vpc_endpoint.secretsmanager.id
+  security_group_id = aws_security_group.rds-cluster-sg-ref.id
+
+  tags = {
+    Name        = "${local.project}-ref-sg-association"
+    Environment = local.environment
+  }
+}
+
+resource "aws_vpc_endpoint" "secretsmanager" {
+  vpc_id              = aws_vpc.rds-cluster-vpc-int.id
+  service_name        = "com.amazonaws.eu-west-2.secretsmanager"
+  subnet_ids          = aws_db_subnet_group.rds-cluster-subnet-group-int.subnet_ids
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+
+  tags = {
+    Name        = "${local.project}-int-secrets-vpc-endpoint"
+    Environment = local.environment
+  }
+}
+
+resource "aws_vpc_endpoint_security_group_association" "vpc_cluster_security_group_assoc" {
+  vpc_endpoint_id   = aws_vpc_endpoint.secretsmanager.id
+  security_group_id = aws_security_group.rds-cluster-sg-int.id
+
+  tags = {
+    Name        = "${local.project}-int-sg-association"
+    Environment = local.environment
+  }
+}

--- a/terraform/account-wide-infrastructure/test/security-groups.tf
+++ b/terraform/account-wide-infrastructure/test/security-groups.tf
@@ -22,6 +22,22 @@ resource "aws_security_group" "rds-cluster-sg-ref" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  #SecretsManager vpc endpoint port
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  #SecretsManager vpc endpoint port
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   tags = {
     Name        = "nhsd-nrlf-rds-cluster-sg-ref"
     Environment = "ref"
@@ -43,6 +59,22 @@ resource "aws_security_group" "rds-cluster-sg-int" {
   egress {
     from_port   = 5432
     to_port     = 5432
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  #SecretsManager vpc endpoint port
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  #SecretsManager vpc endpoint port
+  egress {
+    from_port   = 443
+    to_port     = 443
     protocol    = "TCP"
     cidr_blocks = ["0.0.0.0/0"]
   }

--- a/terraform/infrastructure/dynamodb__document-pointer.tf
+++ b/terraform/infrastructure/dynamodb__document-pointer.tf
@@ -8,6 +8,8 @@ resource "aws_dynamodb_table" "document-pointer" {
   hash_key                    = "pk"
   range_key                   = "sk"
   deletion_protection_enabled = local.deletion_protection
+  stream_enabled              = true
+  stream_view_type            = "NEW_IMAGE"
 
   attribute {
     name = "pk"

--- a/terraform/infrastructure/kms.tf
+++ b/terraform/infrastructure/kms.tf
@@ -4,3 +4,10 @@ module "kms__cloudwatch" {
   assume_account = var.assume_account
   prefix         = local.prefix
 }
+
+data "aws_kms_key" "document-pointer-kms" {
+  key_id = "alias/${local.prefix}--document-pointer"
+  depends_on = [
+    aws_dynamodb_table.document-pointer
+  ]
+}

--- a/terraform/infrastructure/modules/postgres_cluster/dynamodb.tf
+++ b/terraform/infrastructure/modules/postgres_cluster/dynamodb.tf
@@ -1,0 +1,5 @@
+resource "aws_lambda_event_source_mapping" "dynamodb-stream-source" {
+  event_source_arn  = var.dynamodb_table.stream_arn
+  function_name     = module.rds-cluster-stream-writer.arn
+  starting_position = "LATEST"
+}

--- a/terraform/infrastructure/modules/postgres_cluster/lambda.tf
+++ b/terraform/infrastructure/modules/postgres_cluster/lambda.tf
@@ -21,3 +21,73 @@ module "rds-cluster-sql-query-lambda" {
     security_group_ids = [data.aws_security_group.rds-cluster-vpc-security-group.id]
   }
 }
+
+module "rds-cluster-stream-writer" {
+  source      = "../lambda"
+  parent_path = var.name
+  name        = "stream_writer"
+  region      = var.region
+  prefix      = var.prefix
+  kms_key_id  = var.cloudwatch_kms_arn
+  environment_variables = {
+    POSTGRES_DATABASE_NAME = var.environment
+    RDS_CLUSTER_HOST       = data.aws_rds_cluster.rds-cluster.reader_endpoint
+    RDS_CLUSTER_PORT       = data.aws_rds_cluster.rds-cluster.port
+    POSTGRES_USERNAME      = "${var.environment}-write"
+    POSTGRES_PASSWORD      = aws_secretsmanager_secret.write_password.arn
+  }
+  layers = concat(var.layers, [module.psycopg2.layer_arn])
+  additional_policies = [
+    "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
+    aws_iam_policy.stream-writer-lambda.arn
+  ]
+  handler = "${var.name}.stream_writer.index.handler"
+  depends_on = [
+    data.aws_rds_cluster.rds-cluster,
+    aws_iam_policy.stream-writer-lambda
+  ]
+  vpc = {
+    subnet_ids         = data.aws_subnets.rds-cluster-vpc-private-subnets.ids
+    security_group_ids = [data.aws_security_group.rds-cluster-vpc-security-group.id]
+  }
+}
+
+resource "aws_iam_policy" "stream-writer-lambda" {
+  name        = "${var.prefix}-stream-writer-lambda"
+  description = "Read write password from secretsmanager"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ]
+        Effect = "Allow"
+        Resource = [
+          aws_secretsmanager_secret.write_password.arn
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:DescribeStream",
+          "dynamodb:GetRecords",
+          "dynamodb:GetShardIterator",
+          "dynamodb:ListStreams"
+        ],
+        Resource = [
+          var.dynamodb_table.stream_arn
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt"
+        ],
+        Resource = [
+          var.dynamodb_table_kms_key_arn
+        ]
+      }
+    ]
+  })
+}

--- a/terraform/infrastructure/modules/postgres_cluster/vars.tf
+++ b/terraform/infrastructure/modules/postgres_cluster/vars.tf
@@ -8,3 +8,5 @@ variable "layers" {}
 variable "schema_path" {}
 variable "static_dimensions_path" {}
 variable "assume_account" {}
+variable "dynamodb_table" {}
+variable "dynamodb_table_kms_key_arn" {}

--- a/terraform/infrastructure/postgres_cluster.tf
+++ b/terraform/infrastructure/postgres_cluster.tf
@@ -1,13 +1,15 @@
 module "mi" {
-  source                 = "./modules/postgres_cluster"
-  schema_path            = "../../mi/schema/schema.sql"
-  static_dimensions_path = "../../mi/schema/static_dimensions.sql"
-  name                   = "mi"
-  prefix                 = local.prefix
-  environment            = local.environment
-  region                 = local.region
-  cloudwatch_kms_arn     = module.kms__cloudwatch.kms_arn
-  account_name           = local.account_name
-  layers                 = [module.third_party.layer_arn]
-  assume_account         = var.assume_account
+  source                     = "./modules/postgres_cluster"
+  schema_path                = "../../mi/schema/schema.sql"
+  static_dimensions_path     = "../../mi/schema/static_dimensions.sql"
+  name                       = "mi"
+  prefix                     = local.prefix
+  environment                = local.environment
+  region                     = local.region
+  cloudwatch_kms_arn         = module.kms__cloudwatch.kms_arn
+  account_name               = local.account_name
+  layers                     = [module.third_party.layer_arn]
+  assume_account             = var.assume_account
+  dynamodb_table             = aws_dynamodb_table.document-pointer
+  dynamodb_table_kms_key_arn = data.aws_kms_key.document-pointer-kms.arn
 }

--- a/terraform/infrastructure/tests/test_dynamodb_encryption.py
+++ b/terraform/infrastructure/tests/test_dynamodb_encryption.py
@@ -1,9 +1,10 @@
-import json
 from datetime import datetime
 from pathlib import Path
 
 import boto3
 import pytest
+
+from nrlf.core.validators import json_load
 
 LIMIT = 100
 ENABLED = "ENABLED"
@@ -31,7 +32,7 @@ def _get_access_token(account_id: str) -> dict[str:str]:
 
 def _get_aws_account_id():
     with open(PATH_TO_OUTPUT) as f:
-        tf_output = json.load(f)
+        tf_output = json_load(f)
     return tf_output["assume_account_id"]["value"]
 
 
@@ -45,7 +46,7 @@ def aws_session() -> boto3.Session:
 @pytest.fixture
 def workspace():
     with open(PATH_TO_OUTPUT) as f:
-        tf_output = json.load(f)
+        tf_output = json_load(f)
     return tf_output["workspace"]["value"]
 
 


### PR DESCRIPTION
- NRLF-533 - 409 Conflict error not thrown on duplicate supersede request
- NRLF-585 - Add Live URLs to API Catalogue
- NRLF-652 - Producer MI - Add infrastructure for dynamodb streams
- NRLF-561 - Build an ASID specific document contract
- NRLF-634 - Helper script to create Data Contracts
- NRLF-642 - Update converter to v0.0.8 in NRLF repository
- NRLF-652 - Fix forward: Remove tags from security groups associations
- NRLF-561 - Fix forward: Fix ASID url
- NRLF-634 - Fix forward: Fix intermittent deploy contract test
- NRLF-494 - Fix forward: Revert changes introduced by NRLF-494, due to being too restrictive for converter