### PR TITLE
NRL-1417 add SBOM generation step to nightly build

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -38,11 +38,6 @@ jobs:
       - name: Run Unit Tests
         run: make test
 
-      - name: Generate SBOM
-        uses: nhs-england-tools/trivy-action/sbom-scan@v1.4.0
-        with:
-          repo-path: "./"
-
       - name: Build Project
         run: make build
 
@@ -72,3 +67,18 @@ jobs:
         with:
           key: ${{ github.run_id }}-nrlf-permissions
           path: dist/nrlf_permissions.zip
+
+  sbom:
+    name: Generate SBOM - ${{ github.ref }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Git clone - ${{ github.ref }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Generate SBOM
+        uses: nhs-england-tools/trivy-action/sbom-scan@v1.4.0
+        with:
+          repo-path: "./"

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -38,6 +38,11 @@ jobs:
       - name: Run Unit Tests
         run: make test
 
+      - name: Generate SBOM
+        uses: nhs-england-tools/trivy-action/sbom-scan@v1.4.0
+        with:
+          repo-path: "./"
+
       - name: Build Project
         run: make build
 

--- a/.github/workflows/pr-env-deploy.yml
+++ b/.github/workflows/pr-env-deploy.yml
@@ -2,7 +2,6 @@ name: Deploy PR Environment
 run-name: "${{ github.event.action == 'synchronize' && 'Update' || 'Create' }} PR Environment - #${{ github.event.pull_request.number }} (${{ github.event.pull_request.title }})"
 
 on:
-  workflow_dispatch:
   pull_request:
     types: [opened, reopened, synchronize]
 
@@ -68,11 +67,6 @@ jobs:
 
       - name: Build Project
         run: make build
-
-      - name: Generate SBOM
-        uses: nhs-england-tools/trivy-action/sbom-scan@v1.4.0
-        with:
-          repo-path: "./"
 
       - name: Configure Management Credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a #v4.3.1

--- a/.github/workflows/pr-env-deploy.yml
+++ b/.github/workflows/pr-env-deploy.yml
@@ -2,6 +2,7 @@ name: Deploy PR Environment
 run-name: "${{ github.event.action == 'synchronize' && 'Update' || 'Create' }} PR Environment - #${{ github.event.pull_request.number }} (${{ github.event.pull_request.title }})"
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened, reopened, synchronize]
 
@@ -67,6 +68,11 @@ jobs:
 
       - name: Build Project
         run: make build
+
+      - name: Generate SBOM
+        uses: nhs-england-tools/trivy-action/sbom-scan@v1.4.0
+        with:
+          repo-path: "./"
 
       - name: Configure Management Credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a #v4.3.1


### PR DESCRIPTION
Uses the shared trivy action to generate a new SBOM every night from develop.

The generated SBOM is stored in github as an artifact against the action run that generated it. We can also run the workflow ad-hoc if we ever cannot wait until the next scheduled run to refresh it. See our first SBOM here: https://github.com/NHSDigital/NRLF/actions/runs/21292962386 (scroll down)

Linked PR for the shared trivy action to allow an SBOM to be generated from a git repo rather than only a docker image https://github.com/nhs-england-tools/trivy-action/pull/10 (merged & released in v1.4.0)