### PR TITLE
NRL-567 Fix ref pointer IDs longer than 64 chars

### DIFF
--- a/layer/nrlf/core/dynamodb/model.py
+++ b/layer/nrlf/core/dynamodb/model.py
@@ -138,6 +138,10 @@ class DocumentPointer(DynamoDBModel):
             created_on=created_on or create_fhir_instant(),
         )
 
+        # Exception for ref with very long custodians
+        if len(custodian) > 6:
+            core_model.producer_id = custodian
+
         logger.log(
             LogReference.DOCPOINTER005,
             producer_id=core_model.producer_id,

--- a/layer/nrlf/core/dynamodb/model.py
+++ b/layer/nrlf/core/dynamodb/model.py
@@ -213,6 +213,13 @@ class DocumentPointer(DynamoDBModel):
         Validate the id of the DocumentPointer
         The id should be in the format <producer_id|producer_suffix>-<document_id>
         """
+        # special case for REF, pointer IDs would not be this long otherwise. It is because
+        # ref uses long ODS codes combined with the long legacy pointer IDs. So we basically
+        # truncate the ODS code at the start of the ID
+        if len(id_) > 64:
+            id_parts = id_.split("-", 1)
+            return f"{id_parts[0][:63-len(id_parts[1])]}-{id_parts[1]}"
+
         if not re.match(
             r"^(?=.{1,64}$)[A-Za-z0-9|\\.]+-[A-Za-z0-9]+[A-Za-z0-9\\_\\-]*$", id_
         ):

--- a/layer/nrlf/core/dynamodb/model.py
+++ b/layer/nrlf/core/dynamodb/model.py
@@ -214,8 +214,8 @@ class DocumentPointer(DynamoDBModel):
         The id should be in the format <producer_id|producer_suffix>-<document_id>
         """
         # special case for REF, pointer IDs would not be this long otherwise. It is because
-        # ref uses long ODS codes combined with the long legacy pointer IDs. So we basically
-        # truncate the ODS code at the start of the ID
+        # ref uses long ODS codes combined with the long legacy pointer IDs. So we truncate
+        # the ODS code at the start of the ID
         if len(id_) > 64:
             id_parts = id_.split("-", 1)
             return f"{id_parts[0][:63-len(id_parts[1])]}-{id_parts[1]}"

--- a/layer/nrlf/core/dynamodb/tests/test_model.py
+++ b/layer/nrlf/core/dynamodb/tests/test_model.py
@@ -271,6 +271,27 @@ def test_validate_id(id_):
 
 
 @pytest.mark.parametrize(
+    ("id_", "result_id"),
+    [
+        (
+            "240125430100-ecee356b-d0b4-11ee-882e-06cf7080687e-58553343544334485356",
+            "240125-ecee356b-d0b4-11ee-882e-06cf7080687e-58553343544334485356",
+        ),  # higher length
+        (
+            "240125-ecee356b-d0b4-11ee-882e-06cf7080687e-58553343544334485356",
+            "240125-ecee356b-d0b4-11ee-882e-06cf7080687e-58553343544334485356",
+        ),  # exact length
+        (
+            "240-ecee356b-d0b4-11ee-882e-06cf7080687e-58553343544334485356",
+            "240-ecee356b-d0b4-11ee-882e-06cf7080687e-58553343544334485356",
+        ),  # lower length
+    ],
+)
+def test_validate_ref_id(id_, result_id):
+    assert DocumentPointer.validate_id(id_) == result_id
+
+
+@pytest.mark.parametrize(
     "id_",
     [
         "-X26-999999-999999-99999999",

--- a/layer/nrlf/core/validators.py
+++ b/layer/nrlf/core/validators.py
@@ -177,6 +177,9 @@ class DocumentReferenceValidator:
     def _validate_identifiers(self, model: DocumentReference):
         """ """
         logger.log(LogReference.VALIDATOR001, step="identifiers")
+        if len(model.id) > 64:
+            id_parts = model.id.split("-", 1)
+            model.id = f"{id_parts[0][:63-len(id_parts[1])]}-{id_parts[1]}"
 
         if not (custodian_identifier := getattr(model.custodian, "identifier", None)):
             self.result.add_error(

--- a/tests/features/producer/upsertDocumentReference-success.feature
+++ b/tests/features/producer/upsertDocumentReference-success.feature
@@ -47,3 +47,48 @@ Feature: Producer - upsertDocumentReference - Success Scenarios
       | custodian | ANGY1                          |
       | author    | HAR1                           |
       | url       | https://example.org/my-doc.pdf |
+
+  Scenario: Successfully create a Document Pointer with a ref long ID (care plan)
+    Given the application 'DataShare' (ID 'z00z-y11y-x22x') is registered to access the API
+    And the organisation '240125430100' is authorised to access pointer types:
+      | system                 | value     |
+      | http://snomed.info/sct | 736253002 |
+    When producer '240125430100' upserts a DocumentReference with values:
+      | property  | value                                                                  |
+      | id        | 240125430100-ecee356b-d0b4-11ee-882e-06cf7080687e-58553343544334485356 |
+      | subject   | 9278693472                                                             |
+      | status    | current                                                                |
+      | type      | 736253002                                                              |
+      | category  | 734163000                                                              |
+      | custodian | 240125430100                                                           |
+      | author    | HAR1                                                                   |
+      | url       | https://example.org/my-doc.pdf                                         |
+    Then the response status code is 201
+    And the response is an OperationOutcome with 1 issue
+    And the OperationOutcome contains the issue:
+      """
+      {
+        "severity": "information",
+        "code": "informational",
+        "details": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/ValueSet/NRL-ResponseCode",
+              "code": "RESOURCE_CREATED",
+              "display": "Resource created"
+            }
+          ]
+        },
+        "diagnostics": "The document has been created"
+      }
+      """
+    And the Document Reference '240125-ecee356b-d0b4-11ee-882e-06cf7080687e-58553343544334485356' exists with values:
+      | property  | value                                                            |
+      | id        | 240125-ecee356b-d0b4-11ee-882e-06cf7080687e-58553343544334485356 |
+      | subject   | 9278693472                                                       |
+      | status    | current                                                          |
+      | type      | 736253002                                                        |
+      | category  | 734163000                                                        |
+      | custodian | 240125430100                                                     |
+      | author    | HAR1                                                             |
+      | url       | https://example.org/my-doc.pdf                                   |


### PR DESCRIPTION
NRL-567 Fix pointer ID longer than 64 chars when long ODS code and long legacy ID from NRL 2.8