### PR TITLE
NRL-1583 Update location header

### DIFF
--- a/api/producer/createDocumentReference/tests/test_create_document_reference.py
+++ b/api/producer/createDocumentReference/tests/test_create_document_reference.py
@@ -45,7 +45,7 @@ def test_create_document_reference_happy_path(repository: DocumentPointerReposit
     assert result == {
         "statusCode": "201",
         "headers": {
-            "Location": "/producer/FHIR/R4/DocumentReference/Y05868-00000000-0000-0000-0000-000000000001",
+            "Location": "/DocumentReference/Y05868-00000000-0000-0000-0000-000000000001",
             **default_response_headers(),
         },
         "isBase64Encoded": False,
@@ -111,7 +111,7 @@ def test_create_document_reference_happy_path_with_ssp(
     assert result == {
         "statusCode": "201",
         "headers": {
-            "Location": "/producer/FHIR/R4/DocumentReference/Y05868-00000000-0000-0000-0000-000000000001",
+            "Location": "/DocumentReference/Y05868-00000000-0000-0000-0000-000000000001",
             **default_response_headers(),
         },
         "isBase64Encoded": False,
@@ -1270,7 +1270,7 @@ def test_create_document_reference_supersede_deletes_old_pointers_replace(
     assert result == {
         "statusCode": "201",
         "headers": {
-            "Location": "/producer/FHIR/R4/DocumentReference/Y05868-00000000-0000-0000-0000-000000000001",
+            "Location": "/DocumentReference/Y05868-00000000-0000-0000-0000-000000000001",
             **default_response_headers(),
         },
         "isBase64Encoded": False,
@@ -1329,7 +1329,7 @@ def test_create_document_reference_supersede_succeeds_with_toggle(
     assert result == {
         "statusCode": "201",
         "headers": {
-            "Location": "/producer/FHIR/R4/DocumentReference/Y05868-00000000-0000-0000-0000-000000000001",
+            "Location": "/DocumentReference/Y05868-00000000-0000-0000-0000-000000000001",
             **default_response_headers(),
         },
         "isBase64Encoded": False,
@@ -1444,7 +1444,7 @@ def test_create_document_reference_create_relatesto_not_replaces(
     assert result == {
         "statusCode": "201",
         "headers": {
-            "Location": "/producer/FHIR/R4/DocumentReference/Y05868-00000000-0000-0000-0000-000000000001",
+            "Location": "/DocumentReference/Y05868-00000000-0000-0000-0000-000000000001",
             **default_response_headers(),
         },
         "isBase64Encoded": False,
@@ -1496,7 +1496,7 @@ def test_create_document_reference_with_date_ignored(
     assert result == {
         "statusCode": "201",
         "headers": {
-            "Location": "/producer/FHIR/R4/DocumentReference/Y05868-00000000-0000-0000-0000-000000000001",
+            "Location": "/DocumentReference/Y05868-00000000-0000-0000-0000-000000000001",
             **default_response_headers(),
         },
         "isBase64Encoded": False,
@@ -1562,7 +1562,7 @@ def test_create_document_reference_with_date_and_meta_lastupdated_ignored(
     assert result == {
         "statusCode": "201",
         "headers": {
-            "Location": "/producer/FHIR/R4/DocumentReference/Y05868-00000000-0000-0000-0000-000000000001",
+            "Location": "/DocumentReference/Y05868-00000000-0000-0000-0000-000000000001",
             **default_response_headers(),
         },
         "isBase64Encoded": False,
@@ -1626,7 +1626,7 @@ def test_create_document_reference_with_date_overidden(
     assert result == {
         "statusCode": "201",
         "headers": {
-            "Location": "/producer/FHIR/R4/DocumentReference/Y05868-00000000-0000-0000-0000-000000000001",
+            "Location": "/DocumentReference/Y05868-00000000-0000-0000-0000-000000000001",
             **default_response_headers(),
         },
         "isBase64Encoded": False,

--- a/api/producer/upsertDocumentReference/tests/test_upsert_document_reference.py
+++ b/api/producer/upsertDocumentReference/tests/test_upsert_document_reference.py
@@ -43,7 +43,7 @@ def test_upsert_document_reference_happy_path(repository: DocumentPointerReposit
     assert result == {
         "statusCode": "201",
         "headers": {
-            "Location": "/producer/FHIR/R4/DocumentReference/Y05868-99999-99999-999999",
+            "Location": "/DocumentReference/Y05868-99999-99999-999999",
             **default_response_headers(),
         },
         "isBase64Encoded": False,
@@ -105,7 +105,7 @@ def test_upsert_document_reference_happy_path_with_ssp(
     assert result == {
         "statusCode": "201",
         "headers": {
-            "Location": "/producer/FHIR/R4/DocumentReference/Y05868-99999-99999-999999",
+            "Location": "/DocumentReference/Y05868-99999-99999-999999",
             **default_response_headers(),
         },
         "isBase64Encoded": False,
@@ -915,7 +915,7 @@ def test_upsert_document_reference_invalid_relatesto_not_exists_still_creates_wi
     assert result == {
         "statusCode": "201",
         "headers": {
-            "Location": "/producer/FHIR/R4/DocumentReference/Y05868-99999-99999-999999",
+            "Location": "/DocumentReference/Y05868-99999-99999-999999",
             **default_response_headers(),
         },
         "isBase64Encoded": False,
@@ -1249,7 +1249,7 @@ def test_upsert_document_reference_supersede_deletes_old_pointers_replace(
     assert result == {
         "statusCode": "201",
         "headers": {
-            "Location": "/producer/FHIR/R4/DocumentReference/Y05868-99999-99999-111111",
+            "Location": "/DocumentReference/Y05868-99999-99999-111111",
             **default_response_headers(),
         },
         "isBase64Encoded": False,
@@ -1307,7 +1307,7 @@ def test_upsert_document_reference_supersede_succeeds_with_toggle(
     assert result == {
         "statusCode": "201",
         "headers": {
-            "Location": "/producer/FHIR/R4/DocumentReference/Y05868-99999-99999-999999",
+            "Location": "/DocumentReference/Y05868-99999-99999-999999",
             **default_response_headers(),
         },
         "isBase64Encoded": False,
@@ -1421,7 +1421,7 @@ def test_upsert_document_reference_create_relatesto_not_replaces(
     assert result == {
         "statusCode": "201",
         "headers": {
-            "Location": "/producer/FHIR/R4/DocumentReference/Y05868-99999-99999-111111",
+            "Location": "/DocumentReference/Y05868-99999-99999-111111",
             **default_response_headers(),
         },
         "isBase64Encoded": False,
@@ -1472,7 +1472,7 @@ def test_upsert_document_reference_with_date_ignored(
     assert result == {
         "statusCode": "201",
         "headers": {
-            "Location": "/producer/FHIR/R4/DocumentReference/Y05868-99999-99999-999999",
+            "Location": "/DocumentReference/Y05868-99999-99999-999999",
             **default_response_headers(),
         },
         "isBase64Encoded": False,
@@ -1534,7 +1534,7 @@ def test_upsert_document_reference_with_date_and_meta_lastupdated_ignored(
     assert result == {
         "statusCode": "201",
         "headers": {
-            "Location": "/producer/FHIR/R4/DocumentReference/Y05868-99999-99999-999999",
+            "Location": "/DocumentReference/Y05868-99999-99999-999999",
             **default_response_headers(),
         },
         "isBase64Encoded": False,
@@ -1594,7 +1594,7 @@ def test_upsert_document_reference_with_date_overidden(
     assert result == {
         "statusCode": "201",
         "headers": {
-            "Location": "/producer/FHIR/R4/DocumentReference/Y05868-99999-99999-999999",
+            "Location": "/DocumentReference/Y05868-99999-99999-999999",
             **default_response_headers(),
         },
         "isBase64Encoded": False,

--- a/layer/nrlf/core/constants.py
+++ b/layer/nrlf/core/constants.py
@@ -48,7 +48,7 @@ X_REQUEST_ID_HEADER = "X-Request-Id"
 X_CORRELATION_ID_HEADER = "X-Correlation-Id"
 
 
-PRODUCER_URL_PATH = "/producer/FHIR/R4/DocumentReference"
+PRODUCER_URL_PATH = "/DocumentReference"
 
 
 class PointerTypes(Enum):

--- a/tests/features/producer/createDocumentReference-success.feature
+++ b/tests/features/producer/createDocumentReference-success.feature
@@ -35,7 +35,7 @@ Feature: Producer - createDocumentReference - Success Scenarios
       }
       """
     And the response has a Location header
-    And the Location header starts with '/producer/FHIR/R4/DocumentReference/ANGY1-'
+    And the Location header starts with '/DocumentReference/ANGY1-'
     And the resource in the Location header exists with values:
       | property        | value                          |
       | subject         | 9278693472                     |
@@ -82,7 +82,7 @@ Feature: Producer - createDocumentReference - Success Scenarios
   # }
   # """
   # And the response has a Location header
-  # And the Location header starts with '/producer/FHIR/R4/DocumentReference/ANGY1'
+  # And the Location header starts with '/DocumentReference/ANGY1'
   # And the resource in the Location header exists with values:
   # | property  | value                          |
   # | subject   | 9278693472                     |
@@ -141,7 +141,7 @@ Feature: Producer - createDocumentReference - Success Scenarios
       }
       """
     And the response has a Location header
-    And the Location header starts with '/producer/FHIR/R4/DocumentReference/ANGY1-'
+    And the Location header starts with '/DocumentReference/ANGY1-'
     And the resource in the Location header exists with values:
       | property        | value                          |
       | subject         | 9278693472                     |
@@ -191,7 +191,7 @@ Feature: Producer - createDocumentReference - Success Scenarios
       }
       """
     And the response has a Location header
-    And the Location header starts with '/producer/FHIR/R4/DocumentReference/ANGY1-'
+    And the Location header starts with '/DocumentReference/ANGY1-'
     And the resource in the Location header exists with values:
       | property  | value                          |
       | subject   | 9278693472                     |
@@ -270,7 +270,7 @@ Feature: Producer - createDocumentReference - Success Scenarios
       }
       """
     And the response has a Location header
-    And the Location header starts with '/producer/FHIR/R4/DocumentReference/ANGY1-'
+    And the Location header starts with '/DocumentReference/ANGY1-'
     And the resource in the Location header exists with values:
       | property        | value                          |
       | subject         | 9278693472                     |
@@ -313,7 +313,7 @@ Feature: Producer - createDocumentReference - Success Scenarios
       }
       """
     And the response has a Location header
-    And the Location header starts with '/producer/FHIR/R4/DocumentReference/ANGY1-'
+    And the Location header starts with '/DocumentReference/ANGY1-'
     And the resource in the Location header exists with values:
       | property    | value                          |
       | subject     | 9278693472                     |
@@ -363,7 +363,7 @@ Feature: Producer - createDocumentReference - Success Scenarios
       }
       """
     And the response has a Location header
-    And the Location header starts with '/producer/FHIR/R4/DocumentReference/ANGY1-'
+    And the Location header starts with '/DocumentReference/ANGY1-'
     And the resource in the Location header exists with values:
       | property        | value                         |
       | subject         | 9278693472                    |
@@ -482,7 +482,7 @@ Feature: Producer - createDocumentReference - Success Scenarios
       }
       """
     And the response has a Location header
-    And the Location header starts with '/producer/FHIR/R4/DocumentReference/TSTCUS-'
+    And the Location header starts with '/DocumentReference/TSTCUS-'
     And the resource in the Location header exists with values:
       | property                                                       | value                        |
       | content[0].attachment.url                                      | https://example.org/doc1.pdf |
@@ -559,7 +559,7 @@ Feature: Producer - createDocumentReference - Success Scenarios
       }
       """
     And the response has a Location header
-    And the Location header starts with '/producer/FHIR/R4/DocumentReference/TSTCUS-'
+    And the Location header starts with '/DocumentReference/TSTCUS-'
     And the resource in the Location header exists with values:
       | property                                                       | value                                     |
       | content[0].attachment.url                                      | https://example.org/incontext-launch.html |

--- a/tests/features/steps/3_assert.py
+++ b/tests/features/steps/3_assert.py
@@ -373,9 +373,9 @@ def assert_header_starts_with(context: Context, header_name: str, starts_with: s
 def assert_resource_in_location_header_exists_with_values(context: Context):
     location = context.response.headers.get("Location")
 
-    assert location.startswith("/producer/FHIR/R4/DocumentReference/"), format_error(
+    assert location.startswith("/DocumentReference/"), format_error(
         "Unexpected Location header",
-        "/producer/FHIR/R4/DocumentReference/",
+        "/DocumentReference/",
         location,
         context.response.text,
     )


### PR DESCRIPTION
<img width="993" height="825" alt="postman-screenshot" src="https://github.com/user-attachments/assets/08ed388c-f433-46da-8ec6-5aea1b42bcac" />
See attached evidence of successful postman request pointed at my sandy-dev deployment, which returns the newly formatted location header