### PR TITLE
[NRL-578] Add initial top-level Makefile and helper scripts. Update README with Makefile usage

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -4,5 +4,5 @@ jq latest
 python 3.9.15
 terraform 1.3.4
 java zulu-jre-17.42.19
-yq latest
-allure latest
+yq 4.42.1
+allure 2.27.0

--- a/Makefile
+++ b/Makefile
@@ -76,5 +76,6 @@ lint: check-warn ## Lint the project
 	$(PRECOMMIT) run --all-files
 
 clean: ## Remove all generated and temporary files
-	rm -rf $(DIST_PATH)/*.zip
-	rmdir $(DIST_PATH) 2>/dev/null || true
+	[ -n "$(DIST_PATH)" ] && \
+		rm -rf $(DIST_PATH)/*.zip && \
+		rmdir $(DIST_PATH) 2>/dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,80 @@
+
+.EXPORT_ALL_VARIABLES:
+.NOTPARALLEL:
+.ONESHELL:
+.PHONY: *
+
+MAKEFLAGS := --no-print-directory
+SHELL := /bin/bash
+
+# TODO - Fix venv path issues
+PYTEST ?= .venv/bin/pytest
+BEHAVE ?= .venv/bin/behave
+PRECOMMIT ?= .venv/bin/pre-commit
+
+DIST_PATH ?= ./dist
+TEST_ARGS ?=
+FEATURE_TEST_ARGS ?= ./feature_tests
+
+default: build
+
+help: ## Show this help message
+	@echo "Usage: make [target]"
+	@echo
+	@echo "where [target] can be:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+asdf-install: ## Install the required tools via ASDF
+	@cat .tool-versions | while read tool_version; do \
+		tool="$${tool_version% *}"; \
+		asdf plugin add "$${tool}"; \
+	done
+	asdf install
+
+configure: check-warn ## Configure this project repo
+	cp scripts/commit-msg.py .git/hooks/prepare-commit-msg && chmod ug+x .git/hooks/*
+
+check: # Check the build environment is setup correctly
+	@./scripts/check-build-environment.sh
+
+check-warn:
+	@SHOULD_WARN_ONLY=true ./scripts/check-build-environment.sh
+
+build: check-warn build-api-packages ## Build the project
+
+build-api-packages: ./api/consumer/* ./api/producer/*
+	@echo "Building API packages"
+	@mkdir -p $(DIST_PATH)
+	for api in $^; do \
+		[ ! -d "$$api" ] && continue; \
+		./scripts/build-lambda-package.sh $${api} $(DIST_PATH); \
+	done
+
+test: check-warn ## Run the unit tests
+	@echo "Running unit tests"
+	$(PYTEST) -m "not integration and not legacy and not smoke" --ignore=mi $(TEST_ARGS)
+
+test-integration: check-warn ## Run the integration tests
+	@echo "Running integration tests"
+	$(PYTEST) -m "integration and not firehose" $(TEST_ARGS)
+
+test-firehose-integration: check-warn ## Run the firehose integration tests
+	@echo "Running firehose integration tests"
+	$(PYTEST) -m "integration and firehose" --runslow $(TEST_ARGS)
+
+test-features: check-warn ## Run the BDD feature tests locally
+	@echo "Running feature tests locally"
+	$(BEHAVE) $(FEATURE_TEST_ARGS)
+
+test-features-integration: check-warn ## Run the BDD feature tests in the integration environment
+	@echo "Running feature tests in the integration environment"
+	$(BEHAVE) --define="integration_test=true" $(FEATURE_TEST_ARGS)
+	allure generate ./allure-results -o ./allure-report --clean
+	allure open ./allure-report
+
+lint: check-warn ## Lint the project
+	$(PRECOMMIT) run --all-files
+
+clean: ## Remove all generated and temporary files
+	rm -rf $(DIST_PATH)/*.zip
+	rmdir $(DIST_PATH) 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Before you tackle this guide, there are some more instructions here on the [Deve
 For an easy way to make sure your local system matches the requirements needed you can use `asdf tool manager`. This tool fetches the required versions of the libraries needed and sets the directory to use that version instead of your system's default version. To get it up and running,
 
 - Install `asdf` using the instructions given here. https://asdf-vm.com/guide/getting-started.html. You can check it installed properly by using the command `asdf --version`
-- Install the dependencies using the `nrlf-dependencies.sh` bash script. `bash nrlf-dependencies.sh`
+- Install the dependencies using: `$ make asdf-install`
 - You should be good to go.
 
 #### 2. If you prefer to get your local machine running manually the requirements are...
@@ -146,7 +146,9 @@ If you wish to use the official guidance, links are below:
 
    These commands should display the PowerShell version and list the installed WSL distributions.
 
-### 3. Linux set up
+### 3. Manually setting up Linux
+
+If you're on Linux/WSL and using ASDF, you can skip these steps.
 
 For those on a linux/WSL setup these are some helpful instructions:
 
@@ -274,7 +276,7 @@ At the root of the repo, run:
 ```shell
 poetry install
 poetry shell
-pre-commit install
+make configure
 ```
 
 NOTE
@@ -286,9 +288,69 @@ NOTE
 
 ---
 
-## Quick Run
+## Getting Started
 
-For those wanting to get up and running quickly can follow this list of instructions which by the end will have given you your own workspace with the current version of NRLF running - you can find more information on steps below this section.
+To build packages:
+
+```
+$ make
+```
+
+To run the linters over your changes:
+
+```
+$ make lint
+```
+
+To run the unit tests:
+
+```
+$ make test
+```
+
+To run the local feature tests:
+
+```
+$ make test-features
+```
+
+### Troubleshooting
+
+To check your environment:
+
+```
+$ make check
+```
+
+this will provide a report of the dependencies in your environment and should highlight the things that are not configured correctly or things that are missing.
+
+### Integration testing
+
+For the integration tests, you need to have deployed your infrastructure (using Terraform).
+
+To run integration tests:
+
+```
+$ make test-integration
+```
+
+To run the Firehose integration tests:
+
+```
+$ make test-firehose-integration
+```
+
+To run the feature integration tests:
+
+```
+$ make test-features-integration
+```
+
+## Quick Run using `nrlf` script
+
+Those using the `nrlf` script and wanting to get up and running quickly can follow this list of instructions which by the end will have given you your own workspace with the current version of NRLF running - you can find more information on steps below this section.
+
+Note that we're trying to phase out the `nrlf` script in favour of using tools like Terraform directly and having a top-level Makefile and `scripts/` scripts to do more complex build/dev actions.
 
 ```shell
 poetry shell
@@ -306,7 +368,7 @@ nrlf terraform destroy <yourname>-test
 
 ---
 
-## Initialise shell environment
+## Initialise shell environment for the `nrlf` script
 
 ```shell
 poetry shell
@@ -333,7 +395,7 @@ The env options are `dev, mgmt, test and prod`
 
 This reads the `~/.aws/config` file. You will need to ensure the config file is setup correctly - see [Developer Onboarding](https://nhsd-confluence.digital.nhs.uk/display/CLP/NRLF+-+Developer+Onboarding).
 
-## Build, Test & Run the API
+## Build, Test & Run the API using the `nrlf` script
 
 Now we have installed the dependencies we're going to need to get the software up and running.
 

--- a/nrlf.sh
+++ b/nrlf.sh
@@ -3,7 +3,7 @@
 export PIPENV_VENV_IN_PROJECT=1
 root=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
 
-for script_file in "$root"/scripts/*.sh; do
+for script_file in "$root"/scripts/_*.sh; do
   source $script_file
 done
 

--- a/scripts/build-lambda-package.sh
+++ b/scripts/build-lambda-package.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Build a lambda package
+#
+set -o errexit -o pipefail -o nounset
+
+api_src_path="$1"
+dist_path="$(pwd)/$2"
+
+package_name="$(basename $api_src_path)"
+
+cd "${api_src_path}" && \
+    zip -q -r "${dist_path}/${package_name}.zip" . \
+        -x tests**\* scripts**\* **__pycache__**\*
+
+echo "✅ Package created: ${dist_path}/${package_name}.zip"

--- a/scripts/check-build-environment.sh
+++ b/scripts/check-build-environment.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Check that the build environment is set up correctly, and warn about issues
+#
+set -o errexit -o pipefail -o nounset
+
+: "${SHOULD_WARN_ONLY:="false"}"
+
+function success() {
+  [ "${SHOULD_WARN_ONLY}" == "true" ] && return
+
+  local message="$1"
+  echo "  ✅  ${message}"
+}
+
+function warning() {
+  local message="$1"
+  echo -e "  ⚠️  \e[31m${message}\e[39m"
+}
+
+echo
+echo "Checking build environment...."
+
+BUILD_DEPENDENCIES="
+    allure
+    behave
+    jq
+    poetry
+    pre-commit
+    pytest
+    python
+    terraform
+    tfenv
+    yq
+    zip
+"
+
+for dep in ${BUILD_DEPENDENCIES}; do
+    set +e
+        dep_path="$(which ${dep} 2> /dev/null)"
+    set -e
+
+    if [ -n "${dep_path}" -a -x "${dep_path}" ]
+    then
+        success "${dep} found at ${dep_path}"
+    else
+        warning "${dep} not found ${dep_path}"
+    fi
+done
+
+if [ "${POETRY_ACTIVE:=0}" != "1" ];
+then
+    warning "Poetry is not active. Run 'poetry shell' to activate it."
+else
+    success "Poetry is active"
+fi


### PR DESCRIPTION
Hopefully this simplifies the env setup, build and tests a little, please shout if you have any comments/suggestions or things that aren't super clear or aren't working.

Notes:
- Added a new top-level Makefile to replace the setup+build+test targets from the nrlf scripts
- Updated README with details of how to use it
- I've preserved the `nrlf` script and docs as-is, we can clean these up once we're happy with the new build stuff