### PR TITLE
[NRL-604] Add K6 tests for producer stress scenarios

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,6 @@ test-performance-baseline:
 test-performance-stress:
 	@echo "Running consumer performance stress test"
 	k6 run --out csv=$(DIST_PATH)/consumer-stress.csv tests/performance/consumer/stress.js -e HOST=$(HOST) -e ENV_TYPE=$(ENV_TYPE)
-	@echo "Running producer performance stress test"
-	k6 run --out csv=$(DIST_PATH)/producer-stress.csv tests/performance/producer/stress.js -e HOST=$(HOST) -e ENV_TYPE=$(ENV_TYPE)
 
 test-performance-soak:
 	@echo "Running consumer performance soak test"

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ FEATURE_TEST_ARGS ?= ./tests/features --format progress2
 TF_WORKSPACE ?= $(shell terraform -chdir=terraform/infrastructure workspace show)
 ENV ?= dev
 APP_ALIAS ?= default
+HOST ?= $(TF_WORKSPACE).api.record-locator.$(ENV).national.nhs.uk
+ENV_TYPE ?= $(ENV)
 
 export PATH := $(PATH):$(PWD)/.venv/bin
 
@@ -85,15 +87,17 @@ test-performance-prepare:
 test-performance: check-warn test-performance-baseline test-performance-stress ## Run the performance tests
 
 test-performance-baseline:
-	@echo "Running performance baseline test"
+	@echo "Running consumer performance baseline test"
 	k6 run --out csv=$(DIST_PATH)/consumer-baseline.csv tests/performance/consumer/baseline.js -e HOST=$(HOST) -e ENV_TYPE=$(ENV_TYPE)
 
 test-performance-stress:
-	@echo "Running performance stress test"
+	@echo "Running consumer performance stress test"
 	k6 run --out csv=$(DIST_PATH)/consumer-stress.csv tests/performance/consumer/stress.js -e HOST=$(HOST) -e ENV_TYPE=$(ENV_TYPE)
+	@echo "Running producer performance stress test"
+	k6 run --out csv=$(DIST_PATH)/producer-stress.csv tests/performance/producer/stress.js -e HOST=$(HOST) -e ENV_TYPE=$(ENV_TYPE)
 
 test-performance-soak:
-	@echo "Running performance soak test"
+	@echo "Running consumer performance soak test"
 	k6 run --out csv=$(DIST_PATH)/consumer-soak.csv tests/performance/consumer/soak.js -e HOST=$(HOST) -e ENV_TYPE=$(ENV_TYPE)
 
 test-performance-output: ## Process outputs from the performance tests

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ FEATURE_TEST_ARGS ?= ./tests/features --format progress2
 TF_WORKSPACE_NAME ?= $(shell terraform -chdir=terraform/infrastructure workspace show)
 ENV ?= dev
 APP_ALIAS ?= default
-HOST ?= $(TF_WORKSPACE).api.record-locator.$(ENV).national.nhs.uk
+HOST ?= $(TF_WORKSPACE_NAME).api.record-locator.$(ENV).national.nhs.uk
 ENV_TYPE ?= $(ENV)
 
 export PATH := $(PATH):$(PWD)/.venv/bin

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ## Overview
 
+NOTE - THIS BRANCH IS A SPIKE
+
 This project has been given the name `nrlf` which stands for `National Records Locator (Futures)` as a replacement of the existing NRL.
 
 This project uses the `Makefile` to build, test and deploy. This will ensure that a developer can reproduce any operation that the CI/CD pipelines does, meaning they can test the application locally or on their own deployed dev environment.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 ## Overview
 
-NOTE - THIS BRANCH IS A SPIKE
-
 This project has been given the name `nrlf` which stands for `National Records Locator (Futures)` as a replacement of the existing NRL.
 
 This project uses the `Makefile` to build, test and deploy. This will ensure that a developer can reproduce any operation that the CI/CD pipelines does, meaning they can test the application locally or on their own deployed dev environment.

--- a/tests/performance/constants.js
+++ b/tests/performance/constants.js
@@ -3,8 +3,12 @@ export const DEFAULT_TEST_RECORD = open(
 );
 export const ODS_CODE = "Y05868";
 export const REFERENCE_DATA = JSON.parse(open("./reference-data.json"));
-export const POINTER_DOCUMENTS = REFERENCE_DATA["documents"];
-export const ALL_POINTER_IDS = Object.keys(POINTER_DOCUMENTS);
+export const POINTER_DOCUMENTS =
+  "documents" in REFERENCE_DATA ? REFERENCE_DATA["documents"] : {};
+export const ALL_POINTER_IDS =
+  "pointer_ids" in REFERENCE_DATA
+    ? REFERENCE_DATA["pointer_ids"]
+    : Object.keys(POINTER_DOCUMENTS);
 export const POINTERS_TO_DELETE = ALL_POINTER_IDS.slice(0, 3500);
 export const POINTER_IDS = ALL_POINTER_IDS.slice(3500);
 export const NHS_NUMBERS = REFERENCE_DATA["nhs_numbers"];

--- a/tests/performance/constants.js
+++ b/tests/performance/constants.js
@@ -3,14 +3,17 @@ export const DEFAULT_TEST_RECORD = open(
 );
 export const ODS_CODE = "Y05868";
 export const REFERENCE_DATA = JSON.parse(open("./reference-data.json"));
-export const POINTER_IDS = REFERENCE_DATA["ids"];
+export const POINTER_DOCUMENTS = REFERENCE_DATA["documents"];
+export const ALL_POINTER_IDS = Object.keys(POINTER_DOCUMENTS);
+export const POINTERS_TO_DELETE = ALL_POINTER_IDS.slice(0, 3500);
+export const POINTER_IDS = ALL_POINTER_IDS.slice(3500);
 export const NHS_NUMBERS = REFERENCE_DATA["nhs_numbers"];
 export const POINTER_TYPES = [
-  "http://snomed.info/sct|736253002",
-  "http://snomed.info/sct|1363501000000100",
-  "http://snomed.info/sct|1382601000000107",
-  "http://snomed.info/sct|325691000000100",
-  "http://snomed.info/sct|736373009",
-  "http://snomed.info/sct|861421000000109",
-  "http://snomed.info/sct|887701000000100",
+  "736253002",
+  "1363501000000100",
+  "1382601000000107",
+  "325691000000100",
+  "736373009",
+  "861421000000109",
+  "887701000000100",
 ];

--- a/tests/performance/consumer/client.js
+++ b/tests/performance/consumer/client.js
@@ -77,7 +77,7 @@ export function searchDocumentReference() {
   const identifier = encodeURIComponent(
     `https://fhir.nhs.uk/Id/nhs-number|${nhsNumber}`
   );
-  const type = encodeURIComponent(pointer_type);
+  const type = encodeURIComponent(`http://snomed.info/sct|${pointer_type}`);
 
   const res = http.get(
     `https://${__ENV.HOST}/consumer/DocumentReference?subject:identifier=${identifier}&type=${type}`,
@@ -118,7 +118,7 @@ export function searchPostDocumentReference() {
 
   const body = JSON.stringify({
     "subject:identifier": `https://fhir.nhs.uk/Id/nhs-number|${nhsNumber}`,
-    type: pointer_type,
+    type: `http://snomed.info/sct|${pointer_type}`,
   });
 
   const res = http.post(

--- a/tests/performance/producer/client.js
+++ b/tests/performance/producer/client.js
@@ -1,18 +1,28 @@
 import http from "k6/http";
-import { ALL_POINTER_TYPES, ODS_CODE } from "../constants.js";
+import {
+  POINTER_TYPES,
+  ODS_CODE,
+  NHS_NUMBERS,
+  POINTER_IDS,
+  POINTER_DOCUMENTS,
+  POINTERS_TO_DELETE,
+} from "../constants.js";
 import { check } from "k6";
+import { randomItem } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { crypto } from "k6/experimental/webcrypto";
+import { createRecord } from "../setup.js";
 
 function getBaseURL() {
   return `https://${__ENV.HOST}/producer/DocumentReference`;
 }
 
-function getHeaders(odsCode = ODS_CODE, pointerTypes = ALL_POINTER_TYPES) {
+function getHeaders(odsCode = ODS_CODE) {
   return {
     "Content-Type": "application/fhir+json",
     "NHSD-Connection-Metadata": JSON.stringify({
       "nrl.ods-code": odsCode,
-      "nrl.pointer-types": Object.keys(pointerTypes).map(
-        (pointerType) => `http://snomed.info/sct|${pointerType}`
+      "nrl.pointer-types": POINTER_TYPES.map(
+        (type) => `http://snomed.info/sct|${type}`
       ),
     }),
     "NHSD-Client-RP-Details": JSON.stringify({
@@ -22,11 +32,121 @@ function getHeaders(odsCode = ODS_CODE, pointerTypes = ALL_POINTER_TYPES) {
   };
 }
 
-export function createDocumentReference(document) {
-  return http.post(getBaseURL(), document, { headers: getHeaders() });
+export function createDocumentReference() {
+  const nhsNumber = randomItem(NHS_NUMBERS);
+  const pointerType = randomItem(POINTER_TYPES);
+  const record = createRecord(nhsNumber, pointerType);
+
+  const res = http.post(getBaseURL(), JSON.stringify(record), {
+    headers: getHeaders(),
+  });
+
+  check(res, { "create status is 201": (r) => r.status === 201 });
+
+  if (res.status !== 201) {
+    console.warn(
+      `Failed to create record: ${res.status}: ${
+        JSON.parse(res.body).issue[0].diagnostics
+      }`
+    );
+  }
 }
 
-export function deleteDocumentReference(document_id) {
-  const url = `${getBaseURL()}/${document_id}`;
-  return http.del(url, { headers: getHeaders() });
+export function readDocumentReference() {
+  const id = randomItem(POINTER_IDS);
+
+  const res = http.get(`${getBaseURL()}/${id}`, { headers: getHeaders() });
+
+  check(res, { "status is 200": (r) => r.status === 200 });
+}
+
+export function updateDocumentReference() {
+  const id = randomItem(POINTER_IDS);
+  const document = POINTER_DOCUMENTS[id];
+
+  document.content[0].attachment.url = "https://example.com/k6-updated-url.pdf";
+
+  const res = http.put(`${getBaseURL()}/${id}`, JSON.stringify(document), {
+    headers: getHeaders(),
+  });
+
+  check(res, { "status is 200": (r) => r.status === 200 });
+}
+
+export function deleteDocumentReference() {
+  const id = randomItem(POINTERS_TO_DELETE);
+
+  const res = http.del(`${getBaseURL()}/${id}`, null, {
+    headers: getHeaders(),
+  });
+
+  check(res, { "delete status is 200": (r) => r.status === 200 });
+}
+
+export function upsertDocumentReference() {
+  const nhsNumber = randomItem(NHS_NUMBERS);
+  const pointerType = randomItem(POINTER_TYPES);
+  const record = createRecord(nhsNumber, pointerType);
+
+  record.id = `k6perf-${crypto.randomUUID()}`;
+
+  const res = http.post(getBaseURL(), JSON.stringify(record), {
+    headers: getHeaders(),
+  });
+
+  check(res, { "create status is 201": (r) => r.status === 201 });
+
+  if (res.status !== 201) {
+    console.warn(
+      `Failed to create record: ${res.status}: ${
+        JSON.parse(res.body).issue[0].diagnostics
+      }`
+    );
+  }
+}
+
+export function searchDocumentReference() {
+  const nhsNumber = randomItem(NHS_NUMBERS);
+  const pointerType = randomItem(POINTER_TYPES);
+
+  const identifier = encodeURIComponent(
+    `https://fhir.nhs.uk/Id/nhs-number|${nhsNumber}`
+  );
+  const type = encodeURIComponent(`http://snomed.info/sct|${pointerType}`);
+
+  const url = `${getBaseURL()}?subject:identifier=${identifier}&type=${type}`;
+
+  const res = http.get(url, {
+    headers: getHeaders(),
+  });
+
+  check(res, { "status is 200": (r) => r.status === 200 });
+
+  if (res.status !== 200) {
+    console.log(
+      `Search failed with ${res.status}: ${JSON.stringify(res.body)}`
+    );
+  }
+}
+
+export function searchPostDocumentReference() {
+  const nhsNumber = randomItem(NHS_NUMBERS);
+  const pointerType = randomItem(POINTER_TYPES);
+
+  const body = JSON.stringify({
+    "subject:identifier": `https://fhir.nhs.uk/Id/nhs-number|${nhsNumber}`,
+    type: `http://snomed.info/sct|${pointerType}`,
+  });
+
+  const res = http.post(`${getBaseURL()}/_search`, body, {
+    headers: getHeaders(),
+  });
+
+  check(res, { "status is 200": (r) => r.status === 200 });
+
+  if (res.status !== 200) {
+    console.log(
+      `Search failed with ${res.status}: ${JSON.stringify(res.body)}`
+    );
+  }
 }

--- a/tests/performance/producer/stress.js
+++ b/tests/performance/producer/stress.js
@@ -1,0 +1,75 @@
+export * from "./client.js";
+
+export const options = {
+  tlsAuth: [
+    {
+      cert: open(`../../../truststore/client/${__ENV.ENV_TYPE}.crt`),
+      key: open(`../../../truststore/client/${__ENV.ENV_TYPE}.key`),
+    },
+  ],
+  scenarios: {
+    createDocumentReference: {
+      exec: "createDocumentReference",
+      executor: "ramping-vus",
+      startVUs: 1,
+      stages: [
+        { target: 10, duration: "30s" },
+        { target: 10, duration: "1m" },
+      ],
+    },
+    readDocumentReference: {
+      exec: "readDocumentReference",
+      executor: "ramping-vus",
+      startVUs: 1,
+      stages: [
+        { target: 10, duration: "30s" },
+        { target: 10, duration: "1m" },
+      ],
+    },
+    updateDocumentReference: {
+      exec: "updateDocumentReference",
+      executor: "ramping-vus",
+      startVUs: 1,
+      stages: [
+        { target: 10, duration: "30s" },
+        { target: 10, duration: "1m" },
+      ],
+    },
+    deleteDocumentReference: {
+      exec: "deleteDocumentReference",
+      executor: "ramping-vus",
+      startVUs: 1,
+      stages: [
+        { target: 10, duration: "30s" },
+        { target: 10, duration: "1m" },
+      ],
+    },
+    upsertDocumentReference: {
+      exec: "upsertDocumentReference",
+      executor: "ramping-vus",
+      startVUs: 1,
+      stages: [
+        { target: 10, duration: "30s" },
+        { target: 10, duration: "1m" },
+      ],
+    },
+    /*searchDocumentReference: {
+      exec: "searchDocumentReference",
+      executor: "ramping-vus",
+      startVUs: 1,
+      stages: [
+        { target: 10, duration: "5s" },
+        //{ target: 10, duration: "1m" },
+      ],
+    },
+    /*searchPostDocumentReference: {
+      exec: "searchPostDocumentReference",
+      executor: "ramping-vus",
+      startVUs: 1,
+      stages: [
+        { target: 10, duration: "30s" },
+        { target: 10, duration: "1m" },
+      ],
+    },*/
+  },
+};

--- a/tests/performance/producer/stress.js
+++ b/tests/performance/producer/stress.js
@@ -58,23 +58,5 @@ export const options = {
         { target: 10, duration: "1m" },
       ],
     },
-    /*searchDocumentReference: {
-      exec: "searchDocumentReference",
-      executor: "ramping-vus",
-      startVUs: 1,
-      stages: [
-        { target: 10, duration: "5s" },
-        //{ target: 10, duration: "1m" },
-      ],
-    },
-    /*searchPostDocumentReference: {
-      exec: "searchPostDocumentReference",
-      executor: "ramping-vus",
-      startVUs: 1,
-      stages: [
-        { target: 10, duration: "30s" },
-        { target: 10, duration: "1m" },
-      ],
-    },*/
   },
 };

--- a/tests/performance/producer/stress.js
+++ b/tests/performance/producer/stress.js
@@ -1,5 +1,10 @@
 export * from "./client.js";
 
+/*
+ * NOTE - To run the producer K6 tests, you need to prepare the data by setting
+ * the output_full_pointers flag to true in the environment.py:setup() method.
+ */
+
 export const options = {
   tlsAuth: [
     {

--- a/tests/performance/setup.js
+++ b/tests/performance/setup.js
@@ -1,57 +1,14 @@
-import { generateNHSNumber } from "./utilities.js";
-import {
-  ALL_POINTER_TYPES,
-  DEFAULT_TEST_RECORD,
-  ODS_CODE,
-} from "./constants.js";
+import { POINTER_TYPES, DEFAULT_TEST_RECORD, ODS_CODE } from "./constants.js";
 import { crypto } from "k6/experimental/webcrypto";
-import {
-  createDocumentReference,
-  deleteDocumentReference,
-} from "./producer/client.js";
-import { fail } from "k6";
-
-const UNIQUE_NHS_NUMBER_COUNT = 5;
-const POINTERS_PER_TYPE = 2;
-
-export const CREATED_NHS_NUMBERS = [];
-export const CREATED_POINTER_IDS = [];
 
 export function createRecord(nhsNumber, pointerType) {
   const record = JSON.parse(DEFAULT_TEST_RECORD);
   record.id = `${ODS_CODE}-${crypto.randomUUID()}`;
 
   record.type.coding[0].code = pointerType;
-  record.type.coding[0].display = ALL_POINTER_TYPES[pointerType];
+  record.type.coding[0].display = POINTER_TYPES[pointerType];
   record.subject.identifier.value = nhsNumber;
   record.context.sourcePatientInfo.identifier.value = nhsNumber;
 
   return record;
-}
-
-export function createTestRecords() {
-  for (let i = 0; i < UNIQUE_NHS_NUMBER_COUNT; i++) {
-    const nhsNumber = generateNHSNumber();
-    CREATED_NHS_NUMBERS.push(nhsNumber);
-
-    for (const pointerType of Object.keys(ALL_POINTER_TYPES)) {
-      for (let j = 0; j < POINTERS_PER_TYPE; j++) {
-        const record = createRecord(nhsNumber, pointerType);
-        CREATED_POINTER_IDS.push(record.id);
-        const result = createDocumentReference(JSON.stringify(record));
-
-        if (result.status !== 201) {
-          console.error(`Failed to create record`);
-          fail(`Failed to create record: ${result.status}`);
-        }
-      }
-    }
-  }
-}
-
-export function deleteTestRecords() {
-  for (const pointerId of CREATED_POINTER_IDS) {
-    console.log(pointerId);
-    deleteDocumentReference(pointerId);
-  }
 }


### PR DESCRIPTION
Main differences are:
- Add K6 tests for producer stress test scenarios
- Change perf test prepare in `environment.py` to save entire pointer into `reference-data.json` file 
- Restructure K6 test tools to support creating/updating pointers