### PR TITLE
[NRL-1990] Allow unstructured data for text/html contents in pointers

### DIFF
--- a/layer/nrlf/core/tests/test_validators.py
+++ b/layer/nrlf/core/tests/test_validators.py
@@ -1198,6 +1198,9 @@ def test_validate_content_format_invalid_code_for_structured_document():
     }
 
 
+@pytest.mark.skip(
+    reason="Disabling temporarily as the validation rule is now allowed (but only for NRL-1966)"
+)
 def test_validate_content_format_invalid_code_for_contact_details():
     validator = DocumentReferenceValidator()
     document_ref_data = load_document_reference_json("Y05868-736253002-Valid")

--- a/layer/nrlf/core/validators.py
+++ b/layer/nrlf/core/validators.py
@@ -473,7 +473,11 @@ class DocumentReferenceValidator:
             if (
                 content.attachment.contentType == "text/html"
                 and content.format.code
-                not in ["urn:nhs-ic:record-contact", "urn:nhs-ic:structured"]
+                not in [
+                    "urn:nhs-ic:record-contact",
+                    "urn:nhs-ic:structured",
+                    "urn:nhs-ic:unstructured",
+                ]
             ):
                 self.result.add_error(
                     issue_code="business-rule",


### PR DESCRIPTION
This PR is for the IPS Hackathon - DO NOT MERGE IT

Adding unstructured as a format code that's allowed for text/html content.

See NRL-1990 for full details.