### PR TITLE
[NRL-1150] Only use Pydantic error['loc'] in ParseErrors if it's present

### DIFF
--- a/layer/nrlf/core/errors.py
+++ b/layer/nrlf/core/errors.py
@@ -59,8 +59,8 @@ class ParseError(Exception):
                 severity="error",
                 code="invalid",
                 details=details,  # type: ignore
-                diagnostics=f"{msg} ({error['loc'][0]}: {error['msg']})",
-                expression=[str(error["loc"][0])],  # type: ignore
+                diagnostics=f"{msg} ({error['loc']}: {error['msg']})",
+                expression=[str(error["loc"])],  # type: ignore
             )
             for error in exc.errors()
         ]

--- a/layer/nrlf/core/errors.py
+++ b/layer/nrlf/core/errors.py
@@ -1,11 +1,23 @@
 from typing import List, Optional
 
 from pydantic import ValidationError
+from pydantic_core import ErrorDetails
 
 from nrlf.core.response import Response
 from nrlf.core.types import CodeableConcept
 from nrlf.producer.fhir.r4 import model as producer_model
 from nrlf.producer.fhir.r4.model import OperationOutcome, OperationOutcomeIssue
+
+
+def diag_for_error(error: ErrorDetails) -> str:
+    if error["loc"]:
+        return f"{error['loc'][0]}: {error['msg']}"
+    else:
+        return f"root: {error['msg']}"
+
+
+def expression_for_error(error: ErrorDetails) -> Optional[str]:
+    return str(error["loc"][0] if error["loc"] else "root")
 
 
 class OperationOutcomeError(Exception):
@@ -59,8 +71,8 @@ class ParseError(Exception):
                 severity="error",
                 code="invalid",
                 details=details,  # type: ignore
-                diagnostics=f"{msg} ({error['loc']}: {error['msg']})",
-                expression=[str(error["loc"])],  # type: ignore
+                diagnostics=f"{msg} ({diag_for_error(error)})",
+                expression=[expression_for_error(error)],  # type: ignore
             )
             for error in exc.errors()
         ]

--- a/layer/nrlf/core/tests/test_request.py
+++ b/layer/nrlf/core/tests/test_request.py
@@ -194,32 +194,108 @@ def test_parse_body_invalid_docref_json():
     response = error.value.response.model_dump()
 
     assert response["statusCode"] == "400"
-    assert response["body"] == json.dumps(
-        {
-            "resourceType": "OperationOutcome",
-            "issue": [
-                {
-                    "severity": "error",
-                    "code": "invalid",
-                    "details": {
-                        "coding": [
-                            {
-                                "system": "https://fhir.nhs.uk/ValueSet/Spine-ErrorOrWarningCode-1",
-                                "code": "MESSAGE_NOT_WELL_FORMED",
-                                "display": "Message not well formed",
-                            }
-                        ],
-                    },
-                    "diagnostics": "Request body could not be parsed ((): Invalid JSON: control character (\\\\u0000-\\\\u001F) found while parsing a string at line 72 column 0)",
-                }
-            ],
-        }
-    )
+    assert json.loads(response["body"]) == {
+        "resourceType": "OperationOutcome",
+        "issue": [
+            {
+                "severity": "error",
+                "code": "invalid",
+                "details": {
+                    "coding": [
+                        {
+                            "system": "https://fhir.nhs.uk/ValueSet/Spine-ErrorOrWarningCode-1",
+                            "code": "MESSAGE_NOT_WELL_FORMED",
+                            "display": "Message not well formed",
+                        }
+                    ],
+                },
+                "diagnostics": "Request body could not be parsed (root: Invalid JSON: control character (\\u0000-\\u001F) found while parsing a string at line 72 column 0)",
+                "expression": ["root"],
+            }
+        ],
+    }
 
 
 def test_parse_body_invalid_json():
     model = DocumentReference
     body = '{ "type": "is-not-a-docref" }'
+
+    with pytest.raises(ParseError) as error:
+        parse_body(model, body)
+
+    response = error.value.response.model_dump()
+
+    assert response["statusCode"] == "400"
+    assert json.loads(response["body"]) == {
+        "resourceType": "OperationOutcome",
+        "issue": [
+            {
+                "severity": "error",
+                "code": "invalid",
+                "details": {
+                    "coding": [
+                        {
+                            "system": "https://fhir.nhs.uk/ValueSet/Spine-ErrorOrWarningCode-1",
+                            "code": "MESSAGE_NOT_WELL_FORMED",
+                            "display": "Message not well formed",
+                        }
+                    ]
+                },
+                "diagnostics": "Request body could not be parsed (resourceType: Field required)",
+                "expression": ["resourceType"],
+            },
+            {
+                "severity": "error",
+                "code": "invalid",
+                "details": {
+                    "coding": [
+                        {
+                            "system": "https://fhir.nhs.uk/ValueSet/Spine-ErrorOrWarningCode-1",
+                            "code": "MESSAGE_NOT_WELL_FORMED",
+                            "display": "Message not well formed",
+                        }
+                    ]
+                },
+                "diagnostics": "Request body could not be parsed (status: Field required)",
+                "expression": ["status"],
+            },
+            {
+                "severity": "error",
+                "code": "invalid",
+                "details": {
+                    "coding": [
+                        {
+                            "system": "https://fhir.nhs.uk/ValueSet/Spine-ErrorOrWarningCode-1",
+                            "code": "MESSAGE_NOT_WELL_FORMED",
+                            "display": "Message not well formed",
+                        }
+                    ]
+                },
+                "diagnostics": "Request body could not be parsed (type: Input should be an object)",
+                "expression": ["type"],
+            },
+            {
+                "severity": "error",
+                "code": "invalid",
+                "details": {
+                    "coding": [
+                        {
+                            "system": "https://fhir.nhs.uk/ValueSet/Spine-ErrorOrWarningCode-1",
+                            "code": "MESSAGE_NOT_WELL_FORMED",
+                            "display": "Message not well formed",
+                        }
+                    ]
+                },
+                "diagnostics": "Request body could not be parsed (content: Field required)",
+                "expression": ["content"],
+            },
+        ],
+    }
+
+
+def test_parse_body_not_json():
+    model = DocumentReference
+    body = "is not json"
 
     with pytest.raises(ParseError) as error:
         parse_body(model, body)
@@ -240,40 +316,10 @@ def test_parse_body_invalid_json():
                             "code": "MESSAGE_NOT_WELL_FORMED",
                             "display": "Message not well formed",
                         }
-                    ],
+                    ]
                 },
-                "diagnostics": "",
-            }
-        ],
-    }
-
-
-def test_parse_body_not_json():
-    model = DocumentReference
-    body = "is not json"
-
-    with pytest.raises(OperationOutcomeError) as error:
-        parse_body(model, body)
-
-    exc = error.value
-
-    assert exc.status_code == "400"
-    assert exc.operation_outcome.model_dump(exclude_none=True) == {
-        "resourceType": "OperationOutcome",
-        "issue": [
-            {
-                "severity": "error",
-                "code": "invalid",
-                "details": {
-                    "coding": [
-                        {
-                            "system": "https://fhir.nhs.uk/ValueSet/Spine-ErrorOrWarningCode-1",
-                            "code": "INVALID_PARAMETER",
-                            "display": "The parameter value is not valid",
-                        }
-                    ],
-                },
-                "diagnostics": "Invalid query parameter",
+                "diagnostics": "Request body could not be parsed (root: Invalid JSON: expected value at line 1 column 1)",
+                "expression": ["root"],
             }
         ],
     }

--- a/layer/nrlf/core/tests/test_request.py
+++ b/layer/nrlf/core/tests/test_request.py
@@ -2,8 +2,10 @@ import json
 
 import pytest
 
-from nrlf.core.errors import OperationOutcomeError
-from nrlf.core.request import parse_headers
+from nrlf.core.errors import OperationOutcomeError, ParseError
+from nrlf.core.request import parse_body, parse_headers
+from nrlf.producer.fhir.r4.model import DocumentReference
+from nrlf.tests.data import load_document_reference_data
 
 
 def test_parse_headers_empty_headers():
@@ -129,3 +131,149 @@ def test_parse_headers_case_insensitive():
     assert metadata.client_rp_details.developer_app_name == "TestApp"
     assert metadata.client_rp_details.developer_app_id == "12345"
     assert metadata.ods_code_parts == ("X26", "001")
+
+
+def test_parse_body_no_model_no_body():
+    body = None
+    model = None
+
+    result = parse_body(model, body)
+
+    assert result is None
+
+
+def test_parse_body_valid_docref():
+    model = DocumentReference
+    docref_body = load_document_reference_data("Y05868-736253002-Valid")
+
+    result = parse_body(model, docref_body)
+
+    assert isinstance(result, DocumentReference)
+
+
+def test_parse_body_no_body():
+    model = DocumentReference
+    body = None
+
+    with pytest.raises(OperationOutcomeError) as error:
+        parse_body(model, body)
+
+    exc = error.value
+
+    assert exc.status_code == "400"
+    assert exc.operation_outcome.model_dump(exclude_none=True) == {
+        "resourceType": "OperationOutcome",
+        "issue": [
+            {
+                "severity": "error",
+                "code": "invalid",
+                "details": {
+                    "coding": [
+                        {
+                            "system": "https://fhir.nhs.uk/ValueSet/Spine-ErrorOrWarningCode-1",
+                            "code": "BAD_REQUEST",
+                            "display": "Bad request",
+                        }
+                    ],
+                },
+                "diagnostics": "Request body is required",
+            }
+        ],
+    }
+
+
+def test_parse_body_invalid_docref_json():
+    model = DocumentReference
+    docref_body = load_document_reference_data("Y05868-736253002-Valid")
+
+    docref_body = docref_body.replace('unstructured"', "unstructured")
+
+    with pytest.raises(ParseError) as error:
+        parse_body(model, docref_body)
+
+    response = error.value.response.model_dump()
+
+    assert response["statusCode"] == "400"
+    assert response["body"] == json.dumps(
+        {
+            "resourceType": "OperationOutcome",
+            "issue": [
+                {
+                    "severity": "error",
+                    "code": "invalid",
+                    "details": {
+                        "coding": [
+                            {
+                                "system": "https://fhir.nhs.uk/ValueSet/Spine-ErrorOrWarningCode-1",
+                                "code": "MESSAGE_NOT_WELL_FORMED",
+                                "display": "Message not well formed",
+                            }
+                        ],
+                    },
+                    "diagnostics": "Request body could not be parsed ((): Invalid JSON: control character (\\\\u0000-\\\\u001F) found while parsing a string at line 72 column 0)",
+                }
+            ],
+        }
+    )
+
+
+def test_parse_body_invalid_json():
+    model = DocumentReference
+    body = '{ "type": "is-not-a-docref" }'
+
+    with pytest.raises(ParseError) as error:
+        parse_body(model, body)
+
+    response = error.value.response
+
+    assert response.statusCode == "400"
+    assert json.loads(response.body) == {
+        "resourceType": "OperationOutcome",
+        "issue": [
+            {
+                "severity": "error",
+                "code": "invalid",
+                "details": {
+                    "coding": [
+                        {
+                            "system": "https://fhir.nhs.uk/ValueSet/Spine-ErrorOrWarningCode-1",
+                            "code": "MESSAGE_NOT_WELL_FORMED",
+                            "display": "Message not well formed",
+                        }
+                    ],
+                },
+                "diagnostics": "",
+            }
+        ],
+    }
+
+
+def test_parse_body_not_json():
+    model = DocumentReference
+    body = "is not json"
+
+    with pytest.raises(OperationOutcomeError) as error:
+        parse_body(model, body)
+
+    exc = error.value
+
+    assert exc.status_code == "400"
+    assert exc.operation_outcome.model_dump(exclude_none=True) == {
+        "resourceType": "OperationOutcome",
+        "issue": [
+            {
+                "severity": "error",
+                "code": "invalid",
+                "details": {
+                    "coding": [
+                        {
+                            "system": "https://fhir.nhs.uk/ValueSet/Spine-ErrorOrWarningCode-1",
+                            "code": "INVALID_PARAMETER",
+                            "display": "The parameter value is not valid",
+                        }
+                    ],
+                },
+                "diagnostics": "Invalid query parameter",
+            }
+        ],
+    }


### PR DESCRIPTION
Also added a bunch of unit tests for `request.py:parse_body()`