### PR TITLE
NRL-2055 Reject v2 requests if they don't have permission to interact with the endpoint being called

### DIFF
--- a/api/consumer/readDocumentReference/tests/test_read_document_reference_consumer.py
+++ b/api/consumer/readDocumentReference/tests/test_read_document_reference_consumer.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from moto import mock_aws
 
 from api.consumer.readDocumentReference.read_document_reference import handler
-from nrlf.core.constants import CLIENT_RP_DETAILS, V2Headers
+from nrlf.core.constants import CLIENT_RP_DETAILS, ConsumerApiInteractions, V2Headers
 from nrlf.core.dynamodb.repository import DocumentPointer, DocumentPointerRepository
 from nrlf.tests.data import load_document_reference
 from nrlf.tests.dynamodb import mock_repository
@@ -14,6 +14,10 @@ from nrlf.tests.events import (
     create_test_api_gateway_event,
     default_response_headers,
 )
+
+create_mock_context_default_args = {
+    "function_name": "nhsd-nrlf--qa-sandbox-2--api--producer--readDocumentReference"
+}
 
 
 @mock_aws
@@ -63,6 +67,7 @@ def test_read_document_reference_happy_path_v2(
 
     get_pointer_permissions_mock.return_value = {
         "access_controls": [],
+        "interactions": [ConsumerApiInteractions.READ_DOCUMENT_REFERENCE.value],
         "types": ["http://snomed.info/sct|736253002"],
     }
 
@@ -71,7 +76,7 @@ def test_read_document_reference_happy_path_v2(
         path_parameters={"id": doc_pointer.id},
     )
 
-    result = handler(event, create_mock_context())
+    result = handler(event, create_mock_context(**create_mock_context_default_args))
     body = result.pop("body")
 
     assert result == {
@@ -222,6 +227,7 @@ def test_read_document_reference_unauthorised_for_type_v2(
 
     get_pointer_permissions_mock.return_value = {
         "access_controls": [],
+        "interactions": [ConsumerApiInteractions.READ_DOCUMENT_REFERENCE.value],
         "types": ["http://snomed.info/sct|736373009"],
     }
 
@@ -230,7 +236,7 @@ def test_read_document_reference_unauthorised_for_type_v2(
         path_parameters={"id": doc_pointer.id},
     )
 
-    result = handler(event, create_mock_context())
+    result = handler(event, create_mock_context(**create_mock_context_default_args))
     body = result.pop("body")
 
     assert result == {

--- a/api/consumer/searchDocumentReference/tests/test_search_document_reference_consumer.py
+++ b/api/consumer/searchDocumentReference/tests/test_search_document_reference_consumer.py
@@ -10,6 +10,7 @@ from nrlf.core.constants import (
     CLIENT_RP_DETAILS,
     TYPE_ATTRIBUTES,
     Categories,
+    ConsumerApiInteractions,
     PointerTypes,
     V2Headers,
 )
@@ -22,6 +23,10 @@ from nrlf.tests.events import (
     create_test_api_gateway_event,
     default_response_headers,
 )
+
+create_mock_context_default_args = {
+    "function_name": "nhsd-nrlf--perftest-2--api--consumer--searchDocumentReference"
+}
 
 
 @mock_aws
@@ -85,6 +90,7 @@ def test_search_document_reference_happy_path_v2(
 
     get_pointer_permissions_mock.return_value = {
         "access_controls": [],
+        "interactions": [ConsumerApiInteractions.SEARCH_DOCUMENT_REFERENCE.value],
         "types": ["http://snomed.info/sct|736253002"],
     }
 
@@ -95,7 +101,7 @@ def test_search_document_reference_happy_path_v2(
         },
     )
 
-    result = handler(event, create_mock_context())
+    result = handler(event, create_mock_context(**create_mock_context_default_args))
     body = result.pop("body")
 
     assert result == {
@@ -752,6 +758,7 @@ def test_search_document_reference_invalid_type_v2(
 
     get_pointer_permissions_mock.return_value = {
         "access_controls": [],
+        "interactions": ConsumerApiInteractions.list(),
         "types": ["http://snomed.info/sct|736253002"],
     }
 
@@ -763,7 +770,7 @@ def test_search_document_reference_invalid_type_v2(
         },
     )
 
-    result = handler(event, create_mock_context())
+    result = handler(event, create_mock_context(**create_mock_context_default_args))
     body = result.pop("body")
 
     assert result == {

--- a/api/consumer/searchPostDocumentReference/tests/test_search_post_document_reference_consumer.py
+++ b/api/consumer/searchPostDocumentReference/tests/test_search_post_document_reference_consumer.py
@@ -11,6 +11,7 @@ from nrlf.core.constants import (
     CLIENT_RP_DETAILS,
     TYPE_ATTRIBUTES,
     Categories,
+    ConsumerApiInteractions,
     PointerTypes,
     V2Headers,
 )
@@ -23,6 +24,10 @@ from nrlf.tests.events import (
     create_test_api_gateway_event,
     default_response_headers,
 )
+
+create_mock_context_default_args = {
+    "function_name": "nhsd-nrlf--qa-2--api--producer--searchPostDocumentReference"
+}
 
 
 @mock_aws
@@ -88,6 +93,7 @@ def test_search_post_document_reference_happy_path_v2(
 
     get_pointer_permissions_mock.return_value = {
         "access_controls": [],
+        "interactions": [ConsumerApiInteractions.SEARCH_POST_DOCUMENT_REFERENCE.value],
         "types": ["http://snomed.info/sct|736253002"],
     }
 
@@ -100,7 +106,7 @@ def test_search_post_document_reference_happy_path_v2(
         ),
     )
 
-    result = handler(event, create_mock_context())
+    result = handler(event, create_mock_context(**create_mock_context_default_args))
     body = result.pop("body")
 
     assert result == {
@@ -510,6 +516,7 @@ def test_search_post_document_reference_invalid_type_v2(
 
     get_pointer_permissions_mock.return_value = {
         "access_controls": [],
+        "interactions": ConsumerApiInteractions.list(),
         "types": ["http://snomed.info/sct|736253002"],
     }
 
@@ -523,7 +530,7 @@ def test_search_post_document_reference_invalid_type_v2(
         ),
     )
 
-    result = handler(event, create_mock_context())
+    result = handler(event, create_mock_context(**create_mock_context_default_args))
     body = result.pop("body")
 
     assert result == {

--- a/api/producer/createDocumentReference/tests/test_create_document_reference.py
+++ b/api/producer/createDocumentReference/tests/test_create_document_reference.py
@@ -14,6 +14,7 @@ from nrlf.core.constants import (
     CLIENT_RP_DETAILS,
     SNOMED_SYSTEM_URL,
     AccessControls,
+    ProducerApiInteractions,
     V2Headers,
 )
 from nrlf.core.dynamodb.repository import DocumentPointer, DocumentPointerRepository
@@ -31,6 +32,10 @@ from nrlf.tests.events import (
     create_test_api_gateway_event,
     default_response_headers,
 )
+
+create_mock_context_default_args = {
+    "function_name": "nhsd-nrlf--01ba47--api--producer--createDocumentReference"
+}
 
 
 @mock_aws
@@ -757,6 +762,7 @@ def test_create_document_reference_happy_path_v2(
 
     get_pointer_permissions_mock.return_value = {
         "access_controls": [],
+        "interactions": [ProducerApiInteractions.CREATE_DOCUMENT_REFERENCE.value],
         "types": ["http://snomed.info/sct|736253002"],
     }
 
@@ -765,7 +771,7 @@ def test_create_document_reference_happy_path_v2(
         body=doc_ref_data,
     )
 
-    result = handler(event, create_mock_context())
+    result = handler(event, create_mock_context(**create_mock_context_default_args))
     body = result.pop("body")
 
     assert result == {
@@ -818,6 +824,7 @@ def test_create_document_reference_pointer_type_not_allowed_v2(
     # Return a type that does not match the document's type
     get_pointer_permissions_mock.return_value = {
         "access_controls": [],
+        "interactions": [ProducerApiInteractions.CREATE_DOCUMENT_REFERENCE.value],
         "types": ["http://snomed.info/sct|736373009"],
     }
 
@@ -826,7 +833,7 @@ def test_create_document_reference_pointer_type_not_allowed_v2(
         body=doc_ref.model_dump_json(exclude_none=True),
     )
 
-    result = handler(event, create_mock_context())
+    result = handler(event, create_mock_context(**create_mock_context_default_args))
     body = result.pop("body")
 
     assert result == {
@@ -1571,6 +1578,7 @@ def test_supersede_non_existent_pointer_succeeds_with_v2_access_control(
 
     get_pointer_permissions_mock.return_value = {
         "access_controls": [AccessControls.ALLOW_SUPERSEDE_WITH_DELETE_FAILURE.value],
+        "interactions": [ProducerApiInteractions.CREATE_DOCUMENT_REFERENCE.value],
         "types": ["http://snomed.info/sct|736253002"],
     }
 
@@ -1579,7 +1587,7 @@ def test_supersede_non_existent_pointer_succeeds_with_v2_access_control(
         body=doc_ref.model_dump_json(exclude_none=True),
     )
 
-    result = handler(event, create_mock_context())
+    result = handler(event, create_mock_context(**create_mock_context_default_args))
     body = result.pop("body")
 
     assert result == {
@@ -1640,6 +1648,7 @@ def test_supersede_fails_without_v2_access_control(
 
     get_pointer_permissions_mock.return_value = {
         "access_controls": [],
+        "interactions": [ProducerApiInteractions.CREATE_DOCUMENT_REFERENCE.value],
         "types": ["http://snomed.info/sct|736253002"],
     }
 
@@ -1648,7 +1657,7 @@ def test_supersede_fails_without_v2_access_control(
         body=doc_ref.model_dump_json(exclude_none=True),
     )
 
-    result = handler(event, create_mock_context())
+    result = handler(event, create_mock_context(**create_mock_context_default_args))
     body = result.pop("body")
 
     assert result == {

--- a/api/producer/searchDocumentReference/tests/test_search_document_reference_producer.py
+++ b/api/producer/searchDocumentReference/tests/test_search_document_reference_producer.py
@@ -10,6 +10,7 @@ from nrlf.core.constants import (
     TYPE_ATTRIBUTES,
     Categories,
     PointerTypes,
+    ProducerApiInteractions,
     V2Headers,
 )
 from nrlf.core.dynamodb.repository import DocumentPointer, DocumentPointerRepository
@@ -21,6 +22,10 @@ from nrlf.tests.events import (
     create_test_api_gateway_event,
     default_response_headers,
 )
+
+create_mock_context_default_args = {
+    "function_name": "nhsd-nrlf--qa-2--api--consumer--searchDocumentReference"
+}
 
 
 @mock_aws
@@ -78,6 +83,7 @@ def test_search_document_reference_happy_path_v2(
 
     get_pointer_permissions_mock.return_value = {
         "access_controls": [],
+        "interactions": [ProducerApiInteractions.SEARCH_DOCUMENT_REFERENCE.value],
         "types": ["http://snomed.info/sct|736253002"],
     }
 
@@ -88,7 +94,7 @@ def test_search_document_reference_happy_path_v2(
         },
     )
 
-    result = handler(event, create_mock_context())
+    result = handler(event, create_mock_context(**create_mock_context_default_args))
     body = result.pop("body")
 
     assert result == {
@@ -543,6 +549,7 @@ def test_search_document_reference_filters_by_pointer_types_v2(
 
     get_pointer_permissions_mock.return_value = {
         "access_controls": [],
+        "interactions": ProducerApiInteractions.list(),
         "types": ["http://snomed.info/sct|736253002"],
     }
 
@@ -553,7 +560,7 @@ def test_search_document_reference_filters_by_pointer_types_v2(
         },
     )
 
-    result = handler(event, create_mock_context())
+    result = handler(event, create_mock_context(**create_mock_context_default_args))
     body = result.pop("body")
 
     assert result == {

--- a/api/producer/searchPostDocumentReference/tests/test_search_post_document_reference_producer.py
+++ b/api/producer/searchPostDocumentReference/tests/test_search_post_document_reference_producer.py
@@ -12,6 +12,7 @@ from nrlf.core.constants import (
     TYPE_ATTRIBUTES,
     Categories,
     PointerTypes,
+    ProducerApiInteractions,
     V2Headers,
 )
 from nrlf.core.dynamodb.repository import DocumentPointer, DocumentPointerRepository
@@ -23,6 +24,10 @@ from nrlf.tests.events import (
     create_test_api_gateway_event,
     default_response_headers,
 )
+
+create_mock_context_default_args = {
+    "function_name": "nhsd-nrlf--ref-2--api--producer--searchPostDocumentReference"
+}
 
 
 @mock_aws
@@ -82,6 +87,7 @@ def test_search_post_document_reference_happy_path_v2(
 
     get_pointer_permissions_mock.return_value = {
         "access_controls": [],
+        "interactions": [ProducerApiInteractions.SEARCH_POST_DOCUMENT_REFERENCE.value],
         "types": ["http://snomed.info/sct|736253002"],
     }
 
@@ -94,7 +100,7 @@ def test_search_post_document_reference_happy_path_v2(
         ),
     )
 
-    result = handler(event, create_mock_context())
+    result = handler(event, create_mock_context(**create_mock_context_default_args))
     body = result.pop("body")
 
     assert result == {
@@ -562,6 +568,7 @@ def test_search_post_document_reference_filters_by_pointer_types_v2(
 
     get_pointer_permissions_mock.return_value = {
         "access_controls": [],
+        "interactions": ProducerApiInteractions.list(),
         "types": ["http://snomed.info/sct|736253002"],
     }
 
@@ -574,7 +581,7 @@ def test_search_post_document_reference_filters_by_pointer_types_v2(
         ),
     )
 
-    result = handler(event, create_mock_context())
+    result = handler(event, create_mock_context(**create_mock_context_default_args))
     body = result.pop("body")
 
     assert result == {

--- a/api/producer/upsertDocumentReference/tests/test_upsert_document_reference.py
+++ b/api/producer/upsertDocumentReference/tests/test_upsert_document_reference.py
@@ -13,7 +13,7 @@ from nrlf.core.constants import (
     CLIENT_RP_DETAILS,
     PERMISSION_SUPERSEDE_IGNORE_DELETE_FAIL,
     AccessControls,
-    ProducerApiInteractions,
+    InternalApiInteractions,
     V2Headers,
 )
 from nrlf.core.dynamodb.repository import DocumentPointer, DocumentPointerRepository
@@ -116,7 +116,7 @@ def test_upsert_document_reference_happy_path_v2(
 
     get_pointer_permissions_mock.return_value = {
         "access_controls": [],
-        "interactions": [ProducerApiInteractions.UPSERT_DOCUMENT_REFERENCE.value],
+        "interactions": [InternalApiInteractions.UPSERT_DOCUMENT_REFERENCE.value],
         "types": ["http://snomed.info/sct|736253002"],
     }
 
@@ -838,7 +838,7 @@ def test_upsert_document_reference_pointer_type_not_allowed_v2(
 
     get_pointer_permissions_mock.return_value = {
         "access_controls": [],
-        "interactions": [ProducerApiInteractions.UPSERT_DOCUMENT_REFERENCE.value],
+        "interactions": [InternalApiInteractions.UPSERT_DOCUMENT_REFERENCE.value],
         "types": ["http://snomed.info/sct|99999999999"],
     }
 
@@ -1553,7 +1553,7 @@ def test_supersede_non_existent_pointer_succeeds_with_v2_access_control(
 
     get_pointer_permissions_mock.return_value = {
         "access_controls": [AccessControls.ALLOW_SUPERSEDE_WITH_DELETE_FAILURE.value],
-        "interactions": ProducerApiInteractions.list(),
+        "interactions": InternalApiInteractions.list(),
         "types": ["http://snomed.info/sct|736253002"],
     }
 
@@ -1623,7 +1623,7 @@ def test_supersede_fails_without_v2_access_control(
 
     get_pointer_permissions_mock.return_value = {
         "access_controls": [],
-        "interactions": [ProducerApiInteractions.UPSERT_DOCUMENT_REFERENCE.value],
+        "interactions": [InternalApiInteractions.UPSERT_DOCUMENT_REFERENCE.value],
         "types": ["http://snomed.info/sct|736253002"],
     }
 

--- a/api/producer/upsertDocumentReference/tests/test_upsert_document_reference.py
+++ b/api/producer/upsertDocumentReference/tests/test_upsert_document_reference.py
@@ -13,6 +13,7 @@ from nrlf.core.constants import (
     CLIENT_RP_DETAILS,
     PERMISSION_SUPERSEDE_IGNORE_DELETE_FAIL,
     AccessControls,
+    ProducerApiInteractions,
     V2Headers,
 )
 from nrlf.core.dynamodb.repository import DocumentPointer, DocumentPointerRepository
@@ -30,6 +31,10 @@ from nrlf.tests.events import (
     create_test_api_gateway_event,
     default_response_headers,
 )
+
+create_mock_context_default_args = {
+    "function_name": "nhsd-nrlf--qa-sandbox-2--api--producer--upsertDocumentReference"
+}
 
 
 @mock_aws
@@ -111,6 +116,7 @@ def test_upsert_document_reference_happy_path_v2(
 
     get_pointer_permissions_mock.return_value = {
         "access_controls": [],
+        "interactions": [ProducerApiInteractions.UPSERT_DOCUMENT_REFERENCE.value],
         "types": ["http://snomed.info/sct|736253002"],
     }
 
@@ -119,7 +125,7 @@ def test_upsert_document_reference_happy_path_v2(
         body=doc_ref_data,
     )
 
-    result = handler(event, create_mock_context())
+    result = handler(event, create_mock_context(**create_mock_context_default_args))
     body = result.pop("body")
 
     assert result == {
@@ -832,6 +838,7 @@ def test_upsert_document_reference_pointer_type_not_allowed_v2(
 
     get_pointer_permissions_mock.return_value = {
         "access_controls": [],
+        "interactions": [ProducerApiInteractions.UPSERT_DOCUMENT_REFERENCE.value],
         "types": ["http://snomed.info/sct|99999999999"],
     }
 
@@ -840,7 +847,10 @@ def test_upsert_document_reference_pointer_type_not_allowed_v2(
         body=doc_ref.model_dump_json(exclude_none=True),
     )
 
-    result = handler(event, create_mock_context())
+    result = handler(
+        event,
+        create_mock_context(**create_mock_context_default_args),
+    )
     body = result.pop("body")
 
     assert result == {
@@ -1543,6 +1553,7 @@ def test_supersede_non_existent_pointer_succeeds_with_v2_access_control(
 
     get_pointer_permissions_mock.return_value = {
         "access_controls": [AccessControls.ALLOW_SUPERSEDE_WITH_DELETE_FAILURE.value],
+        "interactions": ProducerApiInteractions.list(),
         "types": ["http://snomed.info/sct|736253002"],
     }
 
@@ -1551,7 +1562,7 @@ def test_supersede_non_existent_pointer_succeeds_with_v2_access_control(
         body=doc_ref.model_dump_json(exclude_none=True),
     )
 
-    result = handler(event, create_mock_context())
+    result = handler(event, create_mock_context(**create_mock_context_default_args))
     body = result.pop("body")
 
     assert result == {
@@ -1612,6 +1623,7 @@ def test_supersede_fails_without_v2_access_control(
 
     get_pointer_permissions_mock.return_value = {
         "access_controls": [],
+        "interactions": [ProducerApiInteractions.UPSERT_DOCUMENT_REFERENCE.value],
         "types": ["http://snomed.info/sct|736253002"],
     }
 
@@ -1620,7 +1632,7 @@ def test_supersede_fails_without_v2_access_control(
         body=doc_ref.model_dump_json(exclude_none=True),
     )
 
-    result = handler(event, create_mock_context())
+    result = handler(event, create_mock_context(**create_mock_context_default_args))
     body = result.pop("body")
 
     assert result == {

--- a/api/producer/upsertDocumentReference/tests/test_upsert_document_reference.py
+++ b/api/producer/upsertDocumentReference/tests/test_upsert_document_reference.py
@@ -14,6 +14,7 @@ from nrlf.core.constants import (
     PERMISSION_SUPERSEDE_IGNORE_DELETE_FAIL,
     AccessControls,
     InternalApiInteractions,
+    ProducerApiInteractions,
     V2Headers,
 )
 from nrlf.core.dynamodb.repository import DocumentPointer, DocumentPointerRepository
@@ -1660,6 +1661,76 @@ def test_supersede_fails_without_v2_access_control(
                 },
                 "diagnostics": "The relatesTo target document does not exist",
                 "expression": ["relatesTo[0].target.identifier.value"],
+            }
+        ],
+    }
+
+
+@mock_aws
+@mock_repository
+@patch("nrlf.core.decorators.get_pointer_permissions_v2")
+def test_v2_producer_interactions_cannot_supersede(
+    get_pointer_permissions_mock, repository: DocumentPointerRepository
+):
+    doc_ref = load_document_reference("Y05868-736253002-Valid")
+    doc_pointer = DocumentPointer.from_document_reference(doc_ref)
+    repository.create(doc_pointer)
+
+    # Change document ID and NHS number
+    doc_ref.id = "Y05868-99999-99999-111111"
+    doc_ref.relatesTo = [
+        DocumentReferenceRelatesTo(
+            code="replaces",
+            target=Reference(identifier=Identifier(value="Y05868-99999-99999-999999")),
+        )
+    ]
+
+    v2_headers = create_headers(
+        additional_headers={
+            V2Headers.NHSD_END_USER_ORGANISATION_ODS: "Y05868",
+            V2Headers.NHSD_NRL_APP_ID: "Y05868-TestApp-12345678",
+        }
+    )
+    v2_headers.pop(CLIENT_RP_DETAILS)
+
+    get_pointer_permissions_mock.return_value = {
+        "access_controls": [],
+        "interactions": ProducerApiInteractions.list(),
+        "types": ["http://snomed.info/sct|736253002"],
+    }
+
+    event = create_test_api_gateway_event(
+        headers=v2_headers,
+        body=doc_ref.model_dump_json(exclude_none=True),
+    )
+
+    result = handler(event, create_mock_context(**create_mock_context_default_args))
+    body = result.pop("body")
+
+    assert result == {
+        "statusCode": "403",
+        "headers": default_response_headers(),
+        "isBase64Encoded": False,
+    }
+
+    parsed_body = json.loads(body)
+
+    assert parsed_body == {
+        "resourceType": "OperationOutcome",
+        "issue": [
+            {
+                "severity": "error",
+                "code": "forbidden",
+                "details": {
+                    "coding": [
+                        {
+                            "code": "ACCESS DENIED",
+                            "display": "Access has been denied to process this request",
+                            "system": "https://fhir.nhs.uk/CodeSystem/Spine-ErrorOrWarningCode",
+                        }
+                    ]
+                },
+                "diagnostics": "Your organisation 'Y05868' does not have permission to access this resource. Contact the onboarding team.",
             }
         ],
     }

--- a/layer/nrlf/core/constants.py
+++ b/layer/nrlf/core/constants.py
@@ -100,11 +100,18 @@ class ProducerApiInteractions(Enum):
     CREATE_DOCUMENT_REFERENCE = ApiInteractions.CREATE_DOCUMENT_REFERENCE.value
     DELETE_DOCUMENT_REFERENCE = ApiInteractions.DELETE_DOCUMENT_REFERENCE.value
     UPDATE_DOCUMENT_REFERENCE = ApiInteractions.UPDATE_DOCUMENT_REFERENCE.value
-    UPSERT_DOCUMENT_REFERENCE = ApiInteractions.UPSERT_DOCUMENT_REFERENCE.value
 
     @staticmethod
     def list():
         return [interaction.value for interaction in ProducerApiInteractions]
+
+
+class InternalApiInteractions(Enum):
+    UPSERT_DOCUMENT_REFERENCE = ApiInteractions.UPSERT_DOCUMENT_REFERENCE.value
+
+    @staticmethod
+    def list():
+        return [interaction.value for interaction in InternalApiInteractions]
 
 
 NHSD_REQUEST_ID_HEADER = "NHSD-Request-Id"

--- a/layer/nrlf/core/constants.py
+++ b/layer/nrlf/core/constants.py
@@ -65,6 +65,48 @@ class AccessControls(Enum):
         return [control.value for control in AccessControls]
 
 
+class ApiInteractions(Enum):
+    READ_DOCUMENT_REFERENCE = "readDocumentReference"
+    SEARCH_DOCUMENT_REFERENCE = "searchDocumentReference"
+    SEARCH_POST_DOCUMENT_REFERENCE = "searchPostDocumentReference"
+    CREATE_DOCUMENT_REFERENCE = "createDocumentReference"
+    DELETE_DOCUMENT_REFERENCE = "deleteDocumentReference"
+    UPDATE_DOCUMENT_REFERENCE = "updateDocumentReference"
+    UPSERT_DOCUMENT_REFERENCE = "upsertDocumentReference"
+
+    @staticmethod
+    def list():
+        return [interaction.value for interaction in ApiInteractions]
+
+
+class ConsumerApiInteractions(Enum):
+    READ_DOCUMENT_REFERENCE = ApiInteractions.READ_DOCUMENT_REFERENCE.value
+    SEARCH_DOCUMENT_REFERENCE = ApiInteractions.SEARCH_DOCUMENT_REFERENCE.value
+    SEARCH_POST_DOCUMENT_REFERENCE = (
+        ApiInteractions.SEARCH_POST_DOCUMENT_REFERENCE.value
+    )
+
+    @staticmethod
+    def list():
+        return [interaction.value for interaction in ConsumerApiInteractions]
+
+
+class ProducerApiInteractions(Enum):
+    READ_DOCUMENT_REFERENCE = ApiInteractions.READ_DOCUMENT_REFERENCE.value
+    SEARCH_DOCUMENT_REFERENCE = ApiInteractions.SEARCH_DOCUMENT_REFERENCE.value
+    SEARCH_POST_DOCUMENT_REFERENCE = (
+        ApiInteractions.SEARCH_POST_DOCUMENT_REFERENCE.value
+    )
+    CREATE_DOCUMENT_REFERENCE = ApiInteractions.CREATE_DOCUMENT_REFERENCE.value
+    DELETE_DOCUMENT_REFERENCE = ApiInteractions.DELETE_DOCUMENT_REFERENCE.value
+    UPDATE_DOCUMENT_REFERENCE = ApiInteractions.UPDATE_DOCUMENT_REFERENCE.value
+    UPSERT_DOCUMENT_REFERENCE = ApiInteractions.UPSERT_DOCUMENT_REFERENCE.value
+
+    @staticmethod
+    def list():
+        return [interaction.value for interaction in ProducerApiInteractions]
+
+
 NHSD_REQUEST_ID_HEADER = "NHSD-Request-Id"
 NHSD_CORRELATION_ID_HEADER = "NHSD-Correlation-Id"
 X_REQUEST_ID_HEADER = "X-Request-Id"

--- a/layer/nrlf/core/decorators.py
+++ b/layer/nrlf/core/decorators.py
@@ -74,7 +74,7 @@ def error_handler(
 
 
 def header_handler(
-    wrapped_func: Callable[..., Dict[str, Any]]
+    wrapped_func: Callable[..., Dict[str, Any]],
 ) -> Callable[..., Dict[str, Any]]:
     """
     Wraps the function to set the specific headers in the request and response
@@ -118,7 +118,7 @@ def header_handler(
 
 
 def logger_initialiser(
-    wrapper_func: Callable[..., Dict[str, Any]]
+    wrapper_func: Callable[..., Dict[str, Any]],
 ) -> Callable[..., Dict[str, Any]]:
     """
     Wraps the function and initialises the request logger
@@ -210,6 +210,10 @@ def load_connection_metadata(headers: Dict[str, str], config: Config, path=""):
     logger.log(LogReference.HANDLER004c, pointer_types=pointer_types)
 
     return metadata
+
+
+def _parse_function_name(full_function_name: str):
+    return full_function_name.split("-")[-1]
 
 
 def filter_kwargs(handler_func: RequestHandler, kwargs: Dict[str, Any]):
@@ -336,6 +340,26 @@ def request_handler(
                     details=SpineErrorConcept.from_code("ACCESS DENIED"),
                     diagnostics=f"Your organisation '{metadata.ods_code}' does not have permission to access this resource. Contact the onboarding team.",
                 )
+
+            if metadata.nrl_permissions_policy:
+                allowed_interactions = metadata.nrl_permissions_policy.interactions
+                if (
+                    _parse_function_name(context.function_name)
+                    not in allowed_interactions
+                ):
+                    logger.log(
+                        LogReference.HANDLER005a,
+                        ods_code=metadata.ods_code,
+                        app_id=metadata.nrl_app_id,
+                        interactions=allowed_interactions,
+                    )
+                    raise OperationOutcomeError(
+                        status_code="403",
+                        severity="error",
+                        code="forbidden",
+                        details=SpineErrorConcept.from_code("ACCESS DENIED"),
+                        diagnostics=f"Your organisation '{metadata.ods_code}' does not have permission to access this resource. Contact the onboarding team.",
+                    )
 
             kwargs = {
                 "event": event,

--- a/layer/nrlf/core/log_references.py
+++ b/layer/nrlf/core/log_references.py
@@ -34,6 +34,7 @@ class LogReference(Enum):
     HANDLER004c = _Reference("INFO", "Parsed embedded permissions file")
     HANDLER004d = _Reference("INFO", "Using v2 permissions model")
     HANDLER005 = _Reference("WARN", "Rejecting request due to missing pointer types")
+    HANDLER005a = _Reference("WARN", "Rejecting request due to missing interaction")
     HANDLER006 = _Reference("DEBUG", "Attempting to parse request parameters")
     HANDLER007 = _Reference("INFO", "Parsed request parameters")
     HANDLER008 = _Reference("DEBUG", "Attempting to parse request body")

--- a/layer/nrlf/core/tests/test_decorators.py
+++ b/layer/nrlf/core/tests/test_decorators.py
@@ -935,6 +935,30 @@ def test_load_v2_connection_metadata_specific_types(mocker: MockerFixture):
     assert metadata.nrl_permissions_policy.types == specific_types
 
 
+def test_load_v2_connection_metadata_access_control_does_not_override_interactions(
+    mocker: MockerFixture,
+):
+    mocker.patch(
+        "nrlf.core.decorators.get_pointer_permissions_v2",
+        return_value={
+            "access_controls": [AccessControls.ALLOW_ALL_TYPES.value],
+            "interactions": ProducerApiInteractions.list(),
+            "types": [],
+        },
+    )
+
+    metadata = load_connection_metadata(
+        headers=_create_v2_headers(),
+        config=Config(),
+        path="/producer/DocumentReference",
+    )
+
+    assert metadata.nrl_permissions_policy.types == PointerTypes.list()
+    assert (
+        metadata.nrl_permissions_policy.interactions == ProducerApiInteractions.list()
+    )
+
+
 def test_load_v2_connection_metadata_missing_access_controls(mocker: MockerFixture):
     specific_types = ["http://snomed.info/sct|736253002"]
     mocker.patch(

--- a/layer/nrlf/core/tests/test_decorators.py
+++ b/layer/nrlf/core/tests/test_decorators.py
@@ -13,10 +13,13 @@ from nrlf.core.constants import (
     PERMISSION_ALLOW_ALL_POINTER_TYPES,
     X_REQUEST_ID_HEADER,
     AccessControls,
+    ConsumerApiInteractions,
     PointerTypes,
+    ProducerApiInteractions,
     V2Headers,
 )
 from nrlf.core.decorators import (
+    _parse_function_name,
     deprecated,
     error_handler,
     header_handler,
@@ -355,6 +358,49 @@ def test_log_includes_client_cert_details_when_no_cert(mocker: MockerFixture):
     ][0]["client_cert_info"]
 
     assert logged_cert_info == "No client certificate provided"
+
+
+@pytest.mark.parametrize(
+    ("long_function_name", "expected"),
+    [
+        (
+            "nhsd-nrlf--anjal-dev--api--producer--deleteDocumentReference",
+            ProducerApiInteractions.DELETE_DOCUMENT_REFERENCE.value,
+        ),
+        (
+            "nhsd-nrlf--dev-1--api--consumer--readDocumentReference",
+            ConsumerApiInteractions.READ_DOCUMENT_REFERENCE.value,
+        ),
+        (
+            "nhsd-nrlf--int-1--api--consumer--searchPostDocumentReference",
+            ConsumerApiInteractions.SEARCH_POST_DOCUMENT_REFERENCE.value,
+        ),
+        (
+            "nhsd-nrlf--dev-sandbox-2--api--producer--updateDocumentReference",
+            ProducerApiInteractions.UPDATE_DOCUMENT_REFERENCE.value,
+        ),
+        (
+            "nhsd-nrlf--3d9729--api--producer--upsertDocumentReference",
+            ProducerApiInteractions.UPSERT_DOCUMENT_REFERENCE.value,
+        ),
+        (
+            "nhsd-nrlf--ref-2--api--producer--searchPostDocumentReference",
+            ProducerApiInteractions.SEARCH_POST_DOCUMENT_REFERENCE.value,
+        ),
+        (
+            "nhsd-nrlf--qa-sandbox-2--api--producer--readDocumentReference",
+            ProducerApiInteractions.READ_DOCUMENT_REFERENCE.value,
+        ),
+        # (
+        #     "nhsd-nrlf--perftest-1--api--producer--searchPostDocumentReferenc",  # uh oh
+        #     ProducerApiInteractions.SEARCH_DOCUMENT_REFERENCE.value,
+        # ),
+    ],
+)
+def test_parse_function_name(long_function_name, expected):
+    result = _parse_function_name(long_function_name)
+
+    assert result == expected
 
 
 def test_verify_request_id_happy_path():
@@ -936,6 +982,100 @@ def test_request_handler_with_custom_repository(mocker: MockerFixture):
     assert repository_mock.call_args.kwargs == {
         "table_name": "unit-test-document-pointer",
     }
+
+
+def test_request_handler_interaction_allowed_when_function_in_v2_interactions(
+    mocker: MockerFixture,
+):
+    mocker.patch(
+        "nrlf.core.decorators.get_pointer_permissions_v2",
+        return_value={
+            "types": ["http://snomed.info/sct|736253002"],
+            "interactions": ["test_function"],
+        },
+    )
+
+    @request_handler()
+    def decorated_function() -> Response:
+        return Response(
+            statusCode="200",
+            body=json.dumps({"message": "Hello, World!"}),
+            headers={"Content-Type": "application/json"},
+        )
+
+    event = create_test_api_gateway_event(headers=_create_v2_headers())
+    context = create_mock_context(function_name="test_function")
+
+    result = decorated_function(event, context)
+
+    assert result["statusCode"] == "200"
+
+
+def test_request_handler_interaction_forbidden_when_function_not_in_v2_interactions(
+    mocker: MockerFixture,
+):
+    mocker.patch(
+        "nrlf.core.decorators.get_pointer_permissions_v2",
+        return_value={
+            "types": ["http://snomed.info/sct|736253002"],
+            "interactions": ["someOtherFunction"],
+        },
+    )
+
+    @request_handler()
+    def decorated_function() -> Response:
+        return Response(
+            statusCode="200",
+            body=json.dumps({"message": "Hello, World!"}),
+            headers={"Content-Type": "application/json"},
+        )
+
+    event = create_test_api_gateway_event(headers=_create_v2_headers())
+    context = create_mock_context(function_name="theOgFunction")
+    mock_logger = mocker.patch("nrlf.core.decorators.logger")
+
+    result = decorated_function(event, context)
+
+    assert result["statusCode"] == "403"
+    parsed_body = json.loads(result["body"])
+    assert parsed_body["issue"][0]["code"] == "forbidden"
+    assert (
+        "'Y05868' does not have permission to access this resource"
+        in parsed_body["issue"][0]["diagnostics"]
+    )
+    assert any(
+        args and args[0] == LogReference.HANDLER005a
+        for args, _ in mock_logger.log.call_args_list
+    )
+
+
+def test_request_handler_interaction_forbidden_when_v2_interactions_empty(
+    mocker: MockerFixture,
+):
+    mocker.patch(
+        "nrlf.core.decorators.get_pointer_permissions_v2",
+        return_value={
+            "types": ["http://snomed.info/sct|736253002"],
+            "interactions": [],
+        },
+    )
+
+    @request_handler()
+    def decorated_function() -> Response:
+        return Response(
+            statusCode="200",
+            body=json.dumps({"message": "Hello, World!"}),
+            headers={"Content-Type": "application/json"},
+        )
+
+    event = create_test_api_gateway_event(headers=_create_v2_headers())
+    context = create_mock_context()
+
+    result = decorated_function(event, context)
+
+    assert result["statusCode"] == "403"
+    parsed_body = json.loads(result["body"])
+    assert parsed_body["issue"][0]["code"] == "forbidden"
 
 
 def test_deprecated_decorator():

--- a/layer/nrlf/core/tests/test_decorators.py
+++ b/layer/nrlf/core/tests/test_decorators.py
@@ -14,6 +14,7 @@ from nrlf.core.constants import (
     X_REQUEST_ID_HEADER,
     AccessControls,
     ConsumerApiInteractions,
+    InternalApiInteractions,
     PointerTypes,
     ProducerApiInteractions,
     V2Headers,
@@ -381,7 +382,7 @@ def test_log_includes_client_cert_details_when_no_cert(mocker: MockerFixture):
         ),
         (
             "nhsd-nrlf--3d9729--api--producer--upsertDocumentReference",
-            ProducerApiInteractions.UPSERT_DOCUMENT_REFERENCE.value,
+            InternalApiInteractions.UPSERT_DOCUMENT_REFERENCE.value,
         ),
         (
             "nhsd-nrlf--ref-2--api--producer--searchPostDocumentReference",

--- a/layer/nrlf/tests/events.py
+++ b/layer/nrlf/tests/events.py
@@ -74,9 +74,9 @@ def create_test_api_gateway_event(
     }
 
 
-def create_mock_context():
+def create_mock_context(function_name="test_function"):
     return Mock(
-        function_name="test_function",
+        function_name=function_name,
         function_version="1",
         invoked_function_arn="arn:aws:lambda:eu-west-2:123456789012:function:test_function:1",
     )

--- a/scripts/get_s3_permissions.py
+++ b/scripts/get_s3_permissions.py
@@ -6,7 +6,12 @@ from pathlib import Path
 import fire
 from aws_session_assume import get_boto_session
 
-from nrlf.core.constants import AccessControls, PointerTypes
+from nrlf.core.constants import (
+    AccessControls,
+    ConsumerApiInteractions,
+    PointerTypes,
+    ProducerApiInteractions,
+)
 
 
 def get_file_folders(s3_client, bucket_name, prefix=""):
@@ -49,10 +54,29 @@ def add_test_files(folder, file_name, local_path):
         json.dump(PointerTypes.list(), f)
 
 
-def _write_permission_file(folder_path, ods_code, pointer_types, access_controls=None):
+def _get_default_interactions(folder_path):
+    if "producer" in str(folder_path):
+        return ProducerApiInteractions.list()
+    return ConsumerApiInteractions.list()
+
+
+def _write_permission_file(
+    folder_path,
+    ods_code,
+    pointer_types,
+    access_controls=None,
+    interactions=None,
+):
     folder_path.mkdir(parents=True, exist_ok=True)
     with open(folder_path / f"{ods_code}.json", "w") as f:
-        json.dump({"access_controls": access_controls or [], "types": pointer_types}, f)
+        json.dump(
+            {
+                "access_controls": access_controls or [],
+                "interactions": interactions or _get_default_interactions(folder_path),
+                "types": pointer_types,
+            },
+            f,
+        )
 
 
 def add_feature_test_files(local_path):

--- a/scripts/get_s3_permissions.py
+++ b/scripts/get_s3_permissions.py
@@ -152,9 +152,13 @@ def add_feature_test_files(local_path):
             ),
             (
                 "z00z-y11y-x22x",
-                "1DSYNC1NT3R4CT1ON5",
+                "1DSYNCTEST",
                 [],
-                [AccessControls.ALLOW_ALL_TYPES.value],
+                [
+                    AccessControls.ALLOW_ALL_TYPES.value,
+                    AccessControls.ALLOW_OVERRIDE_CREATION_DATETIME.value,
+                    AccessControls.ALLOW_SUPERSEDE_WITH_DELETE_FAILURE.value,
+                ],
                 InternalApiInteractions.list(),
             ),
         ],

--- a/scripts/get_s3_permissions.py
+++ b/scripts/get_s3_permissions.py
@@ -9,6 +9,7 @@ from aws_session_assume import get_boto_session
 from nrlf.core.constants import (
     AccessControls,
     ConsumerApiInteractions,
+    InternalApiInteractions,
     PointerTypes,
     ProducerApiInteractions,
 )
@@ -141,7 +142,14 @@ def add_feature_test_files(local_path):
                     AccessControls.ALLOW_OVERRIDE_CREATION_DATETIME.value,
                     AccessControls.ALLOW_SUPERSEDE_WITH_DELETE_FAILURE.value,
                 ],
-                ProducerApiInteractions.list(),
+                ProducerApiInteractions.list().extend(InternalApiInteractions.list()),
+            ),
+            (
+                "z00z-y11y-x22x",
+                "1DSYNC1NT3R4CT1ON5",
+                [],
+                [AccessControls.ALLOW_ALL_TYPES.value],
+                InternalApiInteractions.list(),
             ),
         ],
     }

--- a/scripts/get_s3_permissions.py
+++ b/scripts/get_s3_permissions.py
@@ -93,18 +93,28 @@ def add_feature_test_files(local_path):
                 "RX898",
                 [PointerTypes.MENTAL_HEALTH_PLAN.value],
                 [],
+                ConsumerApiInteractions.list(),
             ),  # http://snomed.info/sct|736253002
             (
                 "app-t004",
                 "ODS1",
                 [PointerTypes.PERSONALISED_CARE_AND_SUPPORT_PLAN.value],
                 [],
+                ConsumerApiInteractions.list(),
             ),
             (
                 "z00z-y11y-x22x",
                 "4LLTYP35C",
                 [],
                 [AccessControls.ALLOW_ALL_TYPES.value],
+                ConsumerApiInteractions.list(),
+            ),
+            (
+                "z00z-y11y-x22x",
+                "1NT3R4CT1ON5",
+                [],
+                [AccessControls.ALLOW_ALL_TYPES.value],
+                [ConsumerApiInteractions.READ_DOCUMENT_REFERENCE.value],
             ),
         ],
         "producer": [
@@ -113,12 +123,14 @@ def add_feature_test_files(local_path):
                 "RX898",
                 [PointerTypes.EOL_CARE_PLAN.value],
                 [],
+                ProducerApiInteractions.list(),
             ),  # http://snomed.info/sct|736373009
             (
                 "app-t004",
                 "ODS1",
                 [PointerTypes.PERSONALISED_CARE_AND_SUPPORT_PLAN.value],
                 [],
+                ProducerApiInteractions.list(),
             ),
             (
                 "z00z-y11y-x22x",
@@ -129,6 +141,7 @@ def add_feature_test_files(local_path):
                     AccessControls.ALLOW_OVERRIDE_CREATION_DATETIME.value,
                     AccessControls.ALLOW_SUPERSEDE_WITH_DELETE_FAILURE.value,
                 ],
+                ProducerApiInteractions.list(),
             ),
         ],
     }
@@ -138,9 +151,10 @@ def add_feature_test_files(local_path):
             ods_code,
             pointer_types,
             access_controls,
+            interactions,
         )
         for actor_type, entries in org_permissions.items()
-        for app_id, ods_code, pointer_types, access_controls in entries
+        for app_id, ods_code, pointer_types, access_controls, interactions in entries
     ]
     app_permissions = {
         "consumer": [

--- a/tests/features/consumer/v2-permissions-by-interaction.feature
+++ b/tests/features/consumer/v2-permissions-by-interaction.feature
@@ -9,7 +9,7 @@ Feature: Consumer v2 permissions by interaction - Success and Failure Scenarios
 
   Scenario: V2 permissions with no access for interaction - searchDocumentReference
     Given the application 'DataShare' (ID 'z00z-y11y-x22x') is registered to access the API
-    When consumer v2 '1DSYNC1NT3R4CT1ON5' searches for DocumentReferences with parameters:
+    When consumer '1DSYNC1NT3R4CT1ON5' searches for DocumentReferences with parameters:
       | parameter | value                                   |
       | subject   | 9278693472                              |
       | type      | http://snomed.info/sct\|887701000000100 |

--- a/tests/features/consumer/v2-permissions-by-interaction.feature
+++ b/tests/features/consumer/v2-permissions-by-interaction.feature
@@ -1,0 +1,34 @@
+Feature: Consumer v2 permissions by interaction - Success and Failure Scenarios
+  For the v2 permissions model, permissions are resolved from a JSON file stored in the
+  nrlf_permissions Lambda layer.  Permissions for the feature tests are baked into the layer
+  by `scripts/get_s3_permissions.py` at build time, so no dynamic seeding step is required for
+  success scenarios.
+
+  Background:
+    Given the application 'DataShare' (ID 'z00z-y11y-x22x') is registered to access the API
+
+  Scenario: V2 permissions with no access for interaction - searchDocumentReference
+    Given the application 'DataShare' (ID 'z00z-y11y-x22x') is registered to access the API
+    When consumer v2 '1DSYNC1NT3R4CT1ON5' searches for DocumentReferences with parameters:
+      | parameter | value                                   |
+      | subject   | 9278693472                              |
+      | type      | http://snomed.info/sct\|887701000000100 |
+    Then the response status code is 403
+    And the response is an OperationOutcome with 1 issue
+    And the OperationOutcome contains the issue:
+      """
+      {
+        "severity": "error",
+        "code": "forbidden",
+        "details": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/CodeSystem/Spine-ErrorOrWarningCode",
+              "code": "ACCESS DENIED",
+              "display": "Access has been denied to process this request"
+            }
+          ]
+        },
+        "diagnostics": "Your organisation '1DSYNC1NT3R4CT1ON5' does not have permission to access this resource. Contact the onboarding team."
+      }
+      """

--- a/tests/features/consumer/v2-permissions-by-interaction.feature
+++ b/tests/features/consumer/v2-permissions-by-interaction.feature
@@ -9,7 +9,7 @@ Feature: Consumer v2 permissions by interaction - Success and Failure Scenarios
 
   Scenario: V2 permissions with no access for interaction - searchDocumentReference
     Given the application 'DataShare' (ID 'z00z-y11y-x22x') is registered to access the API
-    When consumer '1DSYNC1NT3R4CT1ON5' searches for DocumentReferences with parameters:
+    When consumer '1DSYNCTEST' searches for DocumentReferences with parameters:
       | parameter | value                                   |
       | subject   | 9278693472                              |
       | type      | http://snomed.info/sct\|887701000000100 |
@@ -29,6 +29,6 @@ Feature: Consumer v2 permissions by interaction - Success and Failure Scenarios
             }
           ]
         },
-        "diagnostics": "Your organisation '1DSYNC1NT3R4CT1ON5' does not have permission to access this resource. Contact the onboarding team."
+        "diagnostics": "Your organisation '1DSYNCTEST' does not have permission to access this resource. Contact the onboarding team."
       }
       """

--- a/tests/features/producer/v2-permissions-access-controls.feature
+++ b/tests/features/producer/v2-permissions-access-controls.feature
@@ -93,18 +93,18 @@ Feature: Producer v2 access_control permissions - Success and Failure Scenarios
     And the date of the resource in the Location header is not '2024-06-01T12:00:00Z'
 
   Scenario: Successfully supersede a DocumentReference with ALLOW_SUPERSEDE_WITH_DELETE_FAILURE - upsertDocumentReference
-    Given the application 'DataShare' (ID 'v2-z00z-y11y-x22x') is registered to access the API
-    When producer '4LLTYP35P' upserts a DocumentReference with values:
-      | property   | value                                          |
-      | id         | 4LLTYP35P-testid-upsert-0001-0002              |
-      | subject    | 9278693472                                     |
-      | status     | current                                        |
-      | type       | 736253002                                      |
-      | category   | 734163000                                      |
-      | custodian  | 4LLTYP35P                                      |
-      | author     | 4LLTYP35P                                      |
-      | url        | https://example.org/newdoc.pdf                 |
-      | supercedes | 4LLTYP35P-000-ThisRefDoesNotExistSupersedeTest |
+    Given the application 'DataShare' (ID 'z00z-y11y-x22x') is registered to access the API
+    When producer '1DSYNCTEST' upserts a DocumentReference with values:
+      | property   | value                                           |
+      | id         | 1DSYNCTEST-testid-upsert-0001-0002              |
+      | subject    | 9278693472                                      |
+      | status     | current                                         |
+      | type       | 736253002                                       |
+      | category   | 734163000                                       |
+      | custodian  | 1DSYNCTEST                                      |
+      | author     | 1DSYNCTEST                                      |
+      | url        | https://example.org/newdoc.pdf                  |
+      | supercedes | 1DSYNCTEST-000-ThisRefDoesNotExistSupersedeTest |
     Then the response status code is 201
     And the response is an OperationOutcome with 1 issue
     And the OperationOutcome contains the issue:

--- a/tests/features/producer/v2-permissions-by-interaction.feature
+++ b/tests/features/producer/v2-permissions-by-interaction.feature
@@ -1,0 +1,126 @@
+Feature: Producer v2 permissions by pointer type - Success and Failure Scenarios
+  For the v2 permissions model, permissions are resolved from a JSON file stored in the
+  nrlf_permissions Lambda layer.  Permissions for the feature tests are baked into the layer by
+  `scripts/get_s3_permissions.py` at build time, so no dynamic seeding step is required for
+  success scenarios.
+
+  Background:
+    Given the application 'DataShare' (ID 'z00z-y11y-x22x') is registered to access the API
+
+  Scenario: V2 Permissions with no access for producer interaction - createDocumentReference
+    When producer v2 '1DSYNC1NT3R4CT1ON5' creates a DocumentReference with values:
+      | property        | value                          |
+      | subject         | 9278693472                     |
+      | status          | current                        |
+      | type            | 736253002                      |
+      | category        | 734163000                      |
+      | custodian       | RX898                          |
+      | author          | HAR1                           |
+      | url             | https://example.org/my-doc.pdf |
+      | practiceSetting | 788002001                      |
+    Then the response status code is 403
+    And the response is an OperationOutcome with 1 issue
+    And the OperationOutcome contains the issue:
+      """
+      {
+        "severity": "error",
+        "code": "forbidden",
+        "details": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/CodeSystem/Spine-ErrorOrWarningCode",
+              "code": "ACCESS DENIED",
+              "display": "Access has been denied to process this request"
+            }
+          ]
+        },
+        "diagnostics": "Your organisation '1DSYNC1NT3R4CT1ON5' does not have permission to access this resource. Contact the onboarding team."
+      }
+      """
+
+  Scenario: V2 Permissions with all Producer perms has no access for upsert - upsertDocumentReference
+    Given a DocumentReference resource exists with values:
+      | property    | value                                |
+      | id          | ODS1-1111111111-SearchNHSDocRefTest1 |
+      | subject     | 9999999999                           |
+      | status      | current                              |
+      | type        | 736373009                            |
+      | category    | 734163000                            |
+      | contentType | application/pdf                      |
+      | url         | https://example.org/my-doc.pdf       |
+      | custodian   | ODS1                                 |
+      | author      | X26                                  |
+    When producer v2 'ODS1' upserts a DocumentReference with values:
+      | property  | value                                |
+      | id        | ODS1-1111111111-SearchNHSDocRefTest1 |
+      | subject   | 9999999999                           |
+      | status    | current                              |
+      | type      | 736373009                            |
+      | category  | 734163000                            |
+      | url       | https://example.org/my-doc.pdf       |
+      | custodian | ODS1                                 |
+      | author    | X26                                  |
+    Then the response status code is 403
+    And the response is an OperationOutcome with 1 issue
+    And the OperationOutcome contains the issue:
+      """
+      {
+        "severity": "error",
+        "code": "forbidden",
+        "details": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/CodeSystem/Spine-ErrorOrWarningCode",
+              "code": "ACCESS DENIED",
+              "display": "Access has been denied to process this request"
+            }
+          ]
+        },
+        "diagnostics": "Your organisation 'ODS1' does not have permission to access this resource. Contact the onboarding team."
+      }
+      """
+
+  Scenario: V2 Permissions with internal perms has access for upsert - upsertDocumentReference
+    Given the application 'DataShare' (ID 'z00z-y11y-x22x') is registered to access the API
+    And the organisation '1DSYNC1NT3R4CT1ON5' is authorised to access pointer types:
+      | system                 | value     |
+      | http://snomed.info/sct | 736253002 |
+    When producer v1 '1DSYNC1NT3R4CT1ON5' upserts a DocumentReference with values:
+      | property  | value                                      |
+      | id        | 1DSYNC1NT3R4CT1ON5-testid-upsert-0001-0001 |
+      | subject   | 9278693472                                 |
+      | status    | current                                    |
+      | type      | 736253002                                  |
+      | category  | 734163000                                  |
+      | custodian | 1DSYNC1NT3R4CT1ON5                         |
+      | author    | HAR1                                       |
+      | url       | https://example.org/my-doc.pdf             |
+    Then the response status code is 201
+    And the response is an OperationOutcome with 1 issue
+    And the OperationOutcome contains the issue:
+      """
+      {
+        "severity": "information",
+        "code": "informational",
+        "details": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/ValueSet/NRL-ResponseCode",
+              "code": "RESOURCE_CREATED",
+              "display": "Resource created"
+            }
+          ]
+        },
+        "diagnostics": "The document has been created"
+      }
+      """
+    And the Document Reference '1DSYNC1NT3R4CT1ON5-testid-upsert-0001-0001' exists with values:
+      | property  | value                                      |
+      | id        | 1DSYNC1NT3R4CT1ON5-testid-upsert-0001-0001 |
+      | subject   | 9278693472                                 |
+      | status    | current                                    |
+      | type      | 736253002                                  |
+      | category  | 734163000                                  |
+      | custodian | 1DSYNC1NT3R4CT1ON5                         |
+      | author    | HAR1                                       |
+      | url       | https://example.org/my-doc.pdf             |

--- a/tests/features/producer/v2-permissions-by-interaction.feature
+++ b/tests/features/producer/v2-permissions-by-interaction.feature
@@ -8,7 +8,7 @@ Feature: Producer v2 permissions by pointer type - Success and Failure Scenarios
     Given the application 'DataShare' (ID 'z00z-y11y-x22x') is registered to access the API
 
   Scenario: V2 Permissions with no access for producer interaction - createDocumentReference
-    When producer v2 '1DSYNC1NT3R4CT1ON5' creates a DocumentReference with values:
+    When producer '1DSYNC1NT3R4CT1ON5' creates a DocumentReference with values:
       | property        | value                          |
       | subject         | 9278693472                     |
       | status          | current                        |
@@ -50,7 +50,7 @@ Feature: Producer v2 permissions by pointer type - Success and Failure Scenarios
       | url         | https://example.org/my-doc.pdf       |
       | custodian   | ODS1                                 |
       | author      | X26                                  |
-    When producer v2 'ODS1' upserts a DocumentReference with values:
+    When producer 'ODS1' upserts a DocumentReference with values:
       | property  | value                                |
       | id        | ODS1-1111111111-SearchNHSDocRefTest1 |
       | subject   | 9999999999                           |

--- a/tests/features/producer/v2-permissions-by-interaction.feature
+++ b/tests/features/producer/v2-permissions-by-interaction.feature
@@ -8,7 +8,7 @@ Feature: Producer v2 permissions by pointer type - Success and Failure Scenarios
     Given the application 'DataShare' (ID 'z00z-y11y-x22x') is registered to access the API
 
   Scenario: V2 Permissions with no access for producer interaction - createDocumentReference
-    When producer '1DSYNC1NT3R4CT1ON5' creates a DocumentReference with values:
+    When producer '1DSYNCTEST' creates a DocumentReference with values:
       | property        | value                          |
       | subject         | 9278693472                     |
       | status          | current                        |
@@ -34,7 +34,7 @@ Feature: Producer v2 permissions by pointer type - Success and Failure Scenarios
             }
           ]
         },
-        "diagnostics": "Your organisation '1DSYNC1NT3R4CT1ON5' does not have permission to access this resource. Contact the onboarding team."
+        "diagnostics": "Your organisation '1DSYNCTEST' does not have permission to access this resource. Contact the onboarding team."
       }
       """
 
@@ -82,19 +82,19 @@ Feature: Producer v2 permissions by pointer type - Success and Failure Scenarios
 
   Scenario: V2 Permissions with internal perms has access for upsert - upsertDocumentReference
     Given the application 'DataShare' (ID 'z00z-y11y-x22x') is registered to access the API
-    And the organisation '1DSYNC1NT3R4CT1ON5' is authorised to access pointer types:
+    And the organisation '1DSYNCTEST' is authorised to access pointer types:
       | system                 | value     |
       | http://snomed.info/sct | 736253002 |
-    When producer v1 '1DSYNC1NT3R4CT1ON5' upserts a DocumentReference with values:
-      | property  | value                                      |
-      | id        | 1DSYNC1NT3R4CT1ON5-testid-upsert-0001-0001 |
-      | subject   | 9278693472                                 |
-      | status    | current                                    |
-      | type      | 736253002                                  |
-      | category  | 734163000                                  |
-      | custodian | 1DSYNC1NT3R4CT1ON5                         |
-      | author    | HAR1                                       |
-      | url       | https://example.org/my-doc.pdf             |
+    When producer '1DSYNCTEST' upserts a DocumentReference with values:
+      | property  | value                              |
+      | id        | 1DSYNCTEST-testid-upsert-0001-0001 |
+      | subject   | 9278693472                         |
+      | status    | current                            |
+      | type      | 736253002                          |
+      | category  | 734163000                          |
+      | custodian | 1DSYNCTEST                         |
+      | author    | HAR1                               |
+      | url       | https://example.org/my-doc.pdf     |
     Then the response status code is 201
     And the response is an OperationOutcome with 1 issue
     And the OperationOutcome contains the issue:
@@ -114,13 +114,13 @@ Feature: Producer v2 permissions by pointer type - Success and Failure Scenarios
         "diagnostics": "The document has been created"
       }
       """
-    And the Document Reference '1DSYNC1NT3R4CT1ON5-testid-upsert-0001-0001' exists with values:
-      | property  | value                                      |
-      | id        | 1DSYNC1NT3R4CT1ON5-testid-upsert-0001-0001 |
-      | subject   | 9278693472                                 |
-      | status    | current                                    |
-      | type      | 736253002                                  |
-      | category  | 734163000                                  |
-      | custodian | 1DSYNC1NT3R4CT1ON5                         |
-      | author    | HAR1                                       |
-      | url       | https://example.org/my-doc.pdf             |
+    And the Document Reference '1DSYNCTEST-testid-upsert-0001-0001' exists with values:
+      | property  | value                              |
+      | id        | 1DSYNCTEST-testid-upsert-0001-0001 |
+      | subject   | 9278693472                         |
+      | status    | current                            |
+      | type      | 736253002                          |
+      | category  | 734163000                          |
+      | custodian | 1DSYNCTEST                         |
+      | author    | HAR1                               |
+      | url       | https://example.org/my-doc.pdf     |


### PR DESCRIPTION
BIG TODO:
cannot trust lambda function name to contain full interaction name - for long environments this gets concatenated e.g. `"nhsd-nrlf--perftest-1--api--producer--searchPostDocumentReferenc"` 😬 
find somewhere else to get this info from: URL -> interactions map?

- Compare & contrast w/ consumer_interactions & producer_interactions vs interactions: consumer_search & interactions: producer_search vs now.