### PR TITLE
NRL-633 Persistent Environments for Pull Requests

### DIFF
--- a/.github/workflows/pr-env-create-update.yml
+++ b/.github/workflows/pr-env-create-update.yml
@@ -1,5 +1,5 @@
 name: Create PR Environment
-run-name: "${{ github.event.action == 'synchronize ' && 'Update' || 'Create' }} PR Environment - #${{ github.event.pull_request.number }} (${{ github.event.pull_request.title }})"
+run-name: "${{ github.event.action == 'synchronize' && 'Update' || 'Create' }} PR Environment - #${{ github.event.pull_request.number }} (${{ github.event.pull_request.title }})"
 
 on:
   pull_request:

--- a/.github/workflows/pr-env-create-update.yml
+++ b/.github/workflows/pr-env-create-update.yml
@@ -12,6 +12,7 @@ permissions:
   id-token: write
   contents: read
   actions: write
+  issues: write
 
 jobs:
   set-environment-id:
@@ -152,9 +153,9 @@ jobs:
           name: terraform-outputs
           path: terraform/infrastructure/output.json
 
-      - name: Add Failure Pull Request Comment
+      - name: Add Failure Pull Request Comment - Create
         uses: actions/github-script@v7
-        if: ${{ success() }}
+        if: ${{ success() && github.event.action != 'synchronize' }}
         with:
           script: |
             github.rest.issues.createComment({
@@ -164,9 +165,9 @@ jobs:
               body: "🚀 PR environment successfully created.\nURL: ${{ needs.set-environment-id.outputs.environment_id }}.api.record-locator.dev.national.nhs.uk"
             })
 
-      - name: Add Failure Pull Request Comment
+      - name: Add Failure Pull Request Comment - Create
         uses: actions/github-script@v7
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event.action != 'synchronize'  }}
         with:
           script: |
             github.rest.issues.createComment({
@@ -174,6 +175,30 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `💥 Something went wrong while deploying the pull request environment.\n[Check Output Logs](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
+            })
+
+      - name: Add Failure Pull Request Comment - Update
+        uses: actions/github-script@v7
+        if: ${{ success() && github.event.action == 'synchronize' }}
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "🚀 PR environment successfully updated to commit `${{ github.event.pull_request.head.sha }}`."
+            })
+
+      - name: Add Failure Pull Request Comment - Update
+        uses: actions/github-script@v7
+        if: ${{ failure() && github.event.action == 'synchronize'  }}
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `💥 Something went wrong while updating the pull request environment.\n[Check Output Logs](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
             })
 
   integration-test:

--- a/.github/workflows/pr-env-create-update.yml
+++ b/.github/workflows/pr-env-create-update.yml
@@ -1,5 +1,5 @@
 name: Create PR Environment
-run-name: ${{ github.event_path }} Create PR Environment - \#${{ github.event.pull_request.id }} (${{ github.event.pull_request.title }} )
+run-name: ${{ github.event.action == 'synchronize ' && 'Update' || 'Create' }} PR Environment - \#${{ github.event.pull_request.id }} (${{ github.event.pull_request.title }} )
 
 on:
   pull_request:

--- a/.github/workflows/pr-env-create-update.yml
+++ b/.github/workflows/pr-env-create-update.yml
@@ -1,6 +1,9 @@
-name: CI
+name: Create PR Environment
+run-name: ${{ github.event_path }} Create PR Environment - \#${{ github.event.pull_request.id }} (${{ github.event.pull_request.title }} )
 
-on: pull_request
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 permissions:
   id-token: write
@@ -8,21 +11,15 @@ permissions:
   actions: write
 
 jobs:
-  set-uniquish-id:
-    # Set a uniquish ID - good enough for our purposes since it must be close enough to unique for
-    # a) Terraform / AWS to allow clean build/destroys without side-effects (e.g. we don't
-    #    want resources marked for deletion to be recreated in another CI run)
-    # b) Not to fall foul of character limits on AWS resource names: the ID must be short
-    name: Set Unique Environment ID
+  set-environment-id:
+    name: Set Environment ID
     runs-on: [self-hosted, ci]
     steps:
-      - name: Set a uniquish ID
-        id: set_uniqish_id
-        run: |
-          TIME_IN_SECONDS_SINCE_MIDNIGHT=$(date -d "1970-01-01 UTC $(date +%T)" +%s)
-          echo "uniqish_id=${GITHUB_SHA::7}-${TIME_IN_SECONDS_SINCE_MIDNIGHT}" >> $GITHUB_OUTPUT
+      - name: Set a ID based on the branch name
+        id: set_environment_id
+        run: echo "environment_id=$(echo '${{ github.ref }}' | sed 's/refs\/heads\///' | sed 's/feature\///')" > $GITHUB_OUTPUT
     outputs:
-      uniqish_id: ${{ steps.set_uniqish_id.outputs.uniqish_id }}
+      environment_id: ${{ steps.set_environment_id.outputs.environment_id }}
 
   build:
     name: Build Application
@@ -67,10 +64,24 @@ jobs:
           name: build-artifacts
           path: dist/*.zip
 
+      - name: Add Failure Pull Request Comment
+        uses: actions/github-script@v7
+        if: ${{ failure() }}
+        with:
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `💥 Something went wrong while building the pull request environment.\n[Check Output Logs](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
+            })
+
   deploy:
     name: Deploy CI Environment
     runs-on: [self-hosted, ci]
-    needs: [set-uniquish-id, build]
+    needs: [set-environment-id, build]
+    concurrency:
+      group: terraform-${{ github.ref_name }}
     steps:
       - name: Git Clone - ${{ github.event.pull_request.head.ref }}
         uses: actions/checkout@v4
@@ -99,7 +110,7 @@ jobs:
         with:
           aws-region: eu-west-2
           role-to-assume: ${{ secrets.CI_ROLE_NAME }}
-          role-session-name: github-actions-ci-${{ needs.set-uniquish-id.outputs.uniqish_id }}
+          role-session-name: github-actions-ci-${{ needs.set-environment-id.outputs.environment_id }}
 
       - name: Retrieve Server Certificates
         run: aws s3 cp s3://nhsd-nrlf--truststore/server/dev.pem truststore/server/dev.pem
@@ -111,8 +122,8 @@ jobs:
       - name: Terraform Init
         run: |
           terraform -chdir=terraform/infrastructure init
-          terraform -chdir=terraform/infrastructure workspace new ci-${{ needs.set-uniquish-id.outputs.uniqish_id }} || \
-          terraform -chdir=terraform/infrastructure workspace select ci-${{ needs.set-uniquish-id.outputs.uniqish_id }}
+          terraform -chdir=terraform/infrastructure workspace new ${{ needs.set-environment-id.outputs.environment_id }} || \
+          terraform -chdir=terraform/infrastructure workspace select ${{ needs.set-environment-id.outputs.environment_id }}
 
       - name: Terraform Plan
         run: |
@@ -129,6 +140,7 @@ jobs:
           path: terraform/infrastructure/tfplan*
 
       - name: Terraform Apply
+        id: terraform-apply
         run: |
           terraform -chdir=terraform/infrastructure apply tfplan
 
@@ -137,11 +149,37 @@ jobs:
         with:
           name: terraform-outputs
           path: terraform/infrastructure/output.json
+      
+      - name: Add Failure Pull Request Comment
+        uses: actions/github-script@v7
+        if: ${{ success() }}
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "🚀 PR environment successfully created.\nURL: ${{ needs.set-environment-id.outputs.environment_id }}.api.record-locator.dev.national.nhs.uk"
+            })
+
+      - name: Add Failure Pull Request Comment
+        uses: actions/github-script@v7
+        if: ${{ failure() }}
+        with:
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `💥 Something went wrong while deploying the pull request environment.\n[Check Output Logs](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
+            })
 
   integration-test:
     name: Run Integration Tests
-    needs: [set-uniquish-id, deploy]
+    needs: [set-environment-id, deploy]
     runs-on: [self-hosted, ci]
+    concurrency:
+      group: integrationtest-${{ github.ref_name }}
 
     steps:
       - name: Git Clone - ${{ github.event.pull_request.head.ref }}
@@ -168,7 +206,7 @@ jobs:
         with:
           aws-region: eu-west-2
           role-to-assume: ${{ secrets.CI_ROLE_NAME }}
-          role-session-name: github-actions-ci-${{ needs.set-uniquish-id.outputs.uniqish_id }}
+          role-session-name: github-actions-ci-${{ needs.set-environment-id.outputs.environment_id }}
 
       - name: Retrieve Client Certificates
         run: |
@@ -182,13 +220,13 @@ jobs:
       - name: Configure Dev Account Credentials
         id: configure-dev-account-credentials
         run: |
-          aws_credentials=$(aws sts assume-role --role-arn arn:aws:iam::${{ steps.get_account_id.outputs.aws_account_id }}:role/terraform --role-session-name github-actions-ci-${{ needs.set-uniquish-id.outputs.uniqish_id }} --output json)
+          aws_credentials=$(aws sts assume-role --role-arn arn:aws:iam::${{ steps.get_account_id.outputs.aws_account_id }}:role/terraform --role-session-name github-actions-ci-${{ needs.set-environment-id.outputs.environment_id }} --output json)
           echo "aws_access_key_id=$(echo $aws_credentials | jq -r '.Credentials.AccessKeyId')" >> "$GITHUB_OUTPUT"
           echo "aws_secret_access_key=$(echo $aws_credentials | jq -r '.Credentials.SecretAccessKey')" >> "$GITHUB_OUTPUT"
           echo "aws_session_token=$(echo $aws_credentials | jq -r '.Credentials.SessionToken')" >> "$GITHUB_OUTPUT"
 
       - name: Run Integration Tests
-        run: make test-features-integration TF_WORKSPACE=ci-${{ needs.set-uniquish-id.outputs.uniqish_id }}
+        run: make test-features-integration TF_WORKSPACE=${{ needs.set-environment-id.outputs.environment_id }}
         env:
           AWS_ACCESS_KEY_ID: ${{ steps.configure-dev-account-credentials.outputs.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.configure-dev-account-credentials.outputs.aws_secret_access_key }}
@@ -196,8 +234,10 @@ jobs:
 
   performance-test:
     name: Run Performance Tests
-    needs: [set-uniquish-id, integration-test]
+    needs: [set-environment-id, integration-test]
     runs-on: [self-hosted, ci]
+    concurrency:
+      group: performancetest-${{ github.ref_name }}
 
     steps:
       - name: Git Clone - ${{ github.event.pull_request.head.ref }}
@@ -226,7 +266,7 @@ jobs:
         with:
           aws-region: eu-west-2
           role-to-assume: ${{ secrets.CI_ROLE_NAME }}
-          role-session-name: github-actions-ci-${{ needs.set-uniquish-id.outputs.uniqish_id }}
+          role-session-name: github-actions-ci-${{ needs.set-environment-id.outputs.environment_id }}
 
       - name: Pull Client Certificates
         run: make truststore-pull-client ENV=dev
@@ -238,23 +278,23 @@ jobs:
       - name: Configure Dev Account Credentials
         id: configure-dev-account-credentials
         run: |
-          aws_credentials=$(aws sts assume-role --role-arn arn:aws:iam::${{ steps.get_account_id.outputs.aws_account_id }}:role/terraform --role-session-name github-actions-ci-${{ needs.set-uniquish-id.outputs.uniqish_id }} --output json)
+          aws_credentials=$(aws sts assume-role --role-arn arn:aws:iam::${{ steps.get_account_id.outputs.aws_account_id }}:role/terraform --role-session-name github-actions-ci-${{ needs.set-environment-id.outputs.environment_id }} --output json)
           echo "aws_access_key_id=$(echo $aws_credentials | jq -r '.Credentials.AccessKeyId')" >> "$GITHUB_OUTPUT"
           echo "aws_secret_access_key=$(echo $aws_credentials | jq -r '.Credentials.SecretAccessKey')" >> "$GITHUB_OUTPUT"
           echo "aws_session_token=$(echo $aws_credentials | jq -r '.Credentials.SessionToken')" >> "$GITHUB_OUTPUT"
 
       - name: Setup Environment Test Data
-        run: make test-performance-prepare TF_WORKSPACE=ci-${{ needs.set-uniquish-id.outputs.uniqish_id }}
+        run: make test-performance-prepare TF_WORKSPACE=${{ needs.set-environment-id.outputs.environment_id }}
         env:
           AWS_ACCESS_KEY_ID: ${{ steps.configure-dev-account-credentials.outputs.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.configure-dev-account-credentials.outputs.aws_secret_access_key }}
           AWS_SESSION_TOKEN: ${{ steps.configure-dev-account-credentials.outputs.aws_session_token }}
 
       - name: Run Performance Test - Baseline
-        run: make test-performance-baseline HOST=ci-${{ needs.set-uniquish-id.outputs.uniqish_id }}.api.record-locator.dev.national.nhs.uk ENV_TYPE=dev
+        run: make test-performance-baseline HOST=${{ needs.set-environment-id.outputs.environment_id }}.api.record-locator.dev.national.nhs.uk ENV_TYPE=dev
 
       - name: Run Performance Test - Stress
-        run: make test-performance-stress HOST=ci-${{ needs.set-uniquish-id.outputs.uniqish_id }}.api.record-locator.dev.national.nhs.uk ENV_TYPE=dev
+        run: make test-performance-stress HOST=${{ needs.set-environment-id.outputs.environment_id }}.api.record-locator.dev.national.nhs.uk ENV_TYPE=dev
 
       - name: Process Performance Test Outputs
         run: make test-performance-output
@@ -266,53 +306,8 @@ jobs:
           path: dist/*.png
 
       - name: Cleanup Environment Test Data
-        run: make test-performance-cleanup TF_WORKSPACE=ci-${{ needs.set-uniquish-id.outputs.uniqish_id }}
+        run: make test-performance-cleanup TF_WORKSPACE=${{ needs.set-environment-id.outputs.environment_id }}
         env:
           AWS_ACCESS_KEY_ID: ${{ steps.configure-dev-account-credentials.outputs.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.configure-dev-account-credentials.outputs.aws_secret_access_key }}
           AWS_SESSION_TOKEN: ${{ steps.configure-dev-account-credentials.outputs.aws_session_token }}
-
-  destroy:
-    name: Destroy CI Environment
-    needs: [set-uniquish-id, deploy, integration-test, performance-test]
-    runs-on: [self-hosted, ci]
-    if: ${{ always() }}
-
-    steps:
-      - name: Git Clone - ${{ github.event.pull_request.head.ref }}
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-
-      - name: Setup asdf cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.asdf
-          key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}
-          restore-keys: |
-            ${{ runner.os }}-asdf-
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: eu-west-2
-          role-to-assume: ${{ secrets.CI_ROLE_NAME }}
-          role-session-name: github-actions-ci-${{ needs.set-uniquish-id.outputs.uniqish_id }}
-
-      - name: Get AWS Account ID
-        id: get_account_id
-        run: echo "aws_account_id=$(aws secretsmanager get-secret-value --secret-id nhsd-nrlf--mgmt--dev-account-id --query SecretString --output text)" >> "$GITHUB_OUTPUT"
-
-      - name: Terraform Init
-        run: |
-          terraform -chdir=terraform/infrastructure init
-          terraform -chdir=terraform/infrastructure workspace new ci-${{ needs.set-uniquish-id.outputs.uniqish_id }} || \
-          terraform -chdir=terraform/infrastructure workspace select ci-${{ needs.set-uniquish-id.outputs.uniqish_id }}
-
-      - name: Terraform Destroy
-        run: |
-          terraform -chdir=terraform/infrastructure destroy \
-            --var-file=etc/dev.tfvars \
-            --var assume_account=${{ steps.get_account_id.outputs.aws_account_id }} \
-            --var assume_role=terraform \
-            -auto-approve

--- a/.github/workflows/pr-env-create-update.yml
+++ b/.github/workflows/pr-env-create-update.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+concurrency:
+  group: environment-${{ github.ref_name }}
+
 permissions:
   id-token: write
   contents: read
@@ -17,7 +20,7 @@ jobs:
     steps:
       - name: Set a ID based on the branch name
         id: set_environment_id
-        run: echo "environment_id=$(echo '${{ github.ref }}' | sed 's/refs\/heads\///' | sed 's/feature\///')" > $GITHUB_OUTPUT
+        run: echo "environment_id=$(echo '${{ github.event.pull_request.head.ref }}' | sed 's/refs\/heads\///' | sed 's/feature\///')" > $GITHUB_OUTPUT
     outputs:
       environment_id: ${{ steps.set_environment_id.outputs.environment_id }}
 
@@ -80,8 +83,7 @@ jobs:
     name: Deploy CI Environment
     runs-on: [self-hosted, ci]
     needs: [set-environment-id, build]
-    concurrency:
-      group: terraform-${{ github.ref_name }}
+
     steps:
       - name: Git Clone - ${{ github.event.pull_request.head.ref }}
         uses: actions/checkout@v4
@@ -178,8 +180,6 @@ jobs:
     name: Run Integration Tests
     needs: [set-environment-id, deploy]
     runs-on: [self-hosted, ci]
-    concurrency:
-      group: integrationtest-${{ github.ref_name }}
 
     steps:
       - name: Git Clone - ${{ github.event.pull_request.head.ref }}
@@ -236,8 +236,6 @@ jobs:
     name: Run Performance Tests
     needs: [set-environment-id, integration-test]
     runs-on: [self-hosted, ci]
-    concurrency:
-      group: performancetest-${{ github.ref_name }}
 
     steps:
       - name: Git Clone - ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/pr-env-create-update.yml
+++ b/.github/workflows/pr-env-create-update.yml
@@ -1,5 +1,5 @@
 name: Create PR Environment
-run-name: ${{ github.event.action == 'synchronize ' && 'Update' || 'Create' }} PR Environment - #${{ github.event.pull_request.number }} (${{ github.event.pull_request.title }})
+run-name: "${{ github.event.action == 'synchronize ' && 'Update' || 'Create' }} PR Environment - #${{ github.event.pull_request.number }} (${{ github.event.pull_request.title }})"
 
 on:
   pull_request:

--- a/.github/workflows/pr-env-create-update.yml
+++ b/.github/workflows/pr-env-create-update.yml
@@ -22,7 +22,15 @@ jobs:
     steps:
       - name: Set a ID based on the branch name
         id: set_environment_id
-        run: echo "environment_id=$(echo '${{ github.event.pull_request.head.ref }}' | sed 's/refs\/heads\///' | sed 's/feature\///')" > $GITHUB_OUTPUT
+        run: |
+          JIRA_TICKET=$(echo '${{ github.ref }}' | grep '[A-Z]{3,4}-[0-9]{3,5}')
+          BRANCH_HASH=$(echo '${{ github.ref }}' | sha256sum | head -c 8)
+
+          if [ -z "$JIRA_TICKET" ]; then
+            echo "environment_id=pr-${BRANCH_HASH}" > $GITHUB_OUTPUT
+          else
+            echo "environment_id=pr-${JIRA_TICKET}-${BRANCH_HASH}" > $GITHUB_OUTPUT
+          fi
     outputs:
       environment_id: ${{ steps.set_environment_id.outputs.environment_id }}
 

--- a/.github/workflows/pr-env-create-update.yml
+++ b/.github/workflows/pr-env-create-update.yml
@@ -149,7 +149,7 @@ jobs:
         with:
           name: terraform-outputs
           path: terraform/infrastructure/output.json
-      
+
       - name: Add Failure Pull Request Comment
         uses: actions/github-script@v7
         if: ${{ success() }}

--- a/.github/workflows/pr-env-create-update.yml
+++ b/.github/workflows/pr-env-create-update.yml
@@ -72,7 +72,7 @@ jobs:
         if: ${{ failure() }}
         with:
           script: |
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -169,7 +169,7 @@ jobs:
         if: ${{ failure() }}
         with:
           script: |
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/pr-env-create-update.yml
+++ b/.github/workflows/pr-env-create-update.yml
@@ -13,6 +13,7 @@ permissions:
   contents: read
   actions: write
   issues: write
+  pull-requests: write
 
 jobs:
   set-environment-id:

--- a/.github/workflows/pr-env-create-update.yml
+++ b/.github/workflows/pr-env-create-update.yml
@@ -1,5 +1,5 @@
 name: Create PR Environment
-run-name: ${{ github.event.action == 'synchronize ' && 'Update' || 'Create' }} PR Environment - \#${{ github.event.pull_request.id }} (${{ github.event.pull_request.title }} )
+run-name: ${{ github.event.action == 'synchronize ' && 'Update' || 'Create' }} PR Environment - #${{ github.event.pull_request.number }} (${{ github.event.pull_request.title }})
 
 on:
   pull_request:

--- a/.github/workflows/pr-env-deploy.yml
+++ b/.github/workflows/pr-env-deploy.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Set a ID based on the branch name
         id: set_environment_id
         run: |
-          JIRA_TICKET=$(echo '${{ github.event.pull_request.head.ref }}' | grep '[A-Z]{3,4}-[0-9]{3,5}' || true)
-          BRANCH_HASH=$(echo '${{ github.event.pull_request.head.ref }}' | sha256sum | head -c 8)
+          JIRA_TICKET=$(echo '${{ github.event.pull_request.head.ref }}' | grep -Po --color=none '[A-z]{3,4}-[0-9]{3,5}' || true)
+          BRANCH_HASH=$(echo '${{ github.event.pull_request.head.ref }}' | sha256sum | head -c 6)
 
           if [ -z "$JIRA_TICKET" ]; then
             echo "environment_id=pr-${BRANCH_HASH}" > $GITHUB_OUTPUT
@@ -90,7 +90,7 @@ jobs:
             })
 
   deploy:
-    name: Deploy CI Environment
+    name: Deploy PR Environment
     runs-on: [self-hosted, ci]
     needs: [set-environment-id, build]
 
@@ -162,7 +162,7 @@ jobs:
           name: terraform-outputs
           path: terraform/infrastructure/output.json
 
-      - name: Add Failure Pull Request Comment - Create
+      - name: Add Success Pull Request Comment - Create
         uses: actions/github-script@v7
         if: ${{ success() && github.event.action != 'synchronize' }}
         with:
@@ -186,7 +186,7 @@ jobs:
               body: `💥 Something went wrong while deploying the pull request environment.\n[Check Output Logs](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
             })
 
-      - name: Add Failure Pull Request Comment - Update
+      - name: Add Success Pull Request Comment - Update
         uses: actions/github-script@v7
         if: ${{ success() && github.event.action == 'synchronize' }}
         with:

--- a/.github/workflows/pr-env-deploy.yml
+++ b/.github/workflows/pr-env-deploy.yml
@@ -196,7 +196,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "🚀 PR environment successfully updated to commit `${{ github.event.pull_request.head.sha }}`."
+              body: "🚀 PR environment successfully updated to commit `${{ github.event.pull_request.head.sha }}`.\nURL: ${{ needs.set-environment-id.outputs.environment_id }}.api.record-locator.dev.national.nhs.uk"
             })
 
       - name: Add Failure Pull Request Comment - Update

--- a/.github/workflows/pr-env-deploy.yml
+++ b/.github/workflows/pr-env-deploy.yml
@@ -1,4 +1,4 @@
-name: Create PR Environment
+name: Deploy PR Environment
 run-name: "${{ github.event.action == 'synchronize' && 'Update' || 'Create' }} PR Environment - #${{ github.event.pull_request.number }} (${{ github.event.pull_request.title }})"
 
 on:
@@ -23,8 +23,8 @@ jobs:
       - name: Set a ID based on the branch name
         id: set_environment_id
         run: |
-          JIRA_TICKET=$(echo '${{ github.ref }}' | grep '[A-Z]{3,4}-[0-9]{3,5}')
-          BRANCH_HASH=$(echo '${{ github.ref }}' | sha256sum | head -c 8)
+          JIRA_TICKET=$(echo '${{ github.event.pull_request.head.ref }}' | grep '[A-Z]{3,4}-[0-9]{3,5}' || true)
+          BRANCH_HASH=$(echo '${{ github.event.pull_request.head.ref }}' | sha256sum | head -c 8)
 
           if [ -z "$JIRA_TICKET" ]; then
             echo "environment_id=pr-${BRANCH_HASH}" > $GITHUB_OUTPUT

--- a/.github/workflows/pr-env-deploy.yml
+++ b/.github/workflows/pr-env-deploy.yml
@@ -172,7 +172,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "🚀 PR environment successfully deployed.\nCommit Hash: `${{ github.event.pull_request.head.sha }}`\nURL: ${{ needs.set-environment-id.outputs.environment_id }}.api.record-locator.dev.national.nhs.uk"
+              body: "🚀 PR environment successfully deployed.\nCommit Hash: `${{ github.event.pull_request.head.sha }}`\nURL: https://${{ needs.set-environment-id.outputs.environment_id }}.api.record-locator.dev.national.nhs.uk/"
             })
 
       - name: Add Failure Pull Request Comment

--- a/.github/workflows/pr-env-deploy.yml
+++ b/.github/workflows/pr-env-deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set a ID based on the branch name
         id: set_environment_id
         run: |
-          JIRA_TICKET=$(echo '${{ github.event.pull_request.head.ref }}' | grep -Po --color=none '[A-z]{3,4}-[0-9]{3,5}' || true)
+          JIRA_TICKET=$(echo '${{ github.event.pull_request.head.ref }}' | grep -Po --color=none '[A-z]{3,4}-[0-9]{3,5}' | tr '[:upper:]' '[:lower:]' || true)
           BRANCH_HASH=$(echo '${{ github.event.pull_request.head.ref }}' | sha256sum | head -c 6)
 
           if [ -z "$JIRA_TICKET" ]; then

--- a/.github/workflows/pr-env-deploy.yml
+++ b/.github/workflows/pr-env-deploy.yml
@@ -7,6 +7,7 @@ on:
 
 concurrency:
   group: environment-${{ github.ref_name }}
+  cancel-in-progress: ${{ github.event.action == 'reopened' }}
 
 permissions:
   id-token: write

--- a/.github/workflows/pr-env-deploy.yml
+++ b/.github/workflows/pr-env-deploy.yml
@@ -6,8 +6,8 @@ on:
     types: [opened, reopened, synchronize]
 
 concurrency:
-  group: environment-${{ github.ref_name }}
-  cancel-in-progress: ${{ github.event.action == 'reopened' }}
+  group: environment-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
 
 permissions:
   id-token: write
@@ -163,21 +163,21 @@ jobs:
           name: terraform-outputs
           path: terraform/infrastructure/output.json
 
-      - name: Add Success Pull Request Comment - Create
+      - name: Add Success Pull Request Comment
         uses: actions/github-script@v7
-        if: ${{ success() && github.event.action != 'synchronize' }}
+        if: ${{ success() }}
         with:
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "🚀 PR environment successfully created.\nURL: ${{ needs.set-environment-id.outputs.environment_id }}.api.record-locator.dev.national.nhs.uk"
+              body: "🚀 PR environment successfully deployed.\nCommit Hash: `${{ github.event.pull_request.head.sha }}`\nURL: ${{ needs.set-environment-id.outputs.environment_id }}.api.record-locator.dev.national.nhs.uk"
             })
 
-      - name: Add Failure Pull Request Comment - Create
+      - name: Add Failure Pull Request Comment
         uses: actions/github-script@v7
-        if: ${{ failure() && github.event.action != 'synchronize'  }}
+        if: ${{ failure() }}
         with:
           script: |
             github.rest.issues.createComment({
@@ -185,30 +185,6 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `💥 Something went wrong while deploying the pull request environment.\n[Check Output Logs](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
-            })
-
-      - name: Add Success Pull Request Comment - Update
-        uses: actions/github-script@v7
-        if: ${{ success() && github.event.action == 'synchronize' }}
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: "🚀 PR environment successfully updated to commit `${{ github.event.pull_request.head.sha }}`.\nURL: ${{ needs.set-environment-id.outputs.environment_id }}.api.record-locator.dev.national.nhs.uk"
-            })
-
-      - name: Add Failure Pull Request Comment - Update
-        uses: actions/github-script@v7
-        if: ${{ failure() && github.event.action == 'synchronize'  }}
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `💥 Something went wrong while updating the pull request environment.\n[Check Output Logs](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
             })
 
   integration-test:

--- a/.github/workflows/pr-env-deploy.yml
+++ b/.github/workflows/pr-env-deploy.yml
@@ -24,13 +24,19 @@ jobs:
       - name: Set a ID based on the branch name
         id: set_environment_id
         run: |
-          JIRA_TICKET=$(echo '${{ github.event.pull_request.head.ref }}' | grep -Po --color=none '[A-z]{3,4}-[0-9]{3,5}' | tr '[:upper:]' '[:lower:]' || true)
-          BRANCH_HASH=$(echo '${{ github.event.pull_request.head.ref }}' | sha256sum | head -c 6)
+          JIRA_TICKET=$(
+            echo '${{ github.event.pull_request.head.ref }}' | \
+            grep -Po --color=none '[A-z]{3,4}-[0-9]{3,5}' | \
+            sed 's/-//g' | \
+            tr '[:upper:]' '[:lower:]' || \
+            true
+          )
+          BRANCH_HASH=$(echo '${{ github.event.pull_request.head.ref }}${{ github.event.pull_request.id }}' | sha256sum | head -c 6)
 
           if [ -z "$JIRA_TICKET" ]; then
-            echo "environment_id=pr-${BRANCH_HASH}" > $GITHUB_OUTPUT
+            echo "environment_id=${BRANCH_HASH}" > $GITHUB_OUTPUT
           else
-            echo "environment_id=pr-${JIRA_TICKET}-${BRANCH_HASH}" > $GITHUB_OUTPUT
+            echo "environment_id=${JIRA_TICKET}-${BRANCH_HASH}" > $GITHUB_OUTPUT
           fi
     outputs:
       environment_id: ${{ steps.set_environment_id.outputs.environment_id }}

--- a/.github/workflows/pr-env-destroy.yml
+++ b/.github/workflows/pr-env-destroy.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Set a ID based on the branch name
         id: set_environment_id
         run: |
-          JIRA_TICKET=$(echo '${{ github.ref }}' | grep '[A-Z]{3,4}-[0-9]{3,5}')
-          BRANCH_HASH=$(echo '${{ github.ref }}' | sha256sum | head -c 8)
+          JIRA_TICKET=$(echo '${{ github.event.pull_request.head.ref }}' | grep '[A-Z]{3,4}-[0-9]{3,5}')
+          BRANCH_HASH=$(echo '${{ github.event.pull_request.head.ref }}' | sha256sum | head -c 8)
 
           if [ -z "$JIRA_TICKET" ]; then
             echo "environment_id=pr-${BRANCH_HASH}" > $GITHUB_OUTPUT

--- a/.github/workflows/pr-env-destroy.yml
+++ b/.github/workflows/pr-env-destroy.yml
@@ -67,7 +67,7 @@ jobs:
             --var assume_account=${{ steps.get_account_id.outputs.aws_account_id }} \
             --var assume_role=terraform \
             -auto-approve
-      
+
       - name: Add Failure Pull Request Comment
         uses: actions/github-script@v7
         if: ${{ failure() }}

--- a/.github/workflows/pr-env-destroy.yml
+++ b/.github/workflows/pr-env-destroy.yml
@@ -6,7 +6,7 @@ on:
     types: [closed]
 
 concurrency:
-  group: environment-${{ github.ref_name }}
+  group: environment-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/pr-env-destroy.yml
+++ b/.github/workflows/pr-env-destroy.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [closed]
 
+concurrency:
+  group: environment-${{ github.ref_name }}
+  cancel-in-progress: true
+
 permissions:
   id-token: write
   contents: read
@@ -25,9 +29,7 @@ jobs:
     name: Destroy CI Environment
     needs: [set-environment-id]
     runs-on: [self-hosted, ci]
-    concurrency:
-      group: terraform-${{ github.ref_name }}
-      cancel-in-progress: true
+
 
     steps:
       - name: Git Clone - ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/pr-env-destroy.yml
+++ b/.github/workflows/pr-env-destroy.yml
@@ -1,5 +1,5 @@
 name: Create PR Environment
-run-name: ${{ github.event_path }} Create PR Environment - \#${{ github.event.pull_request.id }} (${{ github.event.pull_request.title }} )
+run-name: Destroy PR Environment - \#${{ github.event.pull_request.id }} (${{ github.event.pull_request.title }} )
 
 on:
   pull_request:

--- a/.github/workflows/pr-env-destroy.yml
+++ b/.github/workflows/pr-env-destroy.yml
@@ -37,7 +37,7 @@ jobs:
       environment_id: ${{ steps.set_environment_id.outputs.environment_id }}
 
   destroy:
-    name: Destroy CI Environment
+    name: Destroy PR Environment
     needs: [set-environment-id]
     runs-on: [self-hosted, ci]
 

--- a/.github/workflows/pr-env-destroy.yml
+++ b/.github/workflows/pr-env-destroy.yml
@@ -23,7 +23,16 @@ jobs:
     steps:
       - name: Set a ID based on the branch name
         id: set_environment_id
-        run: echo "environment_id=$(echo '${{ github.ref }}' | sed 's/refs\/heads\///' | sed 's/feature\///')" > $GITHUB_OUTPUT
+        run: |
+          JIRA_TICKET=$(echo '${{ github.ref }}' | grep '[A-Z]{3,4}-[0-9]{3,5}')
+          BRANCH_HASH=$(echo '${{ github.ref }}' | sha256sum | head -c 8)
+
+          if [ -z "$JIRA_TICKET" ]; then
+            echo "environment_id=pr-${BRANCH_HASH}" > $GITHUB_OUTPUT
+          else
+            echo "environment_id=pr-${JIRA_TICKET}-${BRANCH_HASH}" > $GITHUB_OUTPUT
+          fi
+
     outputs:
       environment_id: ${{ steps.set_environment_id.outputs.environment_id }}
 

--- a/.github/workflows/pr-env-destroy.yml
+++ b/.github/workflows/pr-env-destroy.yml
@@ -75,7 +75,7 @@ jobs:
         if: ${{ failure() }}
         with:
           script: |
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/pr-env-destroy.yml
+++ b/.github/workflows/pr-env-destroy.yml
@@ -14,6 +14,7 @@ permissions:
   contents: read
   actions: write
   issues: write
+  pull-requests: write
 
 jobs:
   set-environment-id:

--- a/.github/workflows/pr-env-destroy.yml
+++ b/.github/workflows/pr-env-destroy.yml
@@ -1,5 +1,5 @@
 name: Create PR Environment
-run-name: Destroy PR Environment - #${{ github.event.pull_request.number }} (${{ github.event.pull_request.title }})"
+run-name: "Destroy PR Environment - #${{ github.event.pull_request.number }} (${{ github.event.pull_request.title }})"
 
 on:
   pull_request:

--- a/.github/workflows/pr-env-destroy.yml
+++ b/.github/workflows/pr-env-destroy.yml
@@ -13,6 +13,7 @@ permissions:
   id-token: write
   contents: read
   actions: write
+  issues: write
 
 jobs:
   set-environment-id:

--- a/.github/workflows/pr-env-destroy.yml
+++ b/.github/workflows/pr-env-destroy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set a ID based on the branch name
         id: set_environment_id
         run: |
-          JIRA_TICKET=$(echo '${{ github.event.pull_request.head.ref }}' | grep -Po --color=none '[A-z]{3,4}-[0-9]{3,5}' || true)
+          JIRA_TICKET=$(echo '${{ github.event.pull_request.head.ref }}' | grep -Po --color=none '[A-z]{3,4}-[0-9]{3,5}' | tr '[:upper:]' '[:lower:]' || true)
           BRANCH_HASH=$(echo '${{ github.event.pull_request.head.ref }}' | sha256sum | head -c 6)
 
           if [ -z "$JIRA_TICKET" ]; then

--- a/.github/workflows/pr-env-destroy.yml
+++ b/.github/workflows/pr-env-destroy.yml
@@ -1,5 +1,5 @@
 name: Create PR Environment
-run-name: Destroy PR Environment - \#${{ github.event.pull_request.id }} (${{ github.event.pull_request.title }} )
+run-name: Destroy PR Environment - #${{ github.event.pull_request.number }} (${{ github.event.pull_request.title }})"
 
 on:
   pull_request:
@@ -24,8 +24,8 @@ jobs:
       - name: Set a ID based on the branch name
         id: set_environment_id
         run: |
-          JIRA_TICKET=$(echo '${{ github.event.pull_request.head.ref }}' | grep '[A-Z]{3,4}-[0-9]{3,5}' || true)
-          BRANCH_HASH=$(echo '${{ github.event.pull_request.head.ref }}' | sha256sum | head -c 8)
+          JIRA_TICKET=$(echo '${{ github.event.pull_request.head.ref }}' | grep -Po --color=none '[A-z]{3,4}-[0-9]{3,5}' || true)
+          BRANCH_HASH=$(echo '${{ github.event.pull_request.head.ref }}' | sha256sum | head -c 6)
 
           if [ -z "$JIRA_TICKET" ]; then
             echo "environment_id=pr-${BRANCH_HASH}" > $GITHUB_OUTPUT

--- a/.github/workflows/pr-env-destroy.yml
+++ b/.github/workflows/pr-env-destroy.yml
@@ -24,13 +24,19 @@ jobs:
       - name: Set a ID based on the branch name
         id: set_environment_id
         run: |
-          JIRA_TICKET=$(echo '${{ github.event.pull_request.head.ref }}' | grep -Po --color=none '[A-z]{3,4}-[0-9]{3,5}' | tr '[:upper:]' '[:lower:]' || true)
-          BRANCH_HASH=$(echo '${{ github.event.pull_request.head.ref }}' | sha256sum | head -c 6)
+          JIRA_TICKET=$(
+            echo '${{ github.event.pull_request.head.ref }}' | \
+            grep -Po --color=none '[A-z]{3,4}-[0-9]{3,5}' | \
+            sed 's/-//g' | \
+            tr '[:upper:]' '[:lower:]' || \
+            true
+          )
+          BRANCH_HASH=$(echo '${{ github.event.pull_request.head.ref }}${{ github.event.pull_request.id }}' | sha256sum | head -c 6)
 
           if [ -z "$JIRA_TICKET" ]; then
-            echo "environment_id=pr-${BRANCH_HASH}" > $GITHUB_OUTPUT
+            echo "environment_id=${BRANCH_HASH}" > $GITHUB_OUTPUT
           else
-            echo "environment_id=pr-${JIRA_TICKET}-${BRANCH_HASH}" > $GITHUB_OUTPUT
+            echo "environment_id=${JIRA_TICKET}-${BRANCH_HASH}" > $GITHUB_OUTPUT
           fi
 
     outputs:

--- a/.github/workflows/pr-env-destroy.yml
+++ b/.github/workflows/pr-env-destroy.yml
@@ -30,7 +30,6 @@ jobs:
     needs: [set-environment-id]
     runs-on: [self-hosted, ci]
 
-
     steps:
       - name: Git Clone - ${{ github.event.pull_request.head.ref }}
         uses: actions/checkout@v4

--- a/.github/workflows/pr-env-destroy.yml
+++ b/.github/workflows/pr-env-destroy.yml
@@ -1,0 +1,81 @@
+name: Create PR Environment
+run-name: ${{ github.event_path }} Create PR Environment - \#${{ github.event.pull_request.id }} (${{ github.event.pull_request.title }} )
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  id-token: write
+  contents: read
+  actions: write
+
+jobs:
+  set-environment-id:
+    name: Set Environment ID
+    runs-on: [self-hosted, ci]
+    steps:
+      - name: Set a ID based on the branch name
+        id: set_environment_id
+        run: echo "environment_id=$(echo '${{ github.ref }}' | sed 's/refs\/heads\///' | sed 's/feature\///')" > $GITHUB_OUTPUT
+    outputs:
+      environment_id: ${{ steps.set_environment_id.outputs.environment_id }}
+
+  destroy:
+    name: Destroy CI Environment
+    needs: [set-environment-id]
+    runs-on: [self-hosted, ci]
+    concurrency:
+      group: terraform-${{ github.ref_name }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Git Clone - ${{ github.event.pull_request.head.ref }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Setup asdf cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.asdf
+          key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}
+          restore-keys: |
+            ${{ runner.os }}-asdf-
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: eu-west-2
+          role-to-assume: ${{ secrets.CI_ROLE_NAME }}
+          role-session-name: github-actions-ci-${{ needs.set-environment-id.outputs.environment_id }}
+
+      - name: Get AWS Account ID
+        id: get_account_id
+        run: echo "aws_account_id=$(aws secretsmanager get-secret-value --secret-id nhsd-nrlf--mgmt--dev-account-id --query SecretString --output text)" >> "$GITHUB_OUTPUT"
+
+      - name: Terraform Init
+        run: |
+          terraform -chdir=terraform/infrastructure init
+          terraform -chdir=terraform/infrastructure workspace new ${{ needs.set-environment-id.outputs.environment_id }} || \
+          terraform -chdir=terraform/infrastructure workspace select ${{ needs.set-environment-id.outputs.environment_id }}
+
+      - name: Terraform Destroy
+        run: |
+          terraform -chdir=terraform/infrastructure destroy \
+            --var-file=etc/dev.tfvars \
+            --var assume_account=${{ steps.get_account_id.outputs.aws_account_id }} \
+            --var assume_role=terraform \
+            -auto-approve
+      
+      - name: Add Failure Pull Request Comment
+        uses: actions/github-script@v7
+        if: ${{ failure() }}
+        with:
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `💥 Something went wrong while destroying the pull request environment.\n[Check Output Logs](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
+            })

--- a/.github/workflows/pr-env-destroy.yml
+++ b/.github/workflows/pr-env-destroy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set a ID based on the branch name
         id: set_environment_id
         run: |
-          JIRA_TICKET=$(echo '${{ github.event.pull_request.head.ref }}' | grep '[A-Z]{3,4}-[0-9]{3,5}')
+          JIRA_TICKET=$(echo '${{ github.event.pull_request.head.ref }}' | grep '[A-Z]{3,4}-[0-9]{3,5}' || true)
           BRANCH_HASH=$(echo '${{ github.event.pull_request.head.ref }}' | sha256sum | head -c 8)
 
           if [ -z "$JIRA_TICKET" ]; then

--- a/tests/features/steps/2_request.py
+++ b/tests/features/steps/2_request.py
@@ -80,6 +80,10 @@ def create_post_document_reference_step(context: Context, ods_code: str):
     doc_ref = create_test_document_reference(items)
     context.response = client.create(doc_ref.dict(exclude_none=True))
 
+    if context.response.status_code == 201:
+        doc_ref_id = context.response.headers["Location"].split("/")[-1]
+        context.add_cleanup(lambda: context.repository.delete_by_id(doc_ref_id))
+
 
 @when("producer '{ods_code}' reads a DocumentReference with ID '{doc_ref_id}'")
 def producer_read_document_reference_step(


### PR DESCRIPTION
This adds new environments that get spun up when a pull request is opened.
The environment is updated every time the pull request is synchronised (updated).

When an environment is created or updated, a comment is added to the pull request with the latest deployed commit hash and the URL of the environment.

If an environment deploy fails, a comment should be added to the pull request with details of the run.

If the pull request is closed, the environment will be destroyed. **This will take precedence over any create/update jobs in progress and will cancel those jobs if running.**

If the pull request is reopened, the environment is recreated.