### PR TITLE
NRL-1582 Update KMS policy with backup perms

### DIFF
--- a/terraform/account-wide-infrastructure/dev/aws-backup.tf
+++ b/terraform/account-wide-infrastructure/dev/aws-backup.tf
@@ -103,6 +103,14 @@ resource "aws_kms_key" "backup_notifications" {
         Action   = ["kms:GenerateDataKey*", "kms:Decrypt"]
         Resource = "*"
       },
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "backup.amazonaws.com"
+        }
+        Action   = ["kms:GenerateDataKey*", "kms:Decrypt"]
+        Resource = "*"
+      },
     ]
   })
 }

--- a/terraform/account-wide-infrastructure/prod/aws-backup.tf
+++ b/terraform/account-wide-infrastructure/prod/aws-backup.tf
@@ -103,6 +103,14 @@ resource "aws_kms_key" "backup_notifications" {
         Action   = ["kms:GenerateDataKey*", "kms:Decrypt"]
         Resource = "*"
       },
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "backup.amazonaws.com"
+        }
+        Action   = ["kms:GenerateDataKey*", "kms:Decrypt"]
+        Resource = "*"
+      },
     ]
   })
 }

--- a/terraform/account-wide-infrastructure/test/aws-backup.tf
+++ b/terraform/account-wide-infrastructure/test/aws-backup.tf
@@ -103,6 +103,14 @@ resource "aws_kms_key" "backup_notifications" {
         Action   = ["kms:GenerateDataKey*", "kms:Decrypt"]
         Resource = "*"
       },
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "backup.amazonaws.com"
+        }
+        Action   = ["kms:GenerateDataKey*", "kms:Decrypt"]
+        Resource = "*"
+      },
     ]
   })
 }


### PR DESCRIPTION
These changes have been applied in the test account via the AWS console.  After applying the changes, we ran a series of on demand backups of the pointers table.  We received a [notification](https://nhsdigitalcorporate.enterprise.slack.com/files/U09D2JZ2LTS/F09S3HGDMR6/notification_from_aws_backup) in the Slack channel of the ondemand backup that we cancelled, and no notification of the ondemand backup that completed successfully.