### PR TITLE
NRL-1922 Use commit hashes for github workflow action versions

### DIFF
--- a/.github/workflows/activate-stack.yml
+++ b/.github/workflows/activate-stack.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Git clone - ${{ github.ref }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Git clone - ${{ github.ref }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.ref }}
 
@@ -58,7 +58,7 @@ jobs:
           make get-s3-perms ENV=${account} TF_WORKSPACE_NAME=${inactive_stack}
 
       - name: Save Build Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: build-artifacts
           path: |
@@ -67,7 +67,7 @@ jobs:
             !dist/nrlf_permissions.zip
 
       - name: Save NRLF Permissions cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           key: ${{ github.run_id }}-nrlf-permissions
           path: dist/nrlf_permissions.zip
@@ -81,12 +81,12 @@ jobs:
       contents: read
       actions: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.ref }}
 
       - name: Get build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: build-artifacts
           path: dist

--- a/.github/workflows/deploy-account-wide-infra.yml
+++ b/.github/workflows/deploy-account-wide-infra.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Git clone - ${{ inputs.branch_name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.branch_name }}
 
@@ -115,7 +115,7 @@ jobs:
 
     steps:
       - name: Git clone - ${{ inputs.branch_name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.branch_name }}
 

--- a/.github/workflows/persistent-environment.yml
+++ b/.github/workflows/persistent-environment.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Git clone - ${{ inputs.branch_name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.branch_name }}
 
@@ -59,7 +59,7 @@ jobs:
           make get-s3-perms ENV=${account} TF_WORKSPACE_NAME=${inactive_stack}
 
       - name: Save Build Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: build-artifacts
           path: |
@@ -67,7 +67,7 @@ jobs:
             !dist/nrlf_permissions.zip
 
       - name: Save NRLF Permissions cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           key: ${{ github.run_id }}-nrlf-permissions
           path: dist/nrlf_permissions.zip
@@ -84,7 +84,7 @@ jobs:
 
     steps:
       - name: Git clone - ${{ inputs.branch_name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.branch_name }}
 
@@ -108,13 +108,13 @@ jobs:
           make truststore-pull-server ENV=${account}
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: build-artifacts
           path: dist
 
       - name: Restore NRLF permissions cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           key: ${{ github.run_id }}-nrlf-permissions
           path: dist/nrlf_permissions.zip
@@ -161,7 +161,7 @@ jobs:
 
     steps:
       - name: Git clone - ${{ inputs.branch_name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.branch_name }}
 
@@ -171,13 +171,13 @@ jobs:
           poetry install --no-root
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: build-artifacts
           path: dist
 
       - name: Restore NRLF permissions cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           key: ${{ github.run_id }}-nrlf-permissions
           path: dist/nrlf_permissions.zip
@@ -241,7 +241,7 @@ jobs:
 
     steps:
       - name: Git clone - ${{ inputs.branch_name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.branch_name }}
 
@@ -275,7 +275,7 @@ jobs:
 
     steps:
       - name: Git clone - ${{ inputs.branch_name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.branch_name }}
 
@@ -309,7 +309,7 @@ jobs:
 
     steps:
       - name: Git clone - ${{ inputs.branch_name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.branch_name }}
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Git clone - ${{ github.ref }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.ref }}
 
@@ -35,7 +35,7 @@ jobs:
         run: make test
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: build-artifacts
           path: dist
@@ -49,12 +49,12 @@ jobs:
       contents: read
       actions: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.ref }}
 
       - name: Get build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: build-artifacts
           path: dist

--- a/.github/workflows/pr-env-deploy.yml
+++ b/.github/workflows/pr-env-deploy.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Git Clone - ${{ github.event.pull_request.head.ref }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -80,7 +80,7 @@ jobs:
           make get-s3-perms ENV=dev
 
       - name: Save Build Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: build-artifacts
           path: |
@@ -88,13 +88,13 @@ jobs:
             !dist/nrlf_permissions.zip
 
       - name: Save NRLF Permissions cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           key: ${{ github.run_id }}-nrlf-permissions
           path: dist/nrlf_permissions.zip
 
       - name: Add Failure Pull Request Comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         if: ${{ failure() }}
         with:
           script: |
@@ -119,7 +119,7 @@ jobs:
 
     steps:
       - name: Git Clone - ${{ github.event.pull_request.head.ref }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -136,13 +136,13 @@ jobs:
           role-session-name: github-actions-ci-${{ needs.set-environment-id.outputs.environment_id }}
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: build-artifacts
           path: dist
 
       - name: Restore NRLF permissions cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           key: ${{ github.run_id }}-nrlf-permissions
           path: dist/nrlf_permissions.zip
@@ -172,7 +172,7 @@ jobs:
         run: terraform -chdir=terraform/infrastructure apply tfplan
 
       - name: Add Success Pull Request Comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         if: ${{ success() }}
         with:
           script: |
@@ -184,7 +184,7 @@ jobs:
             })
 
       - name: Add Failure Pull Request Comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         if: ${{ failure() }}
         with:
           script: |
@@ -206,7 +206,7 @@ jobs:
 
     steps:
       - name: Git Clone - ${{ github.event.pull_request.head.ref }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -247,7 +247,7 @@ jobs:
 
     steps:
       - name: Git Clone - ${{ github.event.pull_request.head.ref }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -286,7 +286,7 @@ jobs:
 
     steps:
       - name: Git Clone - ${{ github.event.pull_request.head.ref }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -326,7 +326,7 @@ jobs:
         run: make test-performance-output
 
       - name: Store Performance Test Outputs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: performance-test-outputs
           path: dist/*.png

--- a/.github/workflows/pr-env-destroy.yml
+++ b/.github/workflows/pr-env-destroy.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Git Clone - ${{ github.event.pull_request.head.ref }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.pull_request.merged && github.event.pull_request.base.ref || github.event.pull_request.head.ref }}
 
@@ -94,7 +94,7 @@ jobs:
           terraform -chdir=terraform/infrastructure workspace delete ${{ needs.set-environment-id.outputs.environment_id }}
 
       - name: Add Failure Pull Request Comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         if: ${{ failure() }}
         with:
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Git clone - ${{ github.ref }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.ref }}
 
@@ -70,7 +70,7 @@ jobs:
         run: bash scripts/sbom-create.sh
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: sbom-${{ github.sha }}
           path: sbom.spdx.json

--- a/.github/workflows/rollback-stack.yml
+++ b/.github/workflows/rollback-stack.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Git clone - ${{ github.ref }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/update-lambda-permissions.yml
+++ b/.github/workflows/update-lambda-permissions.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Git clone - ${{ github.ref }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.ref }}
 
@@ -87,7 +87,7 @@ jobs:
 
     steps:
       - name: Git clone - ${{ github.ref }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.ref }}
 
@@ -112,7 +112,7 @@ jobs:
           make get-s3-perms ENV=${account} TF_WORKSPACE_NAME=$STACK_NAME
 
       - name: Save NRLF permissions in cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           key: ${{ github.run_id }}-nrlf-permissions
           path: dist/nrlf_permissions.zip
@@ -129,7 +129,7 @@ jobs:
 
     steps:
       - name: Git clone - ${{ github.ref }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.ref }}
 
@@ -157,7 +157,7 @@ jobs:
           ./scripts/pull-lambda-code-for-stack.sh $STACK_NAME
 
       - name: Save lambda artifacts in cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           key: ${{ github.run_id }}-pulled-lambda-artifacts
           path: dist/*.zip
@@ -174,7 +174,7 @@ jobs:
 
     steps:
       - name: Git clone - ${{ github.ref }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.ref }}
 
@@ -184,14 +184,14 @@ jobs:
           poetry install --no-root
 
       - name: Restore pulled lambda artifacts
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           key: ${{ github.run_id }}-pulled-lambda-artifacts
           path: dist/*.zip
           fail-on-cache-miss: true
 
       - name: Restore NRLF permissions cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           key: ${{ github.run_id }}-nrlf-permissions
           path: dist/nrlf_permissions.zip
@@ -243,7 +243,7 @@ jobs:
 
     steps:
       - name: Git clone - ${{ github.ref }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.ref }}
 
@@ -253,14 +253,14 @@ jobs:
           poetry install --no-root
 
       - name: Restore pulled lambda artifacts
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           key: ${{ github.run_id }}-pulled-lambda-artifacts
           path: dist/*.zip
           fail-on-cache-miss: true
 
       - name: Restore NRLF permissions cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           key: ${{ github.run_id }}-nrlf-permissions
           path: dist/nrlf_permissions.zip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.4.0
+    rev: 001e16323a2f0162336345f4ceb6d72c204980b5 # v1.4.0
     hooks:
       - id: detect-secrets
         exclude: .pre-commit-config.yaml|layer/psycopg2/.*
@@ -12,7 +12,7 @@ repos:
       - id: prettier
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: 38b88246ccc552bffaaf54259d064beeee434539 # v4.0.1
     hooks:
       - id: check-yaml
       - id: check-json
@@ -28,7 +28,7 @@ repos:
 
   # Flake8 for print only (error code T201)
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: b9a7794c4f425ef8419081e6993f99419cc667ea # 6.0.0
     hooks:
       - id: flake8
         additional_dependencies:
@@ -38,13 +38,13 @@ repos:
           - "--exclude=.git,__pycache__,dist,.venv,scripts/*"
 
   - repo: https://github.com/psf/black
-    rev: 24.3.0
+    rev: 552baf822992936134cbd31a38f69c8cfe7c0f05 # 24.3.0
     hooks:
       - id: black
         language_version: python3
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: e44834b7b294701f596c9118d6c370f86671a50d # 5.12.0
     hooks:
       - id: isort
         args:
@@ -58,13 +58,13 @@ repos:
           ]
 
   - repo: https://github.com/ducminh-phan/reformat-gherkin
-    rev: v3.0.1
+    rev: b6674f526d8b198ffad5d016b71430e3dc7a0e8e # v3.0.1
     hooks:
       - id: reformat-gherkin
 
   # This uses the root .terraform-version file, make sure to update it you change the actual terraform versions
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.76.0
+    rev: 07c6764c309d14fd37536e6c679354ab99c59a59 # v1.76.0
     hooks:
       - id: terraform_fmt
         args:


### PR DESCRIPTION
The following actions were updated:

actions/cache/restore@v4 -> 0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
actions/checkout@v4 -> 34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
actions/download-artifacts@v4 -> d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
actions/github-script@v7 -> f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
actions/upload-artifact@v4 -> ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

Also, the pre-commit versions were updated to match the exact commit of each version tag