### PR TITLE
NRL-1654 disable backup on DEV account resources

### DIFF
--- a/terraform/account-wide-infrastructure/dev/dynamodb__pointers-table.tf
+++ b/terraform/account-wide-infrastructure/dev/dynamodb__pointers-table.tf
@@ -1,7 +1,7 @@
 module "dev-pointers-table" {
   source         = "../modules/pointers-table"
   name_prefix    = "nhsd-nrlf--dev"
-  enable_backups = true
+  enable_backups = false
 }
 
 module "dev-sandbox-pointers-table" {

--- a/terraform/account-wide-infrastructure/dev/s3.tf
+++ b/terraform/account-wide-infrastructure/dev/s3.tf
@@ -1,7 +1,7 @@
 module "dev-permissions-store-bucket" {
   source         = "../modules/permissions-store-bucket"
   name_prefix    = "nhsd-nrlf--dev"
-  enable_backups = true
+  enable_backups = false
 }
 
 module "dev-sandbox-permissions-store-bucket" {
@@ -13,7 +13,7 @@ module "dev-truststore-bucket" {
   source                  = "../modules/truststore-bucket"
   name_prefix             = "nhsd-nrlf--dev"
   server_certificate_file = "../../../truststore/server/dev.pem"
-  enable_backups          = true
+  enable_backups          = false
 }
 
 module "dev-sandbox-truststore-bucket" {


### PR DESCRIPTION
The test destination vault will now only be used for immutable copies of INT resources. 