### PR TITLE
[NRL-784] Tweak dynamodb structure and indexes

### DIFF
--- a/api/consumer/searchDocumentReference/search_document_reference.py
+++ b/api/consumer/searchDocumentReference/search_document_reference.py
@@ -46,6 +46,7 @@ def handler(
     base_url = f"https://{config.ENVIRONMENT}.api.service.nhs.uk/"
     self_link = f"{base_url}record-locator/consumer/FHIR/R4/DocumentReference?subject:identifier=https://fhir.nhs.uk/Id/nhs-number|{params.nhs_number}"
 
+    # TODO-NOW - Add checks for type code as well as system please
     if not validate_type_system(params.type, metadata.pointer_types):
         logger.log(
             LogReference.CONSEARCH002,

--- a/api/consumer/searchDocumentReference/search_document_reference.py
+++ b/api/consumer/searchDocumentReference/search_document_reference.py
@@ -46,7 +46,7 @@ def handler(
     base_url = f"https://{config.ENVIRONMENT}.api.service.nhs.uk/"
     self_link = f"{base_url}record-locator/consumer/FHIR/R4/DocumentReference?subject:identifier=https://fhir.nhs.uk/Id/nhs-number|{params.nhs_number}"
 
-    # TODO-NOW - Add checks for type code as well as system please
+    # TODO - Add checks for the type code as well as system
     if not validate_type_system(params.type, metadata.pointer_types):
         logger.log(
             LogReference.CONSEARCH002,

--- a/api/consumer/status/status.py
+++ b/api/consumer/status/status.py
@@ -21,7 +21,7 @@ def handler(event, context) -> Response:
 
         logger.log(LogReference.STATUS002)
         repository = DocumentPointerRepository(environment_prefix=config.PREFIX)
-        repository.get("D#NULL")
+        repository.get_by_id("ODSX-NULL")
 
         response = Response(statusCode="200", body="OK")
         logger.log(LogReference.STATUS999)

--- a/api/producer/createDocumentReference/create_document_reference.py
+++ b/api/producer/createDocumentReference/create_document_reference.py
@@ -91,24 +91,23 @@ def _check_permissions(
         )
 
 
-def _get_documents_to_supersede(
+def _get_document_ids_to_supersede(
     resource: DocumentReference,
     core_model: DocumentPointer,
     metadata: ConnectionMetadata,
     repository: DocumentPointerRepository,
     can_ignore_delete_fail: bool,
-) -> list[DocumentPointer]:
+):
     """
-    Validate the relates_to field and get the list of document IDs to supersede based on the relatesTo field
+    Get the list of document IDs to supersede based on the relatesTo field
     """
     if not resource.relatesTo:
         return []
 
     logger.log(LogReference.PROCREATE006, relatesTo=resource.relatesTo)
-    documents_to_superseded = []
+    ids_to_delete = []
 
     for idx, relates_to in enumerate(resource.relatesTo):
-        # TODO - Move relates_to validation into a validator
         identifier = _validate_identifier(relates_to, idx)
         _validate_producer_id(identifier, metadata, idx)
 
@@ -116,15 +115,9 @@ def _get_documents_to_supersede(
             existing_pointer = _check_existing_pointer(identifier, repository, idx)
             _validate_pointer_details(existing_pointer, core_model, identifier, idx)
 
-            if relates_to.code == "replaces":
-                logger.log(
-                    LogReference.PROCREATE008,
-                    relates_to_code=relates_to.code,
-                    identifier=identifier,
-                )
-                documents_to_superseded.append(existing_pointer)
+        _append_id_if_replaces(relates_to, ids_to_delete, identifier)
 
-    return documents_to_superseded
+    return ids_to_delete
 
 
 def _validate_identifier(relates_to, idx):
@@ -193,6 +186,13 @@ def _append_id_if_replaces(relates_to, ids_to_delete, identifier):
     """
     Append pointer ID if the if the relatesTo code is 'replaces'
     """
+    if relates_to.code == "replaces":
+        logger.log(
+            LogReference.PROCREATE008,
+            relates_to_code=relates_to.code,
+            identifier=identifier,
+        )
+        ids_to_delete.append(identifier)
 
 
 def _raise_operation_outcome_error(diagnostics, idx):
@@ -246,19 +246,15 @@ def handler(
         PERMISSION_SUPERSEDE_IGNORE_DELETE_FAIL in metadata.nrl_permissions
     )
 
-    pointers_to_delete = _get_documents_to_supersede(
+    if ids_to_delete := _get_document_ids_to_supersede(
         result.resource, core_model, metadata, repository, can_ignore_delete_fail
-    )
-
-    if result.resource.relatesTo and "replaces" in [
-        relates_to.code for relates_to in result.resource.relatesTo
-    ]:
+    ):
         logger.log(
             LogReference.PROCREATE010,
             pointer_id=result.resource.id,
-            pointers_to_delete=pointers_to_delete,
+            ids_to_delete=ids_to_delete,
         )
-        repository.supersede(core_model, pointers_to_delete, can_ignore_delete_fail)
+        repository.supersede(core_model, ids_to_delete, can_ignore_delete_fail)
         logger.log(LogReference.PROCREATE999)
         return NRLResponse.RESOURCE_SUPERSEDED(resource_id=result.resource.id)
 

--- a/api/producer/searchDocumentReference/search_document_reference.py
+++ b/api/producer/searchDocumentReference/search_document_reference.py
@@ -61,7 +61,7 @@ def handler(
         pointer_types=pointer_types,
     )
 
-    for result in repository.search_by_custodian(
+    for result in repository.search(
         custodian=metadata.ods_code,
         custodian_suffix=metadata.ods_code_extension,
         nhs_number=params.nhs_number,

--- a/api/producer/searchDocumentReference/search_document_reference.py
+++ b/api/producer/searchDocumentReference/search_document_reference.py
@@ -39,6 +39,15 @@ def handler(
             expression="subject:identifier",
         )
 
+    if not params.nhs_number:
+        logger.log(
+            LogReference.PROSEARCH001, subject_identifier=params.subject_identifier
+        )
+        return SpineErrorResponse.INVALID_NHS_NUMBER(
+            diagnostics="NHS number is missing from the search parameters",
+            expression="subject:identifier",
+        )
+
     if not validate_type_system(params.type, metadata.pointer_types):
         logger.log(
             LogReference.PROSEARCH002,

--- a/api/producer/searchDocumentReference/tests/test_search_document_reference_producer.py
+++ b/api/producer/searchDocumentReference/tests/test_search_document_reference_producer.py
@@ -76,14 +76,30 @@ def test_search_document_reference_missing_nhs_number(
     result = handler(event, create_mock_context())
     body = result.pop("body")
 
-    assert result == {"statusCode": "200", "headers": {}, "isBase64Encoded": False}
+    assert result == {"statusCode": "400", "headers": {}, "isBase64Encoded": False}
 
     parsed_body = json.loads(body)
     assert parsed_body == {
-        "resourceType": "Bundle",
-        "type": "searchset",
-        "total": 0,
-        "entry": [],
+        "issue": [
+            {
+                "code": "invalid",
+                "details": {
+                    "coding": [
+                        {
+                            "code": "INVALID_NHS_NUMBER",
+                            "display": "Invalid NHS number",
+                            "system": "https://fhir.nhs.uk/ValueSet/Spine-ErrorOrWarningCode-1",
+                        },
+                    ],
+                },
+                "diagnostics": "NHS number is missing from the search parameters",
+                "expression": [
+                    "subject:identifier",
+                ],
+                "severity": "error",
+            },
+        ],
+        "resourceType": "OperationOutcome",
     }
 
 

--- a/api/producer/searchPostDocumentReference/search_post_document_reference.py
+++ b/api/producer/searchPostDocumentReference/search_post_document_reference.py
@@ -64,7 +64,7 @@ def handler(
         pointer_types=pointer_types,
     )
 
-    for result in repository.search_by_custodian(
+    for result in repository.search(
         custodian=metadata.ods_code,
         custodian_suffix=metadata.ods_code_extension,
         nhs_number=body.nhs_number,

--- a/api/producer/status/status.py
+++ b/api/producer/status/status.py
@@ -18,7 +18,7 @@ def handler(event, context) -> Response:
 
         logger.log(LogReference.STATUS002)
         repository = DocumentPointerRepository(environment_prefix=config.PREFIX)
-        repository.get("D#NULL")
+        repository.get_by_id("ODSX-NULL")
 
         response = Response(statusCode="200", body="OK")
         logger.log(LogReference.STATUS999)

--- a/api/producer/upsertDocumentReference/upsert_document_reference.py
+++ b/api/producer/upsertDocumentReference/upsert_document_reference.py
@@ -89,40 +89,38 @@ def _check_permissions(
         )
 
 
-def _get_documents_to_supersede(
+def _get_document_ids_to_supersede(
     resource: DocumentReference,
     core_model: DocumentPointer,
     metadata: ConnectionMetadata,
     repository: DocumentPointerRepository,
     can_ignore_delete_fail: bool,
-) -> list[DocumentPointer]:
+):
     """
-    Validate the relates_to field and get the list of document IDs to supersede based on the relatesTo field
+    Get the list of document IDs to supersede based on the relatesTo field
     """
     if not resource.relatesTo:
         return []
 
-    logger.log(LogReference.PROCREATE006, relatesTo=resource.relatesTo)
-    documents_to_superseded = []
+    logger.log(LogReference.PROUPSERT006, relatesTo=resource.relatesTo)
+    ids_to_delete = []
 
     for idx, relates_to in enumerate(resource.relatesTo):
-        # TODO - Move relates_to validation into a validator
         identifier = _validate_identifier(relates_to, idx)
         _validate_producer_id(identifier, metadata, idx)
-
-        if not can_ignore_delete_fail:
+        if can_ignore_delete_fail:
+            logger.log(
+                LogReference.PROUPSERT006a,
+                pointer_id=resource.id,
+                relatesTo=resource.relatesTo,
+            )
+        else:
             existing_pointer = _check_existing_pointer(identifier, repository, idx)
             _validate_pointer_details(existing_pointer, core_model, identifier, idx)
 
-            if relates_to.code == "replaces":
-                logger.log(
-                    LogReference.PROCREATE008,
-                    relates_to_code=relates_to.code,
-                    identifier=identifier,
-                )
-                documents_to_superseded.append(existing_pointer)
+        _append_id_if_replaces(relates_to, ids_to_delete, identifier)
 
-    return documents_to_superseded
+    return ids_to_delete
 
 
 def _validate_identifier(relates_to, idx):
@@ -251,21 +249,17 @@ def handler(
         PERMISSION_SUPERSEDE_IGNORE_DELETE_FAIL in metadata.nrl_permissions
     )
 
-    pointers_to_delete = _get_documents_to_supersede(
+    if ids_to_delete := _get_document_ids_to_supersede(
         result.resource, core_model, metadata, repository, can_ignore_delete_fail
-    )
-
-    if result.resource.relatesTo and "replaces" in [
-        relates_to.code for relates_to in result.resource.relatesTo
-    ]:
+    ):
         logger.log(
             LogReference.PROUPSERT010,
             pointer_id=result.resource.id,
-            pointers_to_delete=pointers_to_delete,
+            ids_to_delete=ids_to_delete,
             can_ignore_delete_fail=can_ignore_delete_fail,
         )
         saved_model = repository.supersede(
-            core_model, pointers_to_delete, can_ignore_delete_fail
+            core_model, ids_to_delete, can_ignore_delete_fail
         )
         logger.log(LogReference.PROUPSERT999)
         return NRLResponse.RESOURCE_SUPERSEDED(resource_id=saved_model.id)

--- a/layer/nrlf/core/constants.py
+++ b/layer/nrlf/core/constants.py
@@ -33,6 +33,7 @@ PERMISSION_AUDIT_DATES_FROM_PAYLOAD = "audit-dates-from-payload"
 PERMISSION_SUPERSEDE_IGNORE_DELETE_FAIL = "supersede-ignore-delete-fail"
 PERMISSION_ALLOW_ALL_POINTER_TYPES = "allow-all-pointer-types"
 
+
 PRODUCER_URL_PATH = "/producer/FHIR/R4/DocumentReference"
 
 
@@ -66,5 +67,6 @@ TYPE_CATEGORIES = {
     PointerTypes.LLOYD_GEORGE_FOLDER.value: Categories.CARE_PLAN.value,
     PointerTypes.NEWS2_CHART.value: Categories.OBSERVATIONS.value,
 }
+
 
 SYSTEM_SHORT_IDS = {"http://snomed.info/sct": "SCT"}

--- a/layer/nrlf/core/constants.py
+++ b/layer/nrlf/core/constants.py
@@ -33,7 +33,6 @@ PERMISSION_AUDIT_DATES_FROM_PAYLOAD = "audit-dates-from-payload"
 PERMISSION_SUPERSEDE_IGNORE_DELETE_FAIL = "supersede-ignore-delete-fail"
 PERMISSION_ALLOW_ALL_POINTER_TYPES = "allow-all-pointer-types"
 
-
 PRODUCER_URL_PATH = "/producer/FHIR/R4/DocumentReference"
 
 
@@ -50,3 +49,22 @@ class PointerTypes(Enum):
     @staticmethod
     def list():
         return list(map(lambda type: type.value, PointerTypes))
+
+
+class Categories(Enum):
+    CARE_PLAN = "http://snomed.info/sct|734163000"
+    OBSERVATIONS = "http://snomed.info/sct|1102421000000108"
+
+
+TYPE_CATEGORIES = {
+    PointerTypes.MENTAL_HEALTH_PLAN.value: Categories.CARE_PLAN.value,
+    PointerTypes.EMERGENCY_HEALTHCARE_PLAN.value: Categories.CARE_PLAN.value,
+    PointerTypes.EOL_COORDINATION_SUMMARY.value: Categories.CARE_PLAN.value,
+    PointerTypes.RESPECT_FORM.value: Categories.CARE_PLAN.value,
+    PointerTypes.CONTINGENCY_PLAN.value: Categories.CARE_PLAN.value,
+    PointerTypes.EOL_CARE_PLAN.value: Categories.CARE_PLAN.value,
+    PointerTypes.LLOYD_GEORGE_FOLDER.value: Categories.CARE_PLAN.value,
+    PointerTypes.NEWS2_CHART.value: Categories.OBSERVATIONS.value,
+}
+
+SYSTEM_SHORT_IDS = {"http://snomed.info/sct": "SCT"}

--- a/layer/nrlf/core/dynamodb/model.py
+++ b/layer/nrlf/core/dynamodb/model.py
@@ -320,7 +320,12 @@ class DocumentPointer(DynamoDBModel):
 
     @property
     def indexes(self) -> Dict[str, str]:
-        indexes = {"pk": self.pk, "sk": self.sk, "doc_key": self.doc_key}
+        indexes = {
+            "pk": self.pk,
+            "sk": self.sk,
+            "patient_key": self.patient_key,
+            "patient_sort": self.patient_sort,
+        }
 
         if self.masterid_key:
             indexes["masterid_key"] = self.masterid_key
@@ -331,15 +336,28 @@ class DocumentPointer(DynamoDBModel):
     def pk(self) -> str:
         """
         Returns the pk (partition key) for the DocumentPointer
-        TODO-NOW: Add docs
         """
-
-        return "#".join([DBPrefix.Patient.value, self.nhs_number])
+        return "#".join([DBPrefix.DocumentPointer.value, self.id])
 
     @property
     def sk(self) -> str:
         """
         Returns the sk (sort key) for the DocumentPointer
+        """
+        return "#".join([DBPrefix.DocumentPointer.value, self.id])
+
+    @property
+    def patient_key(self) -> str:
+        """
+        Returns the patient gsi pk (partition key) for the DocumentPointer
+        TODO-NOW: Add docs
+        """
+        return "#".join([DBPrefix.Patient.value, self.nhs_number])
+
+    @property
+    def patient_sort(self) -> str:
+        """
+        Returns the patient gsi sk (sort key) for the DocumentPointer
         TODO-NOW: Add docs
         """
         return "#".join(
@@ -354,14 +372,6 @@ class DocumentPointer(DynamoDBModel):
                 self.id,
             ]
         )
-
-    @property
-    def doc_key(self) -> str:
-        """
-        Returns the doc_key for the DocumentPointer
-        TODO-NOW: Add docs
-        """
-        return "#".join([DBPrefix.DocumentPointer.value, self.id])
 
     @property
     def masterid_key(self) -> str | None:

--- a/layer/nrlf/core/dynamodb/model.py
+++ b/layer/nrlf/core/dynamodb/model.py
@@ -91,7 +91,7 @@ class DocumentPointer(DynamoDBModel):
         # Get identifiers
         subject_identifier = getattr(resource.subject, "identifier")
         custodian_identifier = getattr(resource.custodian, "identifier")
-        if len(resource.author) != 1:
+        if not resource.author or len(resource.author) != 1:
             raise ValueError("DocumentReference.author must have exactly one item")
         author_identifier = getattr(resource.author[0], "identifier")
 
@@ -103,7 +103,7 @@ class DocumentPointer(DynamoDBModel):
 
         # Get type fields
         type_coding = getattr(resource.type, "coding")
-        if len(type_coding) != 1:
+        if not type_coding or len(type_coding) != 1:
             raise ValueError("DocumentReference.type.coding must have exactly one item")
         pointer_type = f"{type_coding[0].system}|{type_coding[0].code}"
         type_system_id = get_id_for_system(
@@ -112,10 +112,10 @@ class DocumentPointer(DynamoDBModel):
         type_id = f"{type_system_id}-{type_coding[0].code}"
 
         # Get category fields
-        if len(resource.category) != 1:
+        if not resource.category or len(resource.category) != 1:
             raise ValueError("DocumentReference.category must have exactly one item")
         category_coding = getattr(resource.category[0], "coding")
-        if len(category_coding) != 1:
+        if not category_coding or len(category_coding) != 1:
             raise ValueError(
                 "DocumentReference.category.coding must have exactly one item"
             )

--- a/layer/nrlf/core/dynamodb/repository.py
+++ b/layer/nrlf/core/dynamodb/repository.py
@@ -425,3 +425,29 @@ class DocumentPointerRepository(Repository[DocumentPointer]):
             ) from exc
 
         return item
+
+    def delete_by_id(self, id: str):
+        """
+        Delete a DocumentPointer resource by ID.
+        """
+        pointer = self.get_by_id(id)
+
+        if pointer is None:
+            return
+
+        try:
+            result = self.table.delete_item(
+                Key={"pk": pointer.pk, "sk": pointer.sk},
+                ConditionExpression="attribute_exists(doc_key)",
+                ReturnConsumedCapacity="INDEXES",
+            )
+        except ClientError as exc:
+            logger.log(
+                LogReference.REPOSITORY026,
+                exc_info=sys.exc_info(),
+                stacklevel=5,
+                error=str(exc),
+            )
+            raise exc
+
+        return result

--- a/layer/nrlf/core/dynamodb/repository.py
+++ b/layer/nrlf/core/dynamodb/repository.py
@@ -178,7 +178,6 @@ class DocumentPointerRepository(Repository[DocumentPointer]):
         query = {
             "IndexName": "patient_gsi",
             "KeyConditionExpression": " AND ".join(key_conditions),
-            "ExpressionAttributeNames": expression_names,
             "ExpressionAttributeValues": expression_values,
             "Select": "COUNT",
             "ReturnConsumedCapacity": "INDEXES",
@@ -186,6 +185,9 @@ class DocumentPointerRepository(Repository[DocumentPointer]):
 
         if filter_expressions:
             query["FilterExpression"] = " AND ".join(filter_expressions)
+
+        if expression_names:
+            query["ExpressionAttributeNames"] = expression_names
 
         logger.log(LogReference.REPOSITORY017, query=query)
 
@@ -270,11 +272,15 @@ class DocumentPointerRepository(Repository[DocumentPointer]):
         query = {
             "IndexName": "patient_gsi",
             "KeyConditionExpression": " AND ".join(key_conditions),
-            "FilterExpression": " AND ".join(filter_expressions),
-            "ExpressionAttributeNames": expression_names or None,
             "ExpressionAttributeValues": expression_values,
             "ReturnConsumedCapacity": "INDEXES",
         }
+
+        if filter_expressions:
+            query["FilterExpression"] = " AND ".join(filter_expressions)
+
+        if expression_names:
+            query["ExpressionAttributeNames"] = expression_names
 
         yield from self._query(**query)
 

--- a/layer/nrlf/core/dynamodb/tests/test_model.py
+++ b/layer/nrlf/core/dynamodb/tests/test_model.py
@@ -1,11 +1,11 @@
 import json
-from datetime import datetime, timezone
 
 import pytest
 from freezegun import freeze_time
 
 from nrlf.core.constants import PointerTypes
 from nrlf.core.dynamodb.model import DocumentPointer, DynamoDBModel
+from nrlf.core.utils import create_fhir_instant
 from nrlf.producer.fhir.r4.model import DocumentReference
 from nrlf.tests.data import load_document_reference, load_document_reference_json
 
@@ -37,13 +37,17 @@ def test_document_pointer_init():
         id="X26-999999-999999-99999999",
         nhs_number="9999999999",
         custodian="X26",
+        author="X26",
+        master_identifier="1111-11111-111111",
         producer_id=None,  # type: ignore
         type="http://snomed.info/sct|123456789",
+        type_id="SCT-123456789",
+        category="http://snomed.info/sct|987654321",
+        category_id="SCT-987654321",
         source="NRLF",
         version=1,
         document="document",
-        created_on=datetime.now(tz=timezone.utc).isoformat(timespec="milliseconds")
-        + "Z",
+        created_on=create_fhir_instant(),
         document_id="document_id",
     )
 
@@ -56,18 +60,21 @@ def test_document_pointer_init():
         "nhs_number": "9999999999",
         "custodian": "X26",
         "custodian_suffix": None,
+        "author": "X26",
         "producer_id": "X26",
         "type": "http://snomed.info/sct|123456789",
+        "type_id": "SCT-123456789",
+        "category": "http://snomed.info/sct|987654321",
+        "category_id": "SCT-987654321",
+        "master_identifier": "1111-11111-111111",
         "source": "NRLF",
         "version": 1,
         "document": "document",
-        "created_on": "2024-01-01T00:00:00.000+00:00Z",
-        "pk": "D#X26#999999-999999-99999999",
-        "sk": "D#X26#999999-999999-99999999",
-        "pk_1": "P#9999999999",
-        "sk_1": "CO#2024-01-01T00:00:00.000+00:00Z#X26#999999-999999-99999999",
-        "pk_2": "O#X26",
-        "sk_2": "CO#2024-01-01T00:00:00.000+00:00Z#X26#999999-999999-99999999",
+        "created_on": "2024-01-01T00:00:00.000Z",
+        "pk": "P#9999999999",
+        "sk": "C#SCT-987654321#T#SCT-123456789#CO#2024-01-01T00:00:00.000Z#D#X26-999999-999999-99999999",
+        "doc_key": "D#X26-999999-999999-99999999",
+        "masterid_key": "O#X26#MI#1111-11111-111111",
         "schemas": [],
         "updated_on": None,
     }
@@ -82,23 +89,25 @@ def test_document_pointer_from_document_reference_valid():
     document = model_data.pop("document")
 
     assert model_data == {
-        "created_on": "2024-01-01T00:00:00.000+00:00Z",
+        "created_on": "2024-01-01T00:00:00.000Z",
         "custodian": "Y05868",
         "custodian_suffix": None,
+        "author": "Y05868",
         "id": "Y05868-99999-99999-999999",
+        "master_identifier": None,
         "nhs_number": "6700028191",
         "producer_id": "Y05868",
         "schemas": [],
         "source": "NRLF",
         "type": PointerTypes.MENTAL_HEALTH_PLAN.value,
+        "type_id": "SCT-736253002",
+        "category": "http://snomed.info/sct|734163000",
+        "category_id": "SCT-734163000",
         "updated_on": None,
         "version": 1,
-        "pk": "D#Y05868#99999-99999-999999",
-        "sk": "D#Y05868#99999-99999-999999",
-        "pk_1": "P#6700028191",
-        "sk_1": "CO#2024-01-01T00:00:00.000+00:00Z#Y05868#99999-99999-999999",
-        "pk_2": "O#Y05868",
-        "sk_2": "CO#2024-01-01T00:00:00.000+00:00Z#Y05868#99999-99999-999999",
+        "pk": "P#6700028191",
+        "sk": "C#SCT-734163000#T#SCT-736253002#CO#2024-01-01T00:00:00.000Z#D#Y05868-99999-99999-999999",
+        "doc_key": "D#Y05868-99999-99999-999999",
     }
 
     assert json.loads(document) == doc_ref.dict(exclude_none=True)
@@ -107,30 +116,32 @@ def test_document_pointer_from_document_reference_valid():
 def test_document_pointer_from_document_reference_valid_with_created_on():
     doc_ref = load_document_reference("Y05868-736253002-Valid")
     model = DocumentPointer.from_document_reference(
-        doc_ref, created_on="2024-02-02T12:34:56.000+00:00Z"
+        doc_ref, created_on="2024-02-02T12:34:56.000Z"
     )
 
     model_data = model.dict()
     document = model_data.pop("document")
 
     assert model_data == {
-        "created_on": "2024-02-02T12:34:56.000+00:00Z",
+        "created_on": "2024-02-02T12:34:56.000Z",
         "custodian": "Y05868",
         "custodian_suffix": None,
+        "author": "Y05868",
         "id": "Y05868-99999-99999-999999",
+        "master_identifier": None,
         "nhs_number": "6700028191",
         "producer_id": "Y05868",
         "schemas": [],
         "source": "NRLF",
         "type": PointerTypes.MENTAL_HEALTH_PLAN.value,
+        "type_id": "SCT-736253002",
+        "category": "http://snomed.info/sct|734163000",
+        "category_id": "SCT-734163000",
         "updated_on": None,
         "version": 1,
-        "pk": "D#Y05868#99999-99999-999999",
-        "sk": "D#Y05868#99999-99999-999999",
-        "pk_1": "P#6700028191",
-        "sk_1": "CO#2024-02-02T12:34:56.000+00:00Z#Y05868#99999-99999-999999",
-        "pk_2": "O#Y05868",
-        "sk_2": "CO#2024-02-02T12:34:56.000+00:00Z#Y05868#99999-99999-999999",
+        "pk": "P#6700028191",
+        "sk": "C#SCT-734163000#T#SCT-736253002#CO#2024-02-02T12:34:56.000Z#D#Y05868-99999-99999-999999",
+        "doc_key": "D#Y05868-99999-99999-999999",
     }
 
     assert json.loads(document) == doc_ref.dict(exclude_none=True)

--- a/layer/nrlf/core/dynamodb/tests/test_model.py
+++ b/layer/nrlf/core/dynamodb/tests/test_model.py
@@ -71,9 +71,10 @@ def test_document_pointer_init():
         "version": 1,
         "document": "document",
         "created_on": "2024-01-01T00:00:00.000Z",
-        "pk": "P#9999999999",
-        "sk": "C#SCT-987654321#T#SCT-123456789#CO#2024-01-01T00:00:00.000Z#D#X26-999999-999999-99999999",
-        "doc_key": "D#X26-999999-999999-99999999",
+        "pk": "D#X26-999999-999999-99999999",
+        "sk": "D#X26-999999-999999-99999999",
+        "patient_key": "P#9999999999",
+        "patient_sort": "C#SCT-987654321#T#SCT-123456789#CO#2024-01-01T00:00:00.000Z#D#X26-999999-999999-99999999",
         "masterid_key": "O#X26#MI#1111-11111-111111",
         "schemas": [],
         "updated_on": None,
@@ -105,9 +106,10 @@ def test_document_pointer_from_document_reference_valid():
         "category_id": "SCT-734163000",
         "updated_on": None,
         "version": 1,
-        "pk": "P#6700028191",
-        "sk": "C#SCT-734163000#T#SCT-736253002#CO#2024-01-01T00:00:00.000Z#D#Y05868-99999-99999-999999",
-        "doc_key": "D#Y05868-99999-99999-999999",
+        "pk": "D#Y05868-99999-99999-999999",
+        "sk": "D#Y05868-99999-99999-999999",
+        "patient_key": "P#6700028191",
+        "patient_sort": "C#SCT-734163000#T#SCT-736253002#CO#2024-01-01T00:00:00.000Z#D#Y05868-99999-99999-999999",
     }
 
     assert json.loads(document) == doc_ref.dict(exclude_none=True)
@@ -139,9 +141,10 @@ def test_document_pointer_from_document_reference_valid_with_created_on():
         "category_id": "SCT-734163000",
         "updated_on": None,
         "version": 1,
-        "pk": "P#6700028191",
-        "sk": "C#SCT-734163000#T#SCT-736253002#CO#2024-02-02T12:34:56.000Z#D#Y05868-99999-99999-999999",
-        "doc_key": "D#Y05868-99999-99999-999999",
+        "pk": "D#Y05868-99999-99999-999999",
+        "sk": "D#Y05868-99999-99999-999999",
+        "patient_key": "P#6700028191",
+        "patient_sort": "C#SCT-734163000#T#SCT-736253002#CO#2024-02-02T12:34:56.000Z#D#Y05868-99999-99999-999999",
     }
 
     assert json.loads(document) == doc_ref.dict(exclude_none=True)

--- a/layer/nrlf/tests/dynamodb.py
+++ b/layer/nrlf/tests/dynamodb.py
@@ -14,15 +14,17 @@ def create_document_pointer_table(config: Config, dynamodb: DynamoDBServiceResou
         AttributeDefinitions=[
             {"AttributeName": "pk", "AttributeType": "S"},
             {"AttributeName": "sk", "AttributeType": "S"},
-            {"AttributeName": "doc_key", "AttributeType": "S"},
+            {"AttributeName": "patient_key", "AttributeType": "S"},
+            {"AttributeName": "patient_sort", "AttributeType": "S"},
             {"AttributeName": "masterid_key", "AttributeType": "S"},
         ],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
         GlobalSecondaryIndexes=[
             {
-                "IndexName": "dockey_gsi",
+                "IndexName": "patient_gsi",
                 "KeySchema": [
-                    {"AttributeName": "doc_key", "KeyType": "HASH"},
+                    {"AttributeName": "patient_key", "KeyType": "HASH"},
+                    {"AttributeName": "patient_sort", "KeyType": "RANGE"},
                 ],
                 "Projection": {"ProjectionType": "ALL"},
             },

--- a/layer/nrlf/tests/dynamodb.py
+++ b/layer/nrlf/tests/dynamodb.py
@@ -14,26 +14,22 @@ def create_document_pointer_table(config: Config, dynamodb: DynamoDBServiceResou
         AttributeDefinitions=[
             {"AttributeName": "pk", "AttributeType": "S"},
             {"AttributeName": "sk", "AttributeType": "S"},
-            {"AttributeName": "pk_1", "AttributeType": "S"},
-            {"AttributeName": "sk_1", "AttributeType": "S"},
-            {"AttributeName": "pk_2", "AttributeType": "S"},
-            {"AttributeName": "sk_2", "AttributeType": "S"},
+            {"AttributeName": "doc_key", "AttributeType": "S"},
+            {"AttributeName": "masterid_key", "AttributeType": "S"},
         ],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
         GlobalSecondaryIndexes=[
             {
-                "IndexName": "idx_gsi_1",
+                "IndexName": "dockey_gsi",
                 "KeySchema": [
-                    {"AttributeName": "pk_1", "KeyType": "HASH"},
-                    {"AttributeName": "sk_1", "KeyType": "RANGE"},
+                    {"AttributeName": "doc_key", "KeyType": "HASH"},
                 ],
                 "Projection": {"ProjectionType": "ALL"},
             },
             {
-                "IndexName": "idx_gsi_2",
+                "IndexName": "masterid_gsi",
                 "KeySchema": [
-                    {"AttributeName": "pk_2", "KeyType": "HASH"},
-                    {"AttributeName": "sk_2", "KeyType": "RANGE"},
+                    {"AttributeName": "masterid_key", "KeyType": "HASH"},
                 ],
                 "Projection": {"ProjectionType": "ALL"},
             },

--- a/terraform/infrastructure/dynamodb__document-pointer.tf
+++ b/terraform/infrastructure/dynamodb__document-pointer.tf
@@ -20,7 +20,12 @@ resource "aws_dynamodb_table" "document-pointer" {
   }
 
   attribute {
-    name = "doc_key"
+    name = "patient_key"
+    type = "S"
+  }
+
+  attribute {
+    name = "patient_sort"
     type = "S"
   }
 
@@ -30,8 +35,9 @@ resource "aws_dynamodb_table" "document-pointer" {
   }
 
   global_secondary_index {
-    name            = "dockey_gsi"
-    hash_key        = "doc_key"
+    name            = "patient_gsi"
+    hash_key        = "patient_key"
+    range_key       = "patient_sort"
     projection_type = "ALL"
   }
 

--- a/terraform/infrastructure/dynamodb__document-pointer.tf
+++ b/terraform/infrastructure/dynamodb__document-pointer.tf
@@ -20,36 +20,24 @@ resource "aws_dynamodb_table" "document-pointer" {
   }
 
   attribute {
-    name = "pk_1"
+    name = "doc_key"
     type = "S"
   }
 
   attribute {
-    name = "sk_1"
-    type = "S"
-  }
-
-  attribute {
-    name = "pk_2"
-    type = "S"
-  }
-
-  attribute {
-    name = "sk_2"
+    name = "created_sk"
     type = "S"
   }
 
   global_secondary_index {
-    name            = "idx_gsi_1"
-    hash_key        = "pk_1"
-    range_key       = "sk_1"
+    name            = "dockey_gsi"
+    hash_key        = "doc_key"
     projection_type = "ALL"
   }
 
   global_secondary_index {
-    name            = "idx_gsi_2"
-    hash_key        = "pk_2"
-    range_key       = "sk_2"
+    name            = "masterid_gsi"
+    hash_key        = "masterid_key"
     projection_type = "ALL"
   }
 

--- a/terraform/infrastructure/dynamodb__document-pointer.tf
+++ b/terraform/infrastructure/dynamodb__document-pointer.tf
@@ -25,7 +25,7 @@ resource "aws_dynamodb_table" "document-pointer" {
   }
 
   attribute {
-    name = "created_sk"
+    name = "masterid_key"
     type = "S"
   }
 

--- a/tests/features/consumer/countDocumentReference-success.feature
+++ b/tests/features/consumer/countDocumentReference-success.feature
@@ -11,9 +11,11 @@ Feature: Consumer - countDocumentReference - Success Scenarios
       | subject     | 9278693472                       |
       | status      | current                          |
       | type        | 736253002                        |
+      | category    | 734163000                        |
       | contentType | application/pdf                  |
       | url         | https://example.org/my-doc.pdf   |
       | custodian   | 8FW23                            |
+      | author      | 8FW23                            |
     When consumer 'RX898' counts DocumentReferences with parameters:
       | parameter          | value                                         |
       | subject:identifier | https://fhir.nhs.uk/Id/nhs-number\|9278693472 |
@@ -33,9 +35,11 @@ Feature: Consumer - countDocumentReference - Success Scenarios
       | subject     | 9999999999                       |
       | status      | current                          |
       | type        | 736253002                        |
+      | category    | 734163000                        |
       | contentType | application/pdf                  |
       | url         | https://example.org/my-doc.pdf   |
       | custodian   | 8FW23                            |
+      | author      | 8FW23                            |
     When consumer 'RX898' counts DocumentReferences with parameters:
       | parameter          | value                                         |
       | subject:identifier | https://fhir.nhs.uk/Id/nhs-number\|9995001624 |
@@ -56,27 +60,33 @@ Feature: Consumer - countDocumentReference - Success Scenarios
       | subject     | 9278693472                     |
       | status      | current                        |
       | type        | 736253002                      |
+      | category    | 734163000                      |
       | contentType | application/pdf                |
       | url         | https://example.org/my-doc.pdf |
       | custodian   | 8FW23                          |
+      | author      | 8FW23                          |
     And a DocumentReference resource exists with values:
       | property    | value                           |
       | id          | 8FW23-1114567890-CountMultiple2 |
       | subject     | 9278693472                      |
       | status      | current                         |
       | type        | 887701000000100                 |
+      | category    | 734163000                       |
       | contentType | application/pdf                 |
       | url         | https://example.org/my-doc2.pdf |
       | custodian   | 8FW23                           |
+      | author      | 8FW23                           |
     And a DocumentReference resource exists with values:
       | property    | value                           |
       | id          | 8FW23-1114567890-CountMultiple3 |
       | subject     | 9278693472                      |
       | status      | current                         |
       | type        | 887701000000100                 |
+      | category    | 734163000                       |
       | contentType | application/pdf                 |
       | url         | https://example.org/my-doc3.pdf |
       | custodian   | 8FW23                           |
+      | author      | 8FW23                           |
     When consumer 'RX898' counts DocumentReferences with parameters:
       | parameter          | value                                         |
       | subject:identifier | https://fhir.nhs.uk/Id/nhs-number\|9278693472 |

--- a/tests/features/consumer/readDocumentReference-failure.feature
+++ b/tests/features/consumer/readDocumentReference-failure.feature
@@ -90,9 +90,11 @@ Feature: Consumer - readDocumentReference - Failure Scenarios
       | subject     | 9278693472                             |
       | status      | current                                |
       | type        | 887701000000100                        |
+      | category    | 734163000                              |
       | contentType | application/pdf                        |
       | url         | https://example.org/my-doc.pdf         |
       | custodian   | 02V                                    |
+      | author      | 02V                                    |
     When consumer 'RX898' reads a DocumentReference with ID '02V-1111111111-ReadDocRefNoAuthForType'
     Then the response status code is 403
     And the response is an OperationOutcome with 1 issue
@@ -152,9 +154,11 @@ Feature: Consumer - readDocumentReference - Failure Scenarios
       | subject     | 9278693472                               |
       | status      | current                                  |
       | type        | 887701000000100                          |
+      | category    | 734163000                                |
       | contentType | application/pdf                          |
       | url         | https://example.org/my-doc.pdf           |
       | custodian   | 02V                                      |
+      | author      | 02V                                      |
     When consumer 'RX898' reads a DocumentReference with ID '02V-1111111111-ReadDocRefNoAuthForTypeS3'
     Then the response status code is 403
     And the response is an OperationOutcome with 1 issue

--- a/tests/features/consumer/readDocumentReference-success.feature
+++ b/tests/features/consumer/readDocumentReference-success.feature
@@ -11,9 +11,11 @@ Feature: Consumer - readDocumentReference - Success Scenarios
       | subject     | 9999999999                               |
       | status      | current                                  |
       | type        | 736253002                                |
+      | category    | 734163000                                |
       | contentType | application/pdf                          |
       | url         | https://example.org/my-doc.pdf           |
       | custodian   | RX898                                    |
+      | author      | RX898                                    |
     When consumer 'RX898' reads a DocumentReference with ID 'RX898-9999999999-ReadDocRefSameCustodian'
     Then the response status code is 200
     And the response is a DocumentReference with JSON value:
@@ -30,6 +32,17 @@ Feature: Consumer - readDocumentReference - Success Scenarios
             }
           ]
         },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "734163000",
+                "display": "Care plan"
+              }
+            ]
+          }
+        ],
         "subject": {
           "identifier": {
             "system": "https://fhir.nhs.uk/Id/nhs-number",
@@ -42,6 +55,14 @@ Feature: Consumer - readDocumentReference - Success Scenarios
             "value": "RX898"
           }
         },
+        "author": [
+          {
+            "identifier": {
+              "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+              "value": "RX898"
+            }
+          }
+        ],
         "content": [
           {
             "attachment": {
@@ -64,9 +85,11 @@ Feature: Consumer - readDocumentReference - Success Scenarios
       | subject     | 9999999999                             |
       | status      | current                                |
       | type        | 736253002                              |
+      | category    | 734163000                              |
       | contentType | application/pdf                        |
       | url         | https://example.org/my-doc.pdf         |
       | custodian   | X26                                    |
+      | author      | RX898                                  |
     When consumer 'RX898' reads a DocumentReference with ID 'X26-9999999999-ReadDocRefDiffCustodian'
     Then the response status code is 200
     And the response is a DocumentReference with JSON value:
@@ -83,6 +106,17 @@ Feature: Consumer - readDocumentReference - Success Scenarios
             }
           ]
         },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "734163000",
+                "display": "Care plan"
+              }
+            ]
+          }
+        ],
         "subject": {
           "identifier": {
             "system": "https://fhir.nhs.uk/Id/nhs-number",
@@ -95,6 +129,14 @@ Feature: Consumer - readDocumentReference - Success Scenarios
             "value": "X26"
           }
         },
+        "author": [
+          {
+            "identifier": {
+              "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+              "value": "RX898"
+            }
+          }
+        ],
         "content": [
           {
             "attachment": {
@@ -117,8 +159,10 @@ Feature: Consumer - readDocumentReference - Success Scenarios
       | subject     | 9999999999                                 |
       | status      | current                                    |
       | type        | 736253002                                  |
+      | category    | 734163000                                  |
       | contentType | application/pdf                            |
       | url         | https://example.org/my-doc.pdf             |
       | custodian   | RX898\|001                                 |
+      | author      | RX898                                      |
     When consumer 'RX898' reads a DocumentReference with ID 'RX898%7C001-1234567890-ReadDocRefUrlEncoded'
     Then the response status code is 200

--- a/tests/features/consumer/searchDocumentReference-failure.feature
+++ b/tests/features/consumer/searchDocumentReference-failure.feature
@@ -146,9 +146,11 @@ Feature: Consumer - searchDocumentReference - Failure Scenarios
       | subject     | 9278693472                        |
       | status      | current                           |
       | type        | 736253002                         |
+      | category    | 734163000                         |
       | contentType | application/pdf                   |
       | url         | https://example.org/my-doc.pdf    |
       | custodian   | 8FW23                             |
+      | author      | 8FW23                             |
     When consumer 'RX898' searches for DocumentReferences with parameters:
       | parameter | value      |
       | subject   | 9278693472 |

--- a/tests/features/consumer/searchDocumentReference-success.feature
+++ b/tests/features/consumer/searchDocumentReference-success.feature
@@ -11,9 +11,11 @@ Feature: Consumer - searchDocumentReference - Success Scenarios
       | subject     | 9278693472                      |
       | status      | current                         |
       | type        | 736253002                       |
+      | category    | 734163000                       |
       | contentType | application/pdf                 |
       | url         | https://example.org/my-doc.pdf  |
       | custodian   | 02V                             |
+      | author      | 02V                             |
     When consumer 'RX898' searches for DocumentReferences with parameters:
       | parameter | value      |
       | subject   | 9278693472 |
@@ -28,9 +30,11 @@ Feature: Consumer - searchDocumentReference - Success Scenarios
       | subject     | 9278693472                      |
       | status      | current                         |
       | type        | 736253002                       |
+      | category    | 734163000                       |
       | contentType | application/pdf                 |
       | url         | https://example.org/my-doc.pdf  |
       | custodian   | 02V                             |
+      | author      | 02V                             |
 
   Scenario: Search for multiple DocumentReferences by NHS number
     Given the application 'DataShare' (ID 'z00z-y11y-x22x') is registered to access the API
@@ -43,27 +47,33 @@ Feature: Consumer - searchDocumentReference - Success Scenarios
       | subject     | 9278693472                            |
       | status      | current                               |
       | type        | 736253002                             |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc-1.pdf      |
       | custodian   | 02V                                   |
+      | author      | 02V                                   |
     And a DocumentReference resource exists with values:
       | property    | value                                 |
       | id          | 02V-1111111111-SearchMultipleRefTest2 |
       | subject     | 9278693472                            |
       | status      | current                               |
       | type        | 736253002                             |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc-2.pdf      |
       | custodian   | 02V                                   |
+      | author      | 02V                                   |
     And a DocumentReference resource exists with values:
       | property    | value                                 |
       | id          | 02V-1111111111-SearchMultipleRefTest3 |
       | subject     | 9278693472                            |
       | status      | current                               |
       | type        | 887701000000100                       |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc-3.pdf      |
       | custodian   | 02V                                   |
+      | author      | 02V                                   |
     When consumer 'RX898' searches for DocumentReferences with parameters:
       | parameter | value      |
       | subject   | 9278693472 |
@@ -78,18 +88,22 @@ Feature: Consumer - searchDocumentReference - Success Scenarios
       | subject     | 9278693472                            |
       | status      | current                               |
       | type        | 736253002                             |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc-1.pdf      |
       | custodian   | 02V                                   |
+      | author      | 02V                                   |
     And the Bundle contains an DocumentReference with values
       | property    | value                                 |
       | id          | 02V-1111111111-SearchMultipleRefTest2 |
       | subject     | 9278693472                            |
       | status      | current                               |
       | type        | 736253002                             |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc-2.pdf      |
       | custodian   | 02V                                   |
+      | author      | 02V                                   |
     And the Bundle does not contain a DocumentReference with ID '02V-1111111111-SearchMultipleRefTest3'
 
   Scenario: Search for multiple DocumentReferences by NHS number - S3 authorisation
@@ -104,27 +118,33 @@ Feature: Consumer - searchDocumentReference - Success Scenarios
       | subject     | 9278693472                            |
       | status      | current                               |
       | type        | 736253002                             |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc-1.pdf      |
       | custodian   | 02V                                   |
+      | author      | 02V                                   |
     And a DocumentReference resource exists with values:
       | property    | value                                 |
       | id          | 02V-1111111111-SearchMultipleRefTest2 |
       | subject     | 9278693472                            |
       | status      | current                               |
       | type        | 736253002                             |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc-2.pdf      |
       | custodian   | 02V                                   |
+      | author      | 02V                                   |
     And a DocumentReference resource exists with values:
       | property    | value                                 |
       | id          | 02V-1111111111-SearchMultipleRefTest3 |
       | subject     | 9278693472                            |
       | status      | current                               |
       | type        | 887701000000100                       |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc-3.pdf      |
       | custodian   | 02V                                   |
+      | author      | 02V                                   |
     When consumer 'RX898' searches for DocumentReferences with parameters:
       | parameter | value      |
       | subject   | 9278693472 |
@@ -138,18 +158,22 @@ Feature: Consumer - searchDocumentReference - Success Scenarios
       | subject     | 9278693472                            |
       | status      | current                               |
       | type        | 736253002                             |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc-1.pdf      |
       | custodian   | 02V                                   |
+      | author      | 02V                                   |
     And the Bundle contains an DocumentReference with values
       | property    | value                                 |
       | id          | 02V-1111111111-SearchMultipleRefTest2 |
       | subject     | 9278693472                            |
       | status      | current                               |
       | type        | 736253002                             |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc-2.pdf      |
       | custodian   | 02V                                   |
+      | author      | 02V                                   |
     And the Bundle does not contain a DocumentReference with ID '02V-1111111111-SearchMultipleRefTest3'
 
 # No pointers found

--- a/tests/features/consumer/searchPostDocumentReference-failure.feature
+++ b/tests/features/consumer/searchPostDocumentReference-failure.feature
@@ -146,9 +146,11 @@ Feature: Consumer - searchDocumentReference - Failure Scenarios
       | subject     | 9278693472                        |
       | status      | current                           |
       | type        | 736253002                         |
+      | category    | 734163000                         |
       | contentType | application/pdf                   |
       | url         | https://example.org/my-doc.pdf    |
       | custodian   | 8FW23                             |
+      | author      | 8FW23                             |
     When consumer 'RX898' searches for DocumentReferences using POST with request body:
       | key     | value      |
       | subject | 9278693472 |

--- a/tests/features/consumer/searchPostDocumentReference-success.feature
+++ b/tests/features/consumer/searchPostDocumentReference-success.feature
@@ -11,9 +11,11 @@ Feature: Consumer - searchDocumentReference - Success Scenarios
       | subject     | 9278693472                        |
       | status      | current                           |
       | type        | 736253002                         |
+      | category    | 734163000                         |
       | contentType | application/pdf                   |
       | url         | https://example.org/my-doc.pdf    |
       | custodian   | 8FW23                             |
+      | author      | 8FW23                             |
     When consumer 'RX898' searches for DocumentReferences with parameters:
       | parameter | value      |
       | subject   | 9278693472 |
@@ -28,9 +30,11 @@ Feature: Consumer - searchDocumentReference - Success Scenarios
       | subject     | 9278693472                        |
       | status      | current                           |
       | type        | 736253002                         |
+      | category    | 734163000                         |
       | contentType | application/pdf                   |
       | url         | https://example.org/my-doc.pdf    |
       | custodian   | 8FW23                             |
+      | author      | 8FW23                             |
 
   Scenario: Search for multiple DocumentReferences by NHS number
     Given the application 'DataShare' (ID 'z00z-y11y-x22x') is registered to access the API
@@ -43,27 +47,33 @@ Feature: Consumer - searchDocumentReference - Success Scenarios
       | subject     | 9278693472                            |
       | status      | current                               |
       | type        | 736253002                             |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc-1.pdf      |
       | custodian   | X26                                   |
+      | author      | X26                                   |
     And a DocumentReference resource exists with values:
       | property    | value                                 |
       | id          | X26-1111111111-SearchMultipleRefTest2 |
       | subject     | 9278693472                            |
       | status      | current                               |
       | type        | 736253002                             |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc-2.pdf      |
       | custodian   | X26                                   |
+      | author      | X26                                   |
     And a DocumentReference resource exists with values:
       | property    | value                                             |
       | id          | X26-1111111111-SearchMultipleRefTestDifferentType |
       | subject     | 9278693472                                        |
       | status      | current                                           |
       | type        | 887701000000100                                   |
+      | category    | 734163000                                         |
       | contentType | application/pdf                                   |
       | url         | https://example.org/my-doc-3.pdf                  |
       | custodian   | X26                                               |
+      | author      | X26                                               |
     When consumer 'RX898' searches for DocumentReferences with parameters:
       | parameter | value      |
       | subject   | 9278693472 |
@@ -77,18 +87,22 @@ Feature: Consumer - searchDocumentReference - Success Scenarios
       | subject     | 9278693472                            |
       | status      | current                               |
       | type        | 736253002                             |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc-1.pdf      |
       | custodian   | X26                                   |
+      | author      | X26                                   |
     And the Bundle contains an DocumentReference with values
       | property    | value                                 |
       | id          | X26-1111111111-SearchMultipleRefTest2 |
       | subject     | 9278693472                            |
       | status      | current                               |
       | type        | 736253002                             |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc-2.pdf      |
       | custodian   | X26                                   |
+      | author      | X26                                   |
     And the Bundle does not contain a DocumentReference with ID 'X26-1111111111-SearchMultipleRefTestDifferentType'
 
   Scenario: Search for multiple DocumentReferences by NHS number - S3 authorisation
@@ -103,27 +117,33 @@ Feature: Consumer - searchDocumentReference - Success Scenarios
       | subject     | 9278693472                            |
       | status      | current                               |
       | type        | 736253002                             |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc-1.pdf      |
       | custodian   | X26                                   |
+      | author      | X26                                   |
     And a DocumentReference resource exists with values:
       | property    | value                                 |
       | id          | X26-1111111111-SearchMultipleRefTest2 |
       | subject     | 9278693472                            |
       | status      | current                               |
       | type        | 736253002                             |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc-2.pdf      |
       | custodian   | X26                                   |
+      | author      | X26                                   |
     And a DocumentReference resource exists with values:
       | property    | value                                             |
       | id          | X26-1111111111-SearchMultipleRefTestDifferentType |
       | subject     | 9278693472                                        |
       | status      | current                                           |
       | type        | 887701000000100                                   |
+      | category    | 734163000                                         |
       | contentType | application/pdf                                   |
       | url         | https://example.org/my-doc-3.pdf                  |
       | custodian   | X26                                               |
+      | author      | X26                                               |
     When consumer 'RX898' searches for DocumentReferences with parameters:
       | parameter | value      |
       | subject   | 9278693472 |
@@ -137,18 +157,22 @@ Feature: Consumer - searchDocumentReference - Success Scenarios
       | subject     | 9278693472                            |
       | status      | current                               |
       | type        | 736253002                             |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc-1.pdf      |
       | custodian   | X26                                   |
+      | author      | X26                                   |
     And the Bundle contains an DocumentReference with values
       | property    | value                                 |
       | id          | X26-1111111111-SearchMultipleRefTest2 |
       | subject     | 9278693472                            |
       | status      | current                               |
       | type        | 736253002                             |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc-2.pdf      |
       | custodian   | X26                                   |
+      | author      | X26                                   |
     And the Bundle does not contain a DocumentReference with ID 'X26-1111111111-SearchMultipleRefTestDifferentType'
 
 # No pointers found

--- a/tests/features/producer/createDocumentReference-failure.feature
+++ b/tests/features/producer/createDocumentReference-failure.feature
@@ -138,6 +138,7 @@ Feature: Producer - createDocumentReference - Failure Scenarios
       | contentType | application/pdf                 |
       | url         | https://example.org/my-doc.pdf  |
       | custodian   | N0TANGY                         |
+      | author      | HAR1                            |
     When producer 'ANGY1' creates a DocumentReference with values:
       | property   | value                           |
       | subject    | 9278693472                      |

--- a/tests/features/producer/createDocumentReference-success.feature
+++ b/tests/features/producer/createDocumentReference-success.feature
@@ -106,6 +106,7 @@ Feature: Producer - createDocumentReference - Success Scenarios
       | contentType | application/pdf                |
       | url         | https://example.org/my-doc.pdf |
       | custodian   | ANGY1                          |
+      | author      | HAR1                           |
     When producer 'ANGY1' creates a DocumentReference with values:
       | property   | value                          |
       | subject    | 9278693472                     |

--- a/tests/features/producer/readDocumentReference-failure.feature
+++ b/tests/features/producer/readDocumentReference-failure.feature
@@ -141,9 +141,11 @@ Feature: Producer - readDocumentReference - Failure Scenarios
       | subject     | 9999999999                              |
       | status      | current                                 |
       | type        | 736253002                               |
+      | category    | 734163000                               |
       | contentType | application/pdf                         |
       | url         | https://example.org/my-doc.pdf          |
       | custodian   | RX898.001                               |
+      | author      | X26                                     |
     When producer 'RX898.001' reads a DocumentReference with ID 'RX898.001-1234567890-CustSuffixMismatch'
     Then the response status code is 200
     When producer 'RX898.002' reads a DocumentReference with ID 'RX898.001-1234567890-CustSuffixMismatch'

--- a/tests/features/producer/readDocumentReference-success.feature
+++ b/tests/features/producer/readDocumentReference-success.feature
@@ -13,9 +13,11 @@ Feature: Producer - readDocumentReference - Success Scenarios
       | subject     | 9999999999                          |
       | status      | current                             |
       | type        | 736253002                           |
+      | category    | 734163000                           |
       | contentType | application/pdf                     |
       | url         | https://example.org/my-doc.pdf      |
       | custodian   | RX898                               |
+      | author      | HAR1                                |
     When producer 'RX898' reads a DocumentReference with ID 'RX898-9999999999-ReadDocRefSameCust'
     Then the response status code is 200
     And the response is a DocumentReference with JSON value:
@@ -32,6 +34,17 @@ Feature: Producer - readDocumentReference - Success Scenarios
             }
           ]
         },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "734163000",
+                "display": "Care plan"
+              }
+            ]
+          }
+        ],
         "subject": {
           "identifier": {
             "system": "https://fhir.nhs.uk/Id/nhs-number",
@@ -44,6 +57,14 @@ Feature: Producer - readDocumentReference - Success Scenarios
             "value": "RX898"
           }
         },
+        "author": [
+          {
+            "identifier": {
+              "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+              "value": "HAR1"
+            }
+          }
+        ],
         "content": [
           {
             "attachment": {
@@ -67,9 +88,11 @@ Feature: Producer - readDocumentReference - Success Scenarios
       | subject     | 9999999999                          |
       | status      | current                             |
       | type        | 736253002                           |
+      | category    | 734163000                           |
       | contentType | application/pdf                     |
       | url         | https://example.org/my-doc.pdf      |
       | custodian   | RX898                               |
+      | author      | HAR1                                |
     When producer 'RX898' reads a DocumentReference with ID 'RX898-9999999999-ReadDocRefSameCust'
     Then the response status code is 200
     And the response is a DocumentReference with JSON value:
@@ -86,6 +109,17 @@ Feature: Producer - readDocumentReference - Success Scenarios
             }
           ]
         },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "734163000",
+                "display": "Care plan"
+              }
+            ]
+          }
+        ],
         "subject": {
           "identifier": {
             "system": "https://fhir.nhs.uk/Id/nhs-number",
@@ -98,6 +132,14 @@ Feature: Producer - readDocumentReference - Success Scenarios
             "value": "RX898"
           }
         },
+        "author": [
+          {
+            "identifier": {
+              "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+              "value": "HAR1"
+            }
+          }
+        ],
         "content": [
           {
             "attachment": {
@@ -123,8 +165,10 @@ Feature: Producer - readDocumentReference - Success Scenarios
       | subject     | 9999999999                                |
       | status      | current                                   |
       | type        | 736253002                                 |
+      | category    | 734163000                                 |
       | contentType | application/pdf                           |
       | url         | https://example.org/my-doc.pdf            |
       | custodian   | RX898.001                                 |
+      | author      | HAR1                                      |
     When producer 'RX898.001' reads a DocumentReference with ID 'RX898.001-1234567890-ReadDocRefCustSuffix'
     Then the response status code is 200

--- a/tests/features/producer/searchDocumentReference-success.feature
+++ b/tests/features/producer/searchDocumentReference-success.feature
@@ -1,141 +1,5 @@
 Feature: Producer - searchDocumentReference - Success Scenarios
 
-  Scenario: Search for all DocumentReferences in organisation
-    Given the application 'DataShare' (ID 'z00z-y11y-x22x') is registered to access the API
-    And the organisation 'RX898' is authorised to access pointer types:
-      | system                 | value            |
-      | http://snomed.info/sct | 736253002        |
-      | http://snomed.info/sct | 1363501000000100 |
-    And a DocumentReference resource exists with values:
-      | property    | value                                 |
-      | id          | RX898-1111111111-SearchOrgDocRefTest1 |
-      | subject     | 9278693472                            |
-      | status      | current                               |
-      | type        | 736253002                             |
-      | contentType | application/pdf                       |
-      | url         | https://example.org/my-doc.pdf        |
-      | custodian   | RX898                                 |
-    And a DocumentReference resource exists with values:
-      | property    | value                                 |
-      | id          | RX898-1111111111-SearchOrgDocRefTest2 |
-      | subject     | 9999999999                            |
-      | status      | current                               |
-      | type        | 1363501000000100                      |
-      | contentType | application/pdf                       |
-      | url         | https://example.org/my-doc.pdf        |
-      | custodian   | RX898                                 |
-    And a DocumentReference resource exists with values:
-      | property    | value                              |
-      | id          | X26-1111111111-SearchOrgDocRefTest |
-      | subject     | 9278693472                         |
-      | status      | current                            |
-      | type        | 736253002                          |
-      | contentType | application/pdf                    |
-      | url         | https://example.org/my-doc.pdf     |
-      | custodian   | X26                                |
-    When producer 'RX898' searches for DocumentReferences with parameters:
-      | parameter | value |
-    Then the response status code is 200
-    And the response is a searchset Bundle
-    And the Bundle has a total of 2
-    And the Bundle has 2 entry
-    And the Bundle contains an DocumentReference with values
-      | property    | value                                 |
-      | id          | RX898-1111111111-SearchOrgDocRefTest1 |
-      | subject     | 9278693472                            |
-      | status      | current                               |
-      | type        | 736253002                             |
-      | contentType | application/pdf                       |
-      | url         | https://example.org/my-doc.pdf        |
-      | custodian   | RX898                                 |
-    And the Bundle contains an DocumentReference with values
-      | property | value                                 |
-      | id       | RX898-1111111111-SearchOrgDocRefTest2 |
-      | type     | 1363501000000100                      |
-      | subject  | 9999999999                            |
-    And the Bundle does not contain a DocumentReference with ID 'X26-1111111111-SearchOrgDocRefTest'
-
-  Scenario: Search for all DocumentReferences in organisation with suffix
-    Given the application 'DataShare' (ID 'z00z-y11y-x22x') is registered to access the API
-    And the organisation 'RX898.001' is authorised to access pointer types:
-      | system                 | value     |
-      | http://snomed.info/sct | 736253002 |
-    And a DocumentReference resource exists with values:
-      | property    | value                                    |
-      | id          | RX898.001-1111111111-SearchOrgDocRefTest |
-      | subject     | 9278693472                               |
-      | status      | current                                  |
-      | type        | 736253002                                |
-      | contentType | application/pdf                          |
-      | url         | https://example.org/my-doc.pdf           |
-      | custodian   | RX898.001                                |
-    And a DocumentReference resource exists with values:
-      | property    | value                                    |
-      | id          | RX898.002-1111111111-SearchOrgDocRefTest |
-      | subject     | 9278693472                               |
-      | status      | current                                  |
-      | type        | 736253002                                |
-      | contentType | application/pdf                          |
-      | url         | https://example.org/my-doc.pdf           |
-      | custodian   | RX898.002                                |
-    When producer 'RX898.001' searches for DocumentReferences with parameters:
-      | parameter | value |
-    Then the response status code is 200
-    And the response is a searchset Bundle
-    And the Bundle has a total of 1
-    And the Bundle has 1 entry
-    And the Bundle contains an DocumentReference with values
-      | property    | value                                    |
-      | id          | RX898.001-1111111111-SearchOrgDocRefTest |
-      | subject     | 9278693472                               |
-      | status      | current                                  |
-      | type        | 736253002                                |
-      | contentType | application/pdf                          |
-      | url         | https://example.org/my-doc.pdf           |
-      | custodian   | RX898.001                                |
-    And the Bundle does not contain a DocumentReference with ID 'RX898.002-1111111111-SearchOrgDocRefTest'
-
-  Scenario: Search for all DocumentReferences in organisation - S3 authorisation
-    Given the application 'DataShare' (ID 'z00z-y11y-x22x') is registered to access the API
-    And the application is configured to lookup permissions from S3
-    And the organisation 'RX898' is authorised in S3 to access pointer types:
-      | system                 | value     |
-      | http://snomed.info/sct | 736253002 |
-    And a DocumentReference resource exists with values:
-      | property    | value                                |
-      | id          | RX898-1111111111-SearchOrgDocRefTest |
-      | subject     | 9278693472                           |
-      | status      | current                              |
-      | type        | 736253002                            |
-      | contentType | application/pdf                      |
-      | url         | https://example.org/my-doc.pdf       |
-      | custodian   | RX898                                |
-    And a DocumentReference resource exists with values:
-      | property    | value                              |
-      | id          | X26-1111111111-SearchOrgDocRefTest |
-      | subject     | 9278693472                         |
-      | status      | current                            |
-      | type        | 736253002                          |
-      | contentType | application/pdf                    |
-      | url         | https://example.org/my-doc.pdf     |
-      | custodian   | X26                                |
-    When producer 'RX898' searches for DocumentReferences with parameters:
-      | parameter | value |
-    Then the response status code is 200
-    And the response is a searchset Bundle
-    And the Bundle has a total of 1
-    And the Bundle has 1 entry
-    And the Bundle contains an DocumentReference with values
-      | property    | value                                |
-      | id          | RX898-1111111111-SearchOrgDocRefTest |
-      | subject     | 9278693472                           |
-      | status      | current                              |
-      | type        | 736253002                            |
-      | contentType | application/pdf                      |
-      | url         | https://example.org/my-doc.pdf       |
-      | custodian   | RX898                                |
-    And the Bundle does not contain a DocumentReference with ID 'X26-1111111111-SearchOrgDocRefTest'
-
   Scenario: Search for DocumentReferences by NHS number
     Given the application 'DataShare' (ID 'z00z-y11y-x22x') is registered to access the API
     And the organisation 'RX898' is authorised to access pointer types:
@@ -147,18 +11,22 @@ Feature: Producer - searchDocumentReference - Success Scenarios
       | subject     | 9278693472                            |
       | status      | current                               |
       | type        | 736253002                             |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc.pdf        |
       | custodian   | RX898                                 |
+      | author      | X26                                   |
     And a DocumentReference resource exists with values:
       | property    | value                                 |
       | id          | RX898-1111111111-SearchNHSDocRefTest2 |
       | subject     | 9999999999                            |
       | status      | current                               |
       | type        | 736253002                             |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc.pdf        |
       | custodian   | RX898                                 |
+      | author      | X26                                   |
     When producer 'RX898' searches for DocumentReferences with parameters:
       | parameter | value      |
       | subject   | 9278693472 |
@@ -172,66 +40,12 @@ Feature: Producer - searchDocumentReference - Success Scenarios
       | subject     | 9278693472                            |
       | status      | current                               |
       | type        | 736253002                             |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc.pdf        |
       | custodian   | RX898                                 |
+      | author      | X26                                   |
     And the Bundle does not contain a DocumentReference with ID 'RX898-1111111111-SearchNHSDocRefTest2'
-
-  Scenario: Search for DocumentReferences by pointer type
-    Given the application 'DataShare' (ID 'z00z-y11y-x22x') is registered to access the API
-    And the organisation 'RX898' is authorised to access pointer types:
-      | system                 | value            |
-      | http://snomed.info/sct | 736253002        |
-      | http://snomed.info/sct | 1363501000000100 |
-    And a DocumentReference resource exists with values:
-      | property    | value                                 |
-      | id          | RX898-1111111111-SearchNHSDocRefTest1 |
-      | subject     | 9278693472                            |
-      | status      | current                               |
-      | type        | 736253002                             |
-      | contentType | application/pdf                       |
-      | url         | https://example.org/my-doc.pdf        |
-      | custodian   | RX898                                 |
-    And a DocumentReference resource exists with values:
-      | property    | value                                 |
-      | id          | RX898-1111111111-SearchNHSDocRefTest2 |
-      | subject     | 9999999999                            |
-      | status      | current                               |
-      | type        | 736253002                             |
-      | contentType | application/pdf                       |
-      | url         | https://example.org/my-doc.pdf        |
-      | custodian   | RX898                                 |
-    And a DocumentReference resource exists with values:
-      | property    | value                                 |
-      | id          | RX898-1111111111-SearchNHSDocRefTest3 |
-      | subject     | 9999999999                            |
-      | status      | current                               |
-      | type        | 1363501000000100                      |
-      | contentType | application/pdf                       |
-      | url         | https://example.org/my-doc.pdf        |
-      | custodian   | RX898                                 |
-    When producer 'RX898' searches for DocumentReferences with parameters:
-      | parameter    | value     |
-      | pointer_type | 736253002 |
-    Then the response status code is 200
-    And the response is a searchset Bundle
-    And the Bundle has a total of 2
-    And the Bundle has 2 entries
-    And the Bundle contains an DocumentReference with values
-      | property    | value                                 |
-      | id          | RX898-1111111111-SearchNHSDocRefTest1 |
-      | subject     | 9278693472                            |
-      | status      | current                               |
-      | type        | 736253002                             |
-      | contentType | application/pdf                       |
-      | url         | https://example.org/my-doc.pdf        |
-      | custodian   | RX898                                 |
-    And the Bundle contains an DocumentReference with values
-      | property | value                                 |
-      | id       | RX898-1111111111-SearchNHSDocRefTest2 |
-      | subject  | 9999999999                            |
-      | type     | 736253002                             |
-    And the Bundle does not contain a DocumentReference with ID 'RX898-1111111111-SearchNHSDocRefTest3'
 
   Scenario: Search for DocumentReferences by pointer type and NHS number
     Given the application 'DataShare' (ID 'z00z-y11y-x22x') is registered to access the API
@@ -245,27 +59,33 @@ Feature: Producer - searchDocumentReference - Success Scenarios
       | subject     | 9278693472                            |
       | status      | current                               |
       | type        | 736253002                             |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc.pdf        |
       | custodian   | RX898                                 |
+      | author      | X26                                   |
     And a DocumentReference resource exists with values:
       | property    | value                                 |
       | id          | RX898-1111111111-SearchNHSDocRefTest2 |
       | subject     | 9999999999                            |
       | status      | current                               |
       | type        | 736253002                             |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc.pdf        |
       | custodian   | RX898                                 |
+      | author      | X26                                   |
     And a DocumentReference resource exists with values:
       | property    | value                                 |
       | id          | RX898-1111111111-SearchNHSDocRefTest3 |
       | subject     | 9999999999                            |
       | status      | current                               |
       | type        | 1363501000000100                      |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc.pdf        |
       | custodian   | RX898                                 |
+      | author      | X26                                   |
     When producer 'RX898' searches for DocumentReferences with parameters:
       | parameter    | value      |
       | pointer_type | 736253002  |
@@ -280,8 +100,10 @@ Feature: Producer - searchDocumentReference - Success Scenarios
       | subject     | 9999999999                            |
       | status      | current                               |
       | type        | 736253002                             |
+      | category    | 734163000                             |
       | contentType | application/pdf                       |
       | url         | https://example.org/my-doc.pdf        |
       | custodian   | RX898                                 |
+      | author      | X26                                   |
     And the Bundle does not contain a DocumentReference with ID 'RX898-1111111111-SearchNHSDocRefTest1'
     And the Bundle does not contain a DocumentReference with ID 'RX898-1111111111-SearchNHSDocRefTest3'


### PR DESCRIPTION
In this PR, you've got:
- Table is still keyed on the document id
- `patient_gsi` is keyed on patient id using the sort params we need
- author and category are now mandatory fields
- category and type keys are prefixed with an id based on system
- producer search now requires an NHS number
- added `masterid_gsi` to lookup by master identifier
- all unit and integration tests updated for these changes