### PR TITLE
NRL-2099 manage permissions script (parity)

### DIFF
--- a/layer/nrlf/core/constants.py
+++ b/layer/nrlf/core/constants.py
@@ -754,37 +754,37 @@ PERMISSION_KEY_ATTRIBUTES = {
     V2PermissionKey.ACCESS_CONTROLS.value: {
         "display": "access controls",
         "display_singular": "access control",
-        "permission_lookup": None,
+        "attribute_lookup": None,
         "all_assignable_permission_items": AccessControls.list(),
     },
     V2PermissionKey.TYPES.value: {
         "display": "pointer types",
         "display_singular": "pointer type",
-        "permission_lookup": TYPE_ATTRIBUTES,
+        "attribute_lookup": TYPE_ATTRIBUTES,
         "all_assignable_permission_items": PointerTypes.list(),
     },
     V2PermissionKey.CATEGORIES.value: {
         "display": "categories",
         "display_singular": "category",
-        "permission_lookup": CATEGORY_ATTRIBUTES,
+        "attribute_lookup": CATEGORY_ATTRIBUTES,
         "all_assignable_permission_items": Categories.list(),
     },
     V2PermissionKey.INTERACTIONS.value: {
         "display": "interactions",
         "display_singular": "interaction",
-        "permission_lookup": "",
+        "attribute_lookup": "",
         "all_assignable_permission_items": "",
     },
     V2PermissionKey.PRODUCE_FOR_AUTHORS.value: {
         "display": "produce for authors",
         "display_singular": "produce for author",
-        "permission_lookup": "",
+        "attribute_lookup": "",
         "all_assignable_permission_items": "",
     },
     V2PermissionKey.PRODUCE_FOR_CUSTODIANS.value: {
         "display": "produce for custodians",
         "display_singular": "produce for custodian",
-        "permission_lookup": "",
+        "attribute_lookup": "",
         "all_assignable_permission_items": "",
     },
 }

--- a/layer/nrlf/core/constants.py
+++ b/layer/nrlf/core/constants.py
@@ -65,6 +65,61 @@ class AccessControls(Enum):
         return [control.value for control in AccessControls]
 
 
+class SupplierType(Enum):
+    PRODUCER = "producer"
+    CONSUMER = "consumer"
+
+    @staticmethod
+    def list():
+        return [supplier.value for supplier in SupplierType]
+
+
+class V2PermissionKey(Enum):
+    ACCESS_CONTROLS = "access_controls"
+    TYPES = "types"
+    CATEGORIES = "categories"
+    INTERACTIONS = "interactions"
+    PRODUCE_FOR_AUTHORS = "produce_for_authors"
+    PRODUCE_FOR_CUSTODIANS = "produce_for_custodians"
+
+    @staticmethod
+    def list():
+        return [permission_key.value for permission_key in V2PermissionKey]
+
+    def human_readable(self, plural=False):
+        human_lookup = {
+            V2PermissionKey.ACCESS_CONTROLS.value: {
+                "singular": "access control",
+                "plural": "access controls",
+            },
+            V2PermissionKey.TYPES.value: {
+                "singular": "pointer type",
+                "plural": "pointer types",
+            },
+            V2PermissionKey.CATEGORIES.value: {
+                "singular": "category",
+                "plural": "categories",
+            },
+            V2PermissionKey.INTERACTIONS.value: {
+                "singular": "interaction",
+                "plural": "interactions",
+            },
+            V2PermissionKey.PRODUCE_FOR_AUTHORS.value: {
+                "singular": "produce for author",
+                "plural": "produce for authors",
+            },
+            V2PermissionKey.PRODUCE_FOR_CUSTODIANS.value: {
+                "singular": "produce for custodian",
+                "plural": "produce for custodians",
+            },
+        }
+
+        if plural:
+            return human_lookup.get(self.value)["plural"]
+
+        return human_lookup.get(self.value)["singular"]
+
+
 NHSD_REQUEST_ID_HEADER = "NHSD-Request-Id"
 NHSD_CORRELATION_ID_HEADER = "NHSD-Correlation-Id"
 X_REQUEST_ID_HEADER = "X-Request-Id"

--- a/layer/nrlf/core/constants.py
+++ b/layer/nrlf/core/constants.py
@@ -65,61 +65,6 @@ class AccessControls(Enum):
         return [control.value for control in AccessControls]
 
 
-class SupplierType(Enum):
-    PRODUCER = "producer"
-    CONSUMER = "consumer"
-
-    @staticmethod
-    def list():
-        return [supplier.value for supplier in SupplierType]
-
-
-class V2PermissionKey(Enum):
-    ACCESS_CONTROLS = "access_controls"
-    TYPES = "types"
-    CATEGORIES = "categories"
-    INTERACTIONS = "interactions"
-    PRODUCE_FOR_AUTHORS = "produce_for_authors"
-    PRODUCE_FOR_CUSTODIANS = "produce_for_custodians"
-
-    @staticmethod
-    def list():
-        return [permission_key.value for permission_key in V2PermissionKey]
-
-    def human_readable(self, plural=False):
-        human_lookup = {
-            V2PermissionKey.ACCESS_CONTROLS.value: {
-                "singular": "access control",
-                "plural": "access controls",
-            },
-            V2PermissionKey.TYPES.value: {
-                "singular": "pointer type",
-                "plural": "pointer types",
-            },
-            V2PermissionKey.CATEGORIES.value: {
-                "singular": "category",
-                "plural": "categories",
-            },
-            V2PermissionKey.INTERACTIONS.value: {
-                "singular": "interaction",
-                "plural": "interactions",
-            },
-            V2PermissionKey.PRODUCE_FOR_AUTHORS.value: {
-                "singular": "produce for author",
-                "plural": "produce for authors",
-            },
-            V2PermissionKey.PRODUCE_FOR_CUSTODIANS.value: {
-                "singular": "produce for custodian",
-                "plural": "produce for custodians",
-            },
-        }
-
-        if plural:
-            return human_lookup.get(self.value)["plural"]
-
-        return human_lookup.get(self.value)["singular"]
-
-
 NHSD_REQUEST_ID_HEADER = "NHSD-Request-Id"
 NHSD_CORRELATION_ID_HEADER = "NHSD-Correlation-Id"
 X_REQUEST_ID_HEADER = "X-Request-Id"
@@ -789,4 +734,57 @@ ATTACHMENT_CONTENT_TYPES = {
     "application/json",
     "application/fhir+json",
     "application/json+fhir",
+}
+
+
+class V2PermissionKey(Enum):
+    ACCESS_CONTROLS = "access_controls"
+    TYPES = "types"
+    CATEGORIES = "categories"
+    INTERACTIONS = "interactions"
+    PRODUCE_FOR_AUTHORS = "produce_for_authors"
+    PRODUCE_FOR_CUSTODIANS = "produce_for_custodians"
+
+    @staticmethod
+    def list():
+        return [permission_key.value for permission_key in V2PermissionKey]
+
+
+PERMISSION_KEY_ATTRIBUTES = {
+    V2PermissionKey.ACCESS_CONTROLS.value: {
+        "display": "access controls",
+        "display_singular": "access control",
+        "permission_lookup": None,
+        "all_assignable_permission_items": AccessControls.list(),
+    },
+    V2PermissionKey.TYPES.value: {
+        "display": "pointer types",
+        "display_singular": "pointer type",
+        "permission_lookup": TYPE_ATTRIBUTES,
+        "all_assignable_permission_items": PointerTypes.list(),
+    },
+    V2PermissionKey.CATEGORIES.value: {
+        "display": "categories",
+        "display_singular": "category",
+        "permission_lookup": CATEGORY_ATTRIBUTES,
+        "all_assignable_permission_items": Categories.list(),
+    },
+    V2PermissionKey.INTERACTIONS.value: {
+        "display": "interactions",
+        "display_singular": "interaction",
+        "permission_lookup": "",
+        "all_assignable_permission_items": "",
+    },
+    V2PermissionKey.PRODUCE_FOR_AUTHORS.value: {
+        "display": "produce for authors",
+        "display_singular": "produce for author",
+        "permission_lookup": "",
+        "all_assignable_permission_items": "",
+    },
+    V2PermissionKey.PRODUCE_FOR_CUSTODIANS.value: {
+        "display": "produce for custodians",
+        "display_singular": "produce for custodian",
+        "permission_lookup": "",
+        "all_assignable_permission_items": "",
+    },
 }

--- a/scripts/manage_permissions.py
+++ b/scripts/manage_permissions.py
@@ -28,9 +28,9 @@ COMPARE_AND_CONFIRM = (
 )
 
 currently_supported_access_controls = [
-    AccessControls.ALLOW_ALL_TYPES,
-    AccessControls.ALLOW_OVERRIDE_CREATION_DATETIME,
-    AccessControls.ALLOW_SUPERSEDE_WITH_DELETE_FAILURE,
+    AccessControls.ALLOW_ALL_TYPES.value,
+    AccessControls.ALLOW_OVERRIDE_CREATION_DATETIME.value,
+    AccessControls.ALLOW_SUPERSEDE_WITH_DELETE_FAILURE.value,
 ]
 
 
@@ -126,6 +126,7 @@ def list_apps(supplier_type: SupplierType) -> None:
     print(f"There are {len(app_level_perm_files)} apps with app-level permissions:")
     for app_level in app_level_perm_files:
         print(f"- {app_level}")
+    print()
 
 
 def list_orgs(supplier_type: SupplierType, app_id: str) -> None:
@@ -151,6 +152,7 @@ def list_orgs(supplier_type: SupplierType, app_id: str) -> None:
     print(f"There are {len(orgs)} organizations for app {app_id}:")
     for org in orgs:
         print(f"- {org}")
+    print()
 
 
 def list_available_pointer_types() -> None:
@@ -161,6 +163,7 @@ def list_available_pointer_types() -> None:
 
     for pointer_type, attributes in TYPE_ATTRIBUTES.items():
         print("- %-45s (%s)" % (pointer_type, attributes["display"][:45]))
+    print()
 
 
 def list_available_access_controls() -> None:
@@ -171,6 +174,7 @@ def list_available_access_controls() -> None:
 
     for control in currently_supported_access_controls:
         print(f"- {control}")
+    print()
 
 
 def _print_perm(
@@ -279,7 +283,6 @@ def _save_pointer_types(
     app_id: str,
     org_ods,
 ) -> None:
-    print()
     _print_perm_with_lookup(
         "proposed pointer types", proposed_pointer_types, TYPE_ATTRIBUTES
     )
@@ -425,10 +428,8 @@ def add_access_control_perms(
         print(
             f"Error: Unknown or unsupported access controls provided: {', '.join(unknown_access_controls)}"
         )
-        print(
-            f"Error: Unknown or unsupported access controls provided: {', '.join(unknown_access_controls)}"
-        )
         print()
+        list_available_access_controls()
         return
 
     perms_ugly = _get_perms_from_s3(lookup_path)
@@ -454,7 +455,6 @@ def add_access_control_perms(
 
     proposed_access_controls = current_access_controls + list(access_controls_to_add)
 
-    print()
     _print_perm("proposed access controls", proposed_access_controls)
 
     if COMPARE_AND_CONFIRM:
@@ -541,9 +541,9 @@ def remove_pointer_type_perms(
         return
 
     proposed_pointer_types = [
-        current_pointer_type
-        for current_pointer_type in current_pointer_types
-        if current_pointer_type not in pointer_types_to_remove
+        pointer_type
+        for pointer_type in current_pointer_types
+        if pointer_type not in pointer_types_to_remove
     ]
     _save_pointer_types(
         lookup_path,
@@ -553,6 +553,110 @@ def remove_pointer_type_perms(
         app_id,
         org_ods,
     )
+
+
+def remove_access_control_perms(
+    supplier_type: SupplierType,
+    app_id: str,
+    org_ods=None,
+    *access_controls_to_remove: str,
+) -> None:
+    """
+    Remove access controls for a given an app or org.
+    """
+    if supplier_type.lower() not in SupplierType.list() or not app_id:
+        print("Usage: add access control permissions for a given organisation or app")
+        print(
+            "  remove_access_control_perms consumer <app_id> <org_ods> <access_controls>"
+        )
+        print(
+            "  remove_access_control_perms producer <app_id> <org_ods> <access_controls>"
+        )
+        print("  remove_access_control_perms consumer <app_id> <access_controls>")
+        print("  remove_access_control_perms producer <app_id> <access_controls>")
+        return
+
+    if not access_controls_to_remove:
+        print(
+            "No access controls provided. Please specify at least one access control or use clear_perms command."
+        )
+        return
+
+    if org_ods:
+        lookup_path = f"{supplier_type}/{app_id}/{org_ods}.json"
+    else:
+        lookup_path = f"{supplier_type}/{app_id}.json"
+
+    unknown_access_controls = [
+        pt
+        for pt in access_controls_to_remove
+        if pt not in currently_supported_access_controls
+    ]
+    if unknown_access_controls:
+        print(
+            f"Error: Unknown or unsupported access controls provided: {', '.join(unknown_access_controls)}"
+        )
+        print()
+        return
+
+    perms_ugly = _get_perms_from_s3(lookup_path)
+    if not perms_ugly:
+        print(f"Setting up new permissions file...")
+        perms_ugly = "{}"
+
+    current_perms = json.loads(perms_ugly)
+    current_access_controls: list = current_perms.get("access_controls", [])
+
+    # Cannot remove access controls not already assigned
+    access_controls_not_assigned = list(
+        access_control_to_remove
+        for access_control_to_remove in access_controls_to_remove
+        if access_control_to_remove not in current_access_controls
+    )
+    if len(access_controls_not_assigned):
+        print(
+            f"Error: Unable to remove access controls. These access controls aren't assigned to {lookup_path}:"
+        )
+        _print_perm("", access_controls_not_assigned)
+        print()
+        return
+
+    proposed_access_controls = current_access_controls + list(access_controls_to_remove)
+
+    proposed_access_controls = [
+        access_control
+        for access_control in current_access_controls
+        if access_control not in access_controls_to_remove
+    ]
+
+    _print_perm("proposed access controls", proposed_access_controls)
+
+    if COMPARE_AND_CONFIRM:
+        print()
+        confirm = (
+            input("Do you want to proceed with these changes? (yes/NO): ")
+            .strip()
+            .lower()
+        )
+        if confirm != "yes":
+            print("Operation cancelled at user request.")
+            return
+
+    current_perms["access_controls"] = proposed_access_controls
+
+    s3 = _get_s3_client()
+    s3.put_object(
+        Bucket=nrl_auth_bucket_name,
+        Key=lookup_path,
+        Body=json.dumps(current_perms, indent=4),
+        ContentType="application/json",
+    )
+
+    print()
+    print(f"Set permissions for {lookup_path}")
+
+    print()
+    show_perms(supplier_type, app_id, org_ods)
 
 
 def clear_perms(supplier_type: SupplierType, app_id: str, org_ods=None) -> None:
@@ -616,9 +720,10 @@ if __name__ == "__main__":
             "list_available_pointer_types": list_available_pointer_types,
             "list_available_access_controls": list_available_access_controls,
             "show_perms": show_perms,
-            "add_pointer_type_to_perms": add_pointer_type_perms,
-            "add_access_control_to_perms": add_access_control_perms,
+            "add_pointer_type_perms": add_pointer_type_perms,
+            "add_access_control_perms": add_access_control_perms,
             "remove_pointer_type_perms": remove_pointer_type_perms,
+            "remove_access_control_perms": remove_access_control_perms,
             "clear_perms": clear_perms,
             # "help": help,
         }

--- a/scripts/manage_permissions.py
+++ b/scripts/manage_permissions.py
@@ -92,16 +92,78 @@ def _get_perms_from_s3(file_key: str) -> str | None:
     return item["Body"].read().decode("utf-8")
 
 
+def _build_lookup_path(supplier_type: str, app_id: str, org_ods: str | None) -> str:
+    if supplier_type.lower() not in SupplierType.list():
+        print(f"Error: invalid supplier {supplier_type}")
+        return
+    if not app_id:
+        print("Error: please provide an app_id")
+        return
+
+    if org_ods:
+        return f"{supplier_type}/{app_id}/{org_ods}.json"
+    return f"{supplier_type}/{app_id}.json"
+
+
+def _load_or_setup_perms(lookup_path: str) -> dict:
+    perms_ugly = _get_perms_from_s3(lookup_path)
+    if not perms_ugly:
+        print("Setting up new permissions file...")
+        return {}
+    return json.loads(perms_ugly)
+
+
+def _confirm_proceed(
+    prompt: str = "Do you want to proceed with these changes? (yes/NO): ",
+) -> bool:
+    """
+    If COMPARE_AND_CONFIRM enabled, ask the user to confirm before writing changes.
+    """
+    if not COMPARE_AND_CONFIRM:
+        return True
+    print()
+    confirm = input(prompt).strip().lower()
+    if confirm != "yes":
+        print("Operation cancelled at user request.")
+        return False
+    return True
+
+
+def _save_updated_perms(
+    lookup_path: str,
+    updated_perms: dict,
+    supplier_type: str,
+    app_id: str,
+    org_ods: str | None,
+    success_message="Set permissions",
+) -> None:
+    """
+    Write updated permissions to S3 and display the new state.
+    """
+    s3 = _get_s3_client()
+    s3.put_object(
+        Bucket=nrl_auth_bucket_name,
+        Key=lookup_path,
+        Body=json.dumps(updated_perms, indent=4),
+        ContentType="application/json",
+    )
+    print()
+    print(f"{success_message.strip()} for {lookup_path}")
+
+    print()
+    show_perms(supplier_type, app_id, org_ods)
+
+
 def list_apps(supplier_type: SupplierType) -> None:
     """
-    List all consumer or producer applications in the NRL environment.
+    List all consumer or producer applications for a given supplier type
 
-    Apps ending in .json have app-level permissions
+    Specifies which apps have app-level or org-level permissions
+        list_apps consumer
+        list_apps producer
     """
     if supplier_type.lower() not in SupplierType.list():
-        print("Usage: list apps for a given supplier type")
-        print("  list_apps consumer")
-        print("  list_apps producer")
+        print(f"Error: invalid supplier {supplier_type}")
         return
 
     keys = _list_s3_keys(f"{supplier_type}/")
@@ -132,11 +194,12 @@ def list_apps(supplier_type: SupplierType) -> None:
 def list_orgs(supplier_type: SupplierType, app_id: str) -> None:
     """
     List all organizations for a specific consumer or producer application.
+
+        list_orgs consumer <app_id>
+        list_orgs producer <app_id>
     """
     if supplier_type.lower() not in SupplierType.list():
-        print("Usage: list organisations for a given app and supplier type")
-        print("  list_orgs consumer <app_id>")
-        print("  list_orgs producer <app_id>")
+        print(f"Error: invalid supplier {supplier_type}")
         return
 
     keys = _list_s3_keys(f"{supplier_type}/{app_id}/")
@@ -219,19 +282,15 @@ def _print_perm_with_lookup(
 def show_perms(supplier_type: SupplierType, app_id: str, org_ods=None) -> None:
     """
     Show permissions for a given application or organization.
-    """
-    if supplier_type.lower() not in SupplierType.list() or not app_id:
-        print("Usage: show permissions for a given organisation or app")
-        print("  show_perms consumer <app_id> <org_ods>")
-        print("  show_perms producer <app_id> <org_ods>")
-        print("  show_perms consumer <app_id>")
-        print("  show_perms producer <app_id>")
-        return
 
-    if org_ods:
-        lookup_path = f"{supplier_type}/{app_id}/{org_ods}.json"
-    else:
-        lookup_path = f"{supplier_type}/{app_id}.json"
+        show_perms consumer <app_id> <org_ods>
+        show_perms producer <app_id> <org_ods>
+        show_perms consumer <app_id>
+        show_perms producer <app_id>
+    """
+    lookup_path = _build_lookup_path(supplier_type, app_id, org_ods)
+    if not lookup_path:
+        return
 
     perms_ugly = _get_perms_from_s3(lookup_path)
 
@@ -275,98 +334,54 @@ def show_perms(supplier_type: SupplierType, app_id: str, org_ods=None) -> None:
     # )
 
 
-def _save_pointer_types(
-    lookup_path: str,
-    current_perms: dict,
-    proposed_pointer_types: list,
-    supplier_type: SupplierType,
-    app_id: str,
-    org_ods,
-) -> None:
-    _print_perm_with_lookup(
-        "proposed pointer types", proposed_pointer_types, TYPE_ATTRIBUTES
-    )
-
-    if COMPARE_AND_CONFIRM:
-        print()
-        confirm = (
-            input("Do you want to proceed with these changes? (yes/NO): ")
-            .strip()
-            .lower()
-        )
-        if confirm != "yes":
-            print("Operation cancelled at user request.")
-            return
-
-    current_perms["types"] = proposed_pointer_types
-
-    s3 = _get_s3_client()
-    s3.put_object(
-        Bucket=nrl_auth_bucket_name,
-        Key=lookup_path,
-        Body=json.dumps(current_perms, indent=4),
-        ContentType="application/json",
-    )
-
-    print()
-    print(f"Set permissions for {lookup_path}")
-
-    print()
-    show_perms(supplier_type, app_id, org_ods)
-
-
 def add_pointer_type_perms(
     supplier_type: SupplierType, app_id: str, org_ods=None, *pointer_types_to_add: str
 ) -> None:
     """
     Add permissions for a given list of pointer types to an app or org.
 
-    Specify pointer_types = all to add a list of all (current) pointer types.
+    Specify pointer_types=all to add all (current) pointer types.
+
+        add_pointer_type_perms consumer <app_id> <org_ods> <pointer_types>
+        add_pointer_type_perms producer <app_id> <org_ods> <pointer_types>
+        add_pointer_type_perms consumer <app_id> <pointer_types>
+        add_pointer_type_perms producer <app_id> <pointer_types>
 
     TODO:
     highlight new additions in proposed pointer types list e.g. [NEW]
     """
-    if supplier_type.lower() not in SupplierType.list() or not app_id:
-        print("Usage: add pointer type permissions for a given organisation or app")
-        print("  add_pointer_type_perms consumer <app_id> <org_ods> <pointer_types>")
-        print("  add_pointer_type_perms producer <app_id> <org_ods> <pointer_types>")
-        print("  add_pointer_type_perms consumer <app_id> <pointer_types>")
-        print("  add_pointer_type_perms producer <app_id> <pointer_types>")
+
+    lookup_path = _build_lookup_path(supplier_type, app_id, org_ods)
+    if not lookup_path:
         return
 
     if not pointer_types_to_add:
         print("No pointer types provided. Please specify at least one pointer type.")
         return
 
-    if org_ods:
-        lookup_path = f"{supplier_type}/{app_id}/{org_ods}.json"
-    else:
-        lookup_path = f"{supplier_type}/{app_id}.json"
-
     if len(pointer_types_to_add) == 1 and pointer_types_to_add[0] == "all":
         print("Setting permissions for access to all pointer types.")
         pointer_types_to_add = tuple(TYPE_ATTRIBUTES.keys())
 
-    unknown_types = [pt for pt in pointer_types_to_add if pt not in TYPE_ATTRIBUTES]
+    unknown_types = [
+        pointer_type
+        for pointer_type in pointer_types_to_add
+        if pointer_type not in TYPE_ATTRIBUTES
+    ]
     if unknown_types:
         print(f"Error: Unknown pointer types provided: {', '.join(unknown_types)}")
         print()
         return
 
-    perms_ugly = _get_perms_from_s3(lookup_path)
-    if not perms_ugly:
-        print(f"Setting up new permissions file...")
-        perms_ugly = "{}"
-
-    current_perms = json.loads(perms_ugly)
+    current_perms = _load_or_setup_perms(lookup_path)
     current_pointer_types: list = current_perms.get("types", [])
 
-    already_added_types = list(
-        new_pointer_type
-        for new_pointer_type in pointer_types_to_add
-        if new_pointer_type in current_pointer_types
-    )
-    if len(already_added_types):
+    already_added_types = [
+        pointer_type
+        for pointer_type in pointer_types_to_add
+        if pointer_type in current_pointer_types
+    ]
+    if already_added_types:
         print(
             f"Error: Unable to add pointer types. These pointer types are already assigned to {lookup_path}:"
         )
@@ -375,14 +390,15 @@ def add_pointer_type_perms(
         return
 
     proposed_pointer_types = current_pointer_types + list(pointer_types_to_add)
-    _save_pointer_types(
-        lookup_path,
-        current_perms,
-        proposed_pointer_types,
-        supplier_type,
-        app_id,
-        org_ods,
+    _print_perm_with_lookup(
+        "proposed pointer types", proposed_pointer_types, TYPE_ATTRIBUTES
     )
+
+    if not _confirm_proceed():
+        return
+
+    current_perms["types"] = proposed_pointer_types
+    _save_updated_perms(lookup_path, current_perms, supplier_type, app_id, org_ods)
 
 
 def add_access_control_perms(
@@ -391,21 +407,16 @@ def add_access_control_perms(
     """
     Add permissions for a given list of access controls to an app or org.
 
-    Specify access_controls = all to add a list of all (current) access controls.
+        add_access_control_perms consumer <app_id> <org_ods> <access_controls>
+        add_access_control_perms producer <app_id> <org_ods> <access_controls>
+        add_access_control_perms consumer <app_id> <access_controls>
+        add_access_control_perms producer <app_id> <access_controls>
 
     TODO:
     highlight new additions in proposed access controls list e.g. [NEW]
     """
-    if supplier_type.lower() not in SupplierType.list() or not app_id:
-        print("Usage: add access control permissions for a given organisation or app")
-        print(
-            "  add_access_control_perms consumer <app_id> <org_ods> <access_controls>"
-        )
-        print(
-            "  add_access_control_perms producer <app_id> <org_ods> <access_controls>"
-        )
-        print("  add_access_control_perms consumer <app_id> <access_controls>")
-        print("  add_access_control_perms producer <app_id> <access_controls>")
+    lookup_path = _build_lookup_path(supplier_type, app_id, org_ods)
+    if not lookup_path:
         return
 
     if not access_controls_to_add:
@@ -414,15 +425,10 @@ def add_access_control_perms(
         )
         return
 
-    if org_ods:
-        lookup_path = f"{supplier_type}/{app_id}/{org_ods}.json"
-    else:
-        lookup_path = f"{supplier_type}/{app_id}.json"
-
     unknown_access_controls = [
-        pt
-        for pt in access_controls_to_add
-        if pt not in currently_supported_access_controls
+        access_control
+        for access_control in access_controls_to_add
+        if access_control not in currently_supported_access_controls
     ]
     if unknown_access_controls:
         print(
@@ -432,20 +438,15 @@ def add_access_control_perms(
         list_available_access_controls()
         return
 
-    perms_ugly = _get_perms_from_s3(lookup_path)
-    if not perms_ugly:
-        print(f"Setting up new permissions file...")
-        perms_ugly = "{}"
-
-    current_perms = json.loads(perms_ugly)
+    current_perms = _load_or_setup_perms(lookup_path)
     current_access_controls: list = current_perms.get("access_controls", [])
 
-    already_added_access_controls = list(
-        new_access_control
-        for new_access_control in access_controls_to_add
-        if new_access_control in current_access_controls
-    )
-    if len(already_added_access_controls):
+    already_added_access_controls = [
+        access_control
+        for access_control in access_controls_to_add
+        if access_control in current_access_controls
+    ]
+    if already_added_access_controls:
         print(
             f"Error: Unable to add access controls. These access controls are already assigned to {lookup_path}:"
         )
@@ -454,35 +455,13 @@ def add_access_control_perms(
         return
 
     proposed_access_controls = current_access_controls + list(access_controls_to_add)
-
     _print_perm("proposed access controls", proposed_access_controls)
 
-    if COMPARE_AND_CONFIRM:
-        print()
-        confirm = (
-            input("Do you want to proceed with these changes? (yes/NO): ")
-            .strip()
-            .lower()
-        )
-        if confirm != "yes":
-            print("Operation cancelled at user request.")
-            return
+    if not _confirm_proceed():
+        return
 
     current_perms["access_controls"] = proposed_access_controls
-
-    s3 = _get_s3_client()
-    s3.put_object(
-        Bucket=nrl_auth_bucket_name,
-        Key=lookup_path,
-        Body=json.dumps(current_perms, indent=4),
-        ContentType="application/json",
-    )
-
-    print()
-    print(f"Set permissions for {lookup_path}")
-
-    print()
-    show_perms(supplier_type, app_id, org_ods)
+    _save_updated_perms(lookup_path, current_perms, supplier_type, app_id, org_ods)
 
 
 def remove_pointer_type_perms(
@@ -492,14 +471,15 @@ def remove_pointer_type_perms(
     *pointer_types_to_remove: str,
 ) -> None:
     """
-    Remove a list of pointer type permissions for a given app or org.
+    Remove pointer type permissions for a given organisation or app.
+
+        remove_pointer_type_perms consumer <app_id> <org_ods> <pointer_types>
+        remove_pointer_type_perms producer <app_id> <org_ods> <pointer_types>
+        remove_pointer_type_perms consumer <app_id> <pointer_types>
+        remove_pointer_type_perms producer <app_id> <pointer_types>
     """
-    if supplier_type.lower() not in SupplierType.list() or not app_id:
-        print("Usage: remove pointer type permissions for a given organisation or app")
-        print("  remove_pointer_type_perms consumer <app_id> <org_ods> <pointer_types>")
-        print("  remove_pointer_type_perms producer <app_id> <org_ods> <pointer_types>")
-        print("  remove_pointer_type_perms consumer <app_id> <pointer_types>")
-        print("  remove_pointer_type_perms producer <app_id> <pointer_types>")
+    lookup_path = _build_lookup_path(supplier_type, app_id, org_ods)
+    if not lookup_path:
         return
 
     if not pointer_types_to_remove:
@@ -508,12 +488,11 @@ def remove_pointer_type_perms(
         )
         return
 
-    if org_ods:
-        lookup_path = f"{supplier_type}/{app_id}/{org_ods}.json"
-    else:
-        lookup_path = f"{supplier_type}/{app_id}.json"
-
-    unknown_types = [pt for pt in pointer_types_to_remove if pt not in TYPE_ATTRIBUTES]
+    unknown_types = [
+        pointer_type
+        for pointer_type in pointer_types_to_remove
+        if pointer_type not in TYPE_ATTRIBUTES
+    ]
     if unknown_types:
         print(f"Error: Unknown pointer types provided: {', '.join(unknown_types)}")
         print()
@@ -526,13 +505,13 @@ def remove_pointer_type_perms(
     current_perms = json.loads(perms_ugly)
     current_pointer_types: list = current_perms.get("types", [])
 
-    # Cannot remove pointer types not already assigned
-    types_not_assigned = list(
-        type_to_remove
-        for type_to_remove in pointer_types_to_remove
-        if type_to_remove not in current_pointer_types
-    )
-    if len(types_not_assigned):
+    # Cannot remove pointer types that aren't already assigned
+    types_not_assigned = [
+        pointer_type
+        for pointer_type in pointer_types_to_remove
+        if pointer_type not in current_pointer_types
+    ]
+    if types_not_assigned:
         print(
             f"Error: Unable to remove pointer types. These pointer types aren't assigned to {lookup_path}:"
         )
@@ -545,14 +524,15 @@ def remove_pointer_type_perms(
         for pointer_type in current_pointer_types
         if pointer_type not in pointer_types_to_remove
     ]
-    _save_pointer_types(
-        lookup_path,
-        current_perms,
-        proposed_pointer_types,
-        supplier_type,
-        app_id,
-        org_ods,
+    _print_perm_with_lookup(
+        "proposed pointer types", proposed_pointer_types, TYPE_ATTRIBUTES
     )
+
+    if not _confirm_proceed():
+        return
+
+    current_perms["types"] = proposed_pointer_types
+    _save_updated_perms(lookup_path, current_perms, supplier_type, app_id, org_ods)
 
 
 def remove_access_control_perms(
@@ -563,17 +543,14 @@ def remove_access_control_perms(
 ) -> None:
     """
     Remove access controls for a given an app or org.
+
+        remove_access_control_perms consumer <app_id> <org_ods> <access_controls>
+        remove_access_control_perms producer <app_id> <org_ods> <access_controls>
+        remove_access_control_perms consumer <app_id> <access_controls>
+        remove_access_control_perms producer <app_id> <access_controls>
     """
-    if supplier_type.lower() not in SupplierType.list() or not app_id:
-        print("Usage: add access control permissions for a given organisation or app")
-        print(
-            "  remove_access_control_perms consumer <app_id> <org_ods> <access_controls>"
-        )
-        print(
-            "  remove_access_control_perms producer <app_id> <org_ods> <access_controls>"
-        )
-        print("  remove_access_control_perms consumer <app_id> <access_controls>")
-        print("  remove_access_control_perms producer <app_id> <access_controls>")
+    lookup_path = _build_lookup_path(supplier_type, app_id, org_ods)
+    if not lookup_path:
         return
 
     if not access_controls_to_remove:
@@ -582,15 +559,10 @@ def remove_access_control_perms(
         )
         return
 
-    if org_ods:
-        lookup_path = f"{supplier_type}/{app_id}/{org_ods}.json"
-    else:
-        lookup_path = f"{supplier_type}/{app_id}.json"
-
     unknown_access_controls = [
-        pt
-        for pt in access_controls_to_remove
-        if pt not in currently_supported_access_controls
+        access_control
+        for access_control in access_controls_to_remove
+        if access_control not in currently_supported_access_controls
     ]
     if unknown_access_controls:
         print(
@@ -601,19 +573,18 @@ def remove_access_control_perms(
 
     perms_ugly = _get_perms_from_s3(lookup_path)
     if not perms_ugly:
-        print(f"Setting up new permissions file...")
-        perms_ugly = "{}"
+        return
 
     current_perms = json.loads(perms_ugly)
     current_access_controls: list = current_perms.get("access_controls", [])
 
-    # Cannot remove access controls not already assigned
-    access_controls_not_assigned = list(
-        access_control_to_remove
-        for access_control_to_remove in access_controls_to_remove
-        if access_control_to_remove not in current_access_controls
-    )
-    if len(access_controls_not_assigned):
+    # Cannot remove access controls that aren't already assigned
+    access_controls_not_assigned = [
+        access_control
+        for access_control in access_controls_to_remove
+        if access_control not in current_access_controls
+    ]
+    if access_controls_not_assigned:
         print(
             f"Error: Unable to remove access controls. These access controls aren't assigned to {lookup_path}:"
         )
@@ -621,95 +592,61 @@ def remove_access_control_perms(
         print()
         return
 
-    proposed_access_controls = current_access_controls + list(access_controls_to_remove)
-
     proposed_access_controls = [
         access_control
         for access_control in current_access_controls
         if access_control not in access_controls_to_remove
     ]
-
     _print_perm("proposed access controls", proposed_access_controls)
 
-    if COMPARE_AND_CONFIRM:
-        print()
-        confirm = (
-            input("Do you want to proceed with these changes? (yes/NO): ")
-            .strip()
-            .lower()
-        )
-        if confirm != "yes":
-            print("Operation cancelled at user request.")
-            return
+    if not _confirm_proceed():
+        return
 
     current_perms["access_controls"] = proposed_access_controls
-
-    s3 = _get_s3_client()
-    s3.put_object(
-        Bucket=nrl_auth_bucket_name,
-        Key=lookup_path,
-        Body=json.dumps(current_perms, indent=4),
-        ContentType="application/json",
-    )
-
-    print()
-    print(f"Set permissions for {lookup_path}")
-
-    print()
-    show_perms(supplier_type, app_id, org_ods)
+    _save_updated_perms(lookup_path, current_perms, supplier_type, app_id, org_ods)
 
 
 def clear_perms(supplier_type: SupplierType, app_id: str, org_ods=None) -> None:
     """
     Clear permissions for an application or organization.
-    This will remove all permissions for the specified app and org.
 
-    COMPARE_AND_CONFIRM=true \
-    poetry run python ./scripts/manage_permissions.py clear_perms consumer ANJALI_POSTMAN_APP TEST4
+    This will remove ALL permissions for the specified app or org.
+
+        clear_perms consumer <app_id> <org_ods>
+        clear_perms producer <app_id> <org_ods>
+        clear_perms consumer <app_id>
+        clear_perms producer <app_id>
     """
-    if supplier_type.lower() not in SupplierType.list() or not app_id:
-        print("Usage: clear permissions for a given organisation or app")
-        print("  clear_perms consumer <app_id> <org_ods>")
-        print("  clear_perms producer <app_id> <org_ods>")
-        print("  clear_perms consumer <app_id>")
-        print("  clear_perms producer <app_id>")
+
+    lookup_path = _build_lookup_path(supplier_type, app_id, org_ods)
+    if not lookup_path:
         return
 
-    if org_ods:
-        lookup_path = f"{supplier_type}/{app_id}/{org_ods}.json"
-    else:
-        lookup_path = f"{supplier_type}/{app_id}.json"
+    current_perms = _get_perms_from_s3(lookup_path)
+    if not current_perms or current_perms == "{}":
+        print(
+            f"No need to clear permissions for {lookup_path} as it currently has no permissions set."
+        )
+        return
 
     if COMPARE_AND_CONFIRM:
-        current_perms = _get_perms_from_s3(lookup_path)
-        if not current_perms or current_perms == "{}":
-            print(
-                f"No need to clear permissions for {lookup_path} as it currently has no permissions set."
-            )
-            return
-
         print()
         print(f"Current permissions for {lookup_path}:")
         print(current_perms)
 
-        print()
-        confirm = (
-            input("Are you SURE you want to clear these permissions? (yes/NO): ")
-            .strip()
-            .lower()
-        )
-        if confirm != "yes":
-            print("Operation cancelled at user request.")
+        if not _confirm_proceed(
+            "Are you SURE you want to clear these permissions? (yes/NO): "
+        ):
             return
 
-    s3 = _get_s3_client()
-    s3.put_object(
-        Bucket=nrl_auth_bucket_name,
-        Key=lookup_path,
-        Body="{}",
-        ContentType="application/json",
+    _save_updated_perms(
+        lookup_path,
+        {},
+        supplier_type,
+        app_id,
+        org_ods,
+        success_message="Cleared permissions",
     )
-    print(f"Cleared permissions for {lookup_path}.")
 
 
 if __name__ == "__main__":
@@ -725,6 +662,5 @@ if __name__ == "__main__":
             "remove_pointer_type_perms": remove_pointer_type_perms,
             "remove_access_control_perms": remove_access_control_perms,
             "clear_perms": clear_perms,
-            # "help": help,
         }
     )

--- a/scripts/manage_permissions.py
+++ b/scripts/manage_permissions.py
@@ -15,7 +15,15 @@ from enum import Enum
 import fire
 from aws_session_assume import get_boto_session
 
-from nrlf.core.constants import CATEGORY_ATTRIBUTES, TYPE_ATTRIBUTES, AccessControls
+from nrlf.core.constants import (
+    CATEGORY_ATTRIBUTES,
+    TYPE_ATTRIBUTES,
+    AccessControls,
+    Categories,
+    PointerTypes,
+    SupplierType,
+    V2PermissionKey,
+)
 
 nrl_env = os.getenv("ENV", "dev")
 nrl_auth_bucket_name = os.getenv(
@@ -26,6 +34,12 @@ COMPARE_AND_CONFIRM = (
     if nrl_env == "prod"
     else os.getenv("COMPARE_AND_CONFIRM", "false").lower() == "true"
 )
+
+currently_supported_permission_keys = [
+    V2PermissionKey.TYPES.value,
+    V2PermissionKey.ACCESS_CONTROLS.value,
+    # V2PermissionKey.CATEGORIES.value,
+]
 
 currently_supported_access_controls = [
     AccessControls.ALLOW_ALL_TYPES.value,
@@ -38,15 +52,6 @@ print(f"Using NRL environment: {nrl_env}")
 print(f"Using NRL auth bucket: {nrl_auth_bucket_name}")
 print(f"Compare and confirm mode: {COMPARE_AND_CONFIRM}")
 print()
-
-
-class SupplierType(Enum):
-    PRODUCER = "producer"
-    CONSUMER = "consumer"
-
-    @staticmethod
-    def list():
-        return [supplier.value for supplier in SupplierType]
 
 
 def _get_s3_client():
@@ -266,6 +271,10 @@ def _print_perm_with_lookup(
     """
     Lookup human-readable names for a permission and print
     """
+    if not attribute_lookup:
+        _print_perm(perm_pretty_name, perm_to_print)
+        return
+
     printable = []
     for perm_item in perm_to_print:
         display_name = attribute_lookup.get(
@@ -334,167 +343,184 @@ def show_perms(supplier_type: SupplierType, app_id: str, org_ods=None) -> None:
     # )
 
 
-def add_pointer_type_perms(
-    supplier_type: SupplierType, app_id: str, org_ods=None, *pointer_types_to_add: str
+def _add_perm(
+    permission_key: V2PermissionKey,
+    all_assignable_permission_items: dict,
+    permission_lookup: dict[str, dict[str, str]],
+    supplier_type: SupplierType,
+    app_id: str,
+    org_ods=None,
+    *permission_items_to_add: str,
 ) -> None:
     """
-    Add permissions for a given list of pointer types to an app or org.
-
-    Specify pointer_types=all to add all (current) pointer types.
-
-        add_pointer_type_perms consumer <app_id> <org_ods> <pointer_types>
-        add_pointer_type_perms producer <app_id> <org_ods> <pointer_types>
-        add_pointer_type_perms consumer <app_id> <pointer_types>
-        add_pointer_type_perms producer <app_id> <pointer_types>
+    Add one type of permission to an app or org.
 
     TODO:
     highlight new additions in proposed pointer types list e.g. [NEW]
     """
+    if permission_key.value not in currently_supported_permission_keys:
+        print(f"Error: invalid permission being set: {permission_key}")
+        print(f"Supported permission keys: {currently_supported_permission_keys}")
+        return
 
     lookup_path = _build_lookup_path(supplier_type, app_id, org_ods)
     if not lookup_path:
         return
 
-    if not pointer_types_to_add:
-        print("No pointer types provided. Please specify at least one pointer type.")
+    permission_name_plural = permission_key.human_readable(plural=True)
+    permission_name_singular = permission_key.human_readable()
+
+    if not permission_items_to_add:
+        print(
+            f"No {permission_name_plural} provided. Please specify at least one {permission_name_singular}."
+        )
         return
 
-    if len(pointer_types_to_add) == 1 and pointer_types_to_add[0] == "all":
-        print("Setting permissions for access to all pointer types.")
-        pointer_types_to_add = tuple(TYPE_ATTRIBUTES.keys())
+    if len(permission_items_to_add) == 1 and permission_items_to_add[0] == "all":
+        print(f"Setting permissions for access to all {permission_name_plural}.")
+        permission_items_to_add = all_assignable_permission_items
 
-    unknown_types = [
-        pointer_type
-        for pointer_type in pointer_types_to_add
-        if pointer_type not in TYPE_ATTRIBUTES
+    unknown_items = [
+        item
+        for item in permission_items_to_add
+        if item not in all_assignable_permission_items
     ]
-    if unknown_types:
-        print(f"Error: Unknown pointer types provided: {', '.join(unknown_types)}")
+    if unknown_items:
+        print(
+            f"Error: Unknown {permission_name_plural} provided: {', '.join(unknown_items)}"
+        )
         print()
         return
 
     current_perms = _load_or_setup_perms(lookup_path)
-    current_pointer_types: list = current_perms.get("types", [])
+    current_permission_items: list = current_perms.get(permission_key.value, [])
 
-    already_added_types = [
-        pointer_type
-        for pointer_type in pointer_types_to_add
-        if pointer_type in current_pointer_types
+    already_added_items = [
+        item for item in permission_items_to_add if item in current_permission_items
     ]
-    if already_added_types:
+    if already_added_items:
         print(
-            f"Error: Unable to add pointer types. These pointer types are already assigned to {lookup_path}:"
+            f"Error: Unable to add {permission_name_plural}. These {permission_name_plural} are already assigned to {lookup_path}:"
         )
-        _print_perm_with_lookup("", already_added_types, TYPE_ATTRIBUTES)
+        _print_perm_with_lookup("", already_added_items, permission_lookup)
         print()
         return
 
-    proposed_pointer_types = current_pointer_types + list(pointer_types_to_add)
+    proposed_permission_items = current_permission_items + list(permission_items_to_add)
     _print_perm_with_lookup(
-        "proposed pointer types", proposed_pointer_types, TYPE_ATTRIBUTES
+        f"proposed {permission_name_plural}",
+        proposed_permission_items,
+        permission_lookup,
     )
 
     if not _confirm_proceed():
         return
 
-    current_perms["types"] = proposed_pointer_types
+    current_perms[permission_key.value] = proposed_permission_items
     _save_updated_perms(lookup_path, current_perms, supplier_type, app_id, org_ods)
 
 
-def add_access_control_perms(
-    supplier_type: SupplierType, app_id: str, org_ods=None, *access_controls_to_add: str
+def add_permission(
+    perm_key: str,
+    supplier_type: SupplierType,
+    app_id: str,
+    org_ods=None,
+    *items_to_add: str,
+):
+    """
+    Add items to any permission for a given app or org.
+        add_permission <permission_key> <supplier_type> <app_id> <permission_items>
+
+    Add pointer types to a consumer org:
+        add_permission types consumer <app_id> <org_ods> http://snomed.info/sct\|736253002 http://snomed.info/sct\|887701000000100
+
+    Add all current pointer types to a producer org:
+        add_permission types producer <app_id> <org_ods> all
+
+    Add access controls to a producer app:
+        add_permission access_controls producer <app_id> allow_all_types allow_supersede_with_delete_failure
+    """
+    match perm_key:
+        case V2PermissionKey.ACCESS_CONTROLS.value:
+            return _add_perm(
+                V2PermissionKey.ACCESS_CONTROLS,
+                AccessControls.list(),
+                None,
+                supplier_type,
+                app_id,
+                org_ods,
+                *items_to_add,
+            )
+
+        case V2PermissionKey.TYPES.value:
+            _add_perm(
+                V2PermissionKey.TYPES,
+                PointerTypes.list(),
+                TYPE_ATTRIBUTES,
+                supplier_type,
+                app_id,
+                org_ods,
+                *items_to_add,
+            )
+
+        # case V2PermissionKey.CATEGORIES.value:
+        #     _add_perm(
+        #         V2PermissionKey.CATEGORIES,
+        #         Categories.list(),
+        #         CATEGORY_ATTRIBUTES,
+        #         supplier_type,
+        #         app_id,
+        #         org_ods,
+        #         *items_to_add,
+        #     )
+
+        case _:
+            print(f"Unrecognised or unsupported permission key: {perm_key}")
+            print(f"Must be one of: {", ".join(V2PermissionKey.list())}")
+
+
+def _remove_perm(
+    permission_key: V2PermissionKey,
+    all_assignable_permission_items: dict,
+    permission_lookup: dict[str, dict[str, str]],
+    supplier_type: SupplierType,
+    app_id: str,
+    org_ods=None,
+    *permission_items_to_remove: str,
 ) -> None:
     """
-    Add permissions for a given list of access controls to an app or org.
-
-        add_access_control_perms consumer <app_id> <org_ods> <access_controls>
-        add_access_control_perms producer <app_id> <org_ods> <access_controls>
-        add_access_control_perms consumer <app_id> <access_controls>
-        add_access_control_perms producer <app_id> <access_controls>
+    Remove one type of permission to an app or org.
 
     TODO:
-    highlight new additions in proposed access controls list e.g. [NEW]
+    highlight new additions in proposed pointer types list e.g. [NEW]
     """
+    if permission_key.value not in currently_supported_permission_keys:
+        print(f"Error: invalid permission being set: {permission_key}")
+        print(f"Supported permission keys: {currently_supported_permission_keys}")
+        return
+
     lookup_path = _build_lookup_path(supplier_type, app_id, org_ods)
     if not lookup_path:
         return
 
-    if not access_controls_to_add:
+    permission_name_plural = permission_key.human_readable(plural=True)
+    permission_name_singular = permission_key.human_readable()
+
+    if not permission_items_to_remove:
         print(
-            "No access controls provided. Please specify at least one access control."
+            f"No {permission_name_plural} provided. Please specify at least one {permission_name_singular}."
         )
         return
 
-    unknown_access_controls = [
-        access_control
-        for access_control in access_controls_to_add
-        if access_control not in currently_supported_access_controls
+    unknown_items = [
+        item
+        for item in permission_items_to_remove
+        if item not in all_assignable_permission_items
     ]
-    if unknown_access_controls:
+    if unknown_items:
         print(
-            f"Error: Unknown or unsupported access controls provided: {', '.join(unknown_access_controls)}"
+            f"Error: Unknown {permission_name_plural} provided: {', '.join(unknown_items)}"
         )
-        print()
-        list_available_access_controls()
-        return
-
-    current_perms = _load_or_setup_perms(lookup_path)
-    current_access_controls: list = current_perms.get("access_controls", [])
-
-    already_added_access_controls = [
-        access_control
-        for access_control in access_controls_to_add
-        if access_control in current_access_controls
-    ]
-    if already_added_access_controls:
-        print(
-            f"Error: Unable to add access controls. These access controls are already assigned to {lookup_path}:"
-        )
-        _print_perm("", already_added_access_controls)
-        print()
-        return
-
-    proposed_access_controls = current_access_controls + list(access_controls_to_add)
-    _print_perm("proposed access controls", proposed_access_controls)
-
-    if not _confirm_proceed():
-        return
-
-    current_perms["access_controls"] = proposed_access_controls
-    _save_updated_perms(lookup_path, current_perms, supplier_type, app_id, org_ods)
-
-
-def remove_pointer_type_perms(
-    supplier_type: SupplierType,
-    app_id: str,
-    org_ods=None,
-    *pointer_types_to_remove: str,
-) -> None:
-    """
-    Remove pointer type permissions for a given organisation or app.
-
-        remove_pointer_type_perms consumer <app_id> <org_ods> <pointer_types>
-        remove_pointer_type_perms producer <app_id> <org_ods> <pointer_types>
-        remove_pointer_type_perms consumer <app_id> <pointer_types>
-        remove_pointer_type_perms producer <app_id> <pointer_types>
-    """
-    lookup_path = _build_lookup_path(supplier_type, app_id, org_ods)
-    if not lookup_path:
-        return
-
-    if not pointer_types_to_remove:
-        print(
-            "No pointer types provided. Please specify at least one pointer type or use clear_perms command."
-        )
-        return
-
-    unknown_types = [
-        pointer_type
-        for pointer_type in pointer_types_to_remove
-        if pointer_type not in TYPE_ATTRIBUTES
-    ]
-    if unknown_types:
-        print(f"Error: Unknown pointer types provided: {', '.join(unknown_types)}")
         print()
         return
 
@@ -503,107 +529,94 @@ def remove_pointer_type_perms(
         return
 
     current_perms = json.loads(perms_ugly)
-    current_pointer_types: list = current_perms.get("types", [])
+    current_permission_items: list = current_perms.get(permission_key.value, [])
 
-    # Cannot remove pointer types that aren't already assigned
-    types_not_assigned = [
-        pointer_type
-        for pointer_type in pointer_types_to_remove
-        if pointer_type not in current_pointer_types
+    # Cannot remove permission items that aren't already assigned
+    items_not_assigned = [
+        item
+        for item in permission_items_to_remove
+        if item not in current_permission_items
     ]
-    if types_not_assigned:
+    if items_not_assigned:
         print(
-            f"Error: Unable to remove pointer types. These pointer types aren't assigned to {lookup_path}:"
+            f"Error: Unable to remove {permission_name_plural}. These {permission_name_plural} aren't assigned to {lookup_path}:"
         )
-        _print_perm_with_lookup("", types_not_assigned, TYPE_ATTRIBUTES)
+        _print_perm("", items_not_assigned)
         print()
         return
 
-    proposed_pointer_types = [
-        pointer_type
-        for pointer_type in current_pointer_types
-        if pointer_type not in pointer_types_to_remove
+    proposed_permission_items = [
+        item
+        for item in current_permission_items
+        if item not in permission_items_to_remove
     ]
     _print_perm_with_lookup(
-        "proposed pointer types", proposed_pointer_types, TYPE_ATTRIBUTES
+        f"proposed {permission_name_plural}",
+        proposed_permission_items,
+        permission_lookup,
     )
 
     if not _confirm_proceed():
         return
 
-    current_perms["types"] = proposed_pointer_types
+    current_perms[permission_key.value] = proposed_permission_items
     _save_updated_perms(lookup_path, current_perms, supplier_type, app_id, org_ods)
 
 
-def remove_access_control_perms(
+def remove_permission(
+    perm_key: str,
     supplier_type: SupplierType,
     app_id: str,
     org_ods=None,
-    *access_controls_to_remove: str,
-) -> None:
+    *items_to_remove: str,
+):
     """
-    Remove access controls for a given an app or org.
+    Remove items from any permission for a given app or org.
+        remove_permission <permission_key> <supplier_type> <app_id> <permission_items>
 
-        remove_access_control_perms consumer <app_id> <org_ods> <access_controls>
-        remove_access_control_perms producer <app_id> <org_ods> <access_controls>
-        remove_access_control_perms consumer <app_id> <access_controls>
-        remove_access_control_perms producer <app_id> <access_controls>
+    Remove pointer types from a consumer org:
+        remove_permission types consumer <app_id> <org_ods> http://snomed.info/sct\|736253002 http://snomed.info/sct\|887701000000100
+
+    Remove access controls from a producer app:
+        remove_permission access_controls producer <app_id> allow_all_types allow_supersede_with_delete_failure
     """
-    lookup_path = _build_lookup_path(supplier_type, app_id, org_ods)
-    if not lookup_path:
-        return
+    match perm_key:
+        case V2PermissionKey.ACCESS_CONTROLS.value:
+            return _remove_perm(
+                V2PermissionKey.ACCESS_CONTROLS,
+                AccessControls.list(),
+                None,
+                supplier_type,
+                app_id,
+                org_ods,
+                *items_to_remove,
+            )
 
-    if not access_controls_to_remove:
-        print(
-            "No access controls provided. Please specify at least one access control or use clear_perms command."
-        )
-        return
+        case V2PermissionKey.TYPES.value:
+            _remove_perm(
+                V2PermissionKey.TYPES,
+                PointerTypes.list(),
+                TYPE_ATTRIBUTES,
+                supplier_type,
+                app_id,
+                org_ods,
+                *items_to_remove,
+            )
 
-    unknown_access_controls = [
-        access_control
-        for access_control in access_controls_to_remove
-        if access_control not in currently_supported_access_controls
-    ]
-    if unknown_access_controls:
-        print(
-            f"Error: Unknown or unsupported access controls provided: {', '.join(unknown_access_controls)}"
-        )
-        print()
-        return
+        # case V2PermissionKey.CATEGORIES.value:
+        #     _remove_perm(
+        #         V2PermissionKey.CATEGORIES,
+        #         Categories.list(),
+        #         CATEGORY_ATTRIBUTES,
+        #         supplier_type,
+        #         app_id,
+        #         org_ods,
+        #         *items_to_remove,
+        #     )
 
-    perms_ugly = _get_perms_from_s3(lookup_path)
-    if not perms_ugly:
-        return
-
-    current_perms = json.loads(perms_ugly)
-    current_access_controls: list = current_perms.get("access_controls", [])
-
-    # Cannot remove access controls that aren't already assigned
-    access_controls_not_assigned = [
-        access_control
-        for access_control in access_controls_to_remove
-        if access_control not in current_access_controls
-    ]
-    if access_controls_not_assigned:
-        print(
-            f"Error: Unable to remove access controls. These access controls aren't assigned to {lookup_path}:"
-        )
-        _print_perm("", access_controls_not_assigned)
-        print()
-        return
-
-    proposed_access_controls = [
-        access_control
-        for access_control in current_access_controls
-        if access_control not in access_controls_to_remove
-    ]
-    _print_perm("proposed access controls", proposed_access_controls)
-
-    if not _confirm_proceed():
-        return
-
-    current_perms["access_controls"] = proposed_access_controls
-    _save_updated_perms(lookup_path, current_perms, supplier_type, app_id, org_ods)
+        case _:
+            print(f"Unrecognised or unsupported permission key: {perm_key}")
+            print(f"Supported permission keys: {currently_supported_permission_keys}")
 
 
 def clear_perms(supplier_type: SupplierType, app_id: str, org_ods=None) -> None:
@@ -657,10 +670,8 @@ if __name__ == "__main__":
             "list_available_pointer_types": list_available_pointer_types,
             "list_available_access_controls": list_available_access_controls,
             "show_perms": show_perms,
-            "add_pointer_type_perms": add_pointer_type_perms,
-            "add_access_control_perms": add_access_control_perms,
-            "remove_pointer_type_perms": remove_pointer_type_perms,
-            "remove_access_control_perms": remove_access_control_perms,
+            "add_permission": add_permission,
+            "remove_permission": remove_permission,
             "clear_perms": clear_perms,
         }
     )

--- a/scripts/manage_permissions.py
+++ b/scripts/manage_permissions.py
@@ -1,15 +1,12 @@
 #!/usr/bin/env python
 """
-Manage organisation pointer type permissions for NRLF apps in a given environment ENV
+Manage app ans organisation v2 permissions for NRLF apps in a given environment ENV
 """
-
-import json
 import os
+from enum import Enum
 
 import fire
 from aws_session_assume import get_boto_session
-
-from nrlf.core.constants import TYPE_ATTRIBUTES
 
 nrl_env = os.getenv("ENV", "dev")
 nrl_auth_bucket_name = os.getenv(
@@ -26,6 +23,15 @@ print(f"Using NRL environment: {nrl_env}")
 print(f"Using NRL auth bucket: {nrl_auth_bucket_name}")
 print(f"Compare and confirm mode: {COMPARE_AND_CONFIRM}")
 print()
+
+
+class SupplierType(Enum):
+    PRODUCER = "producer"
+    CONSUMER = "consumer"
+
+    @staticmethod
+    def list():
+        return [supplier.value for supplier in SupplierType]
 
 
 def _get_s3_client():
@@ -55,206 +61,48 @@ def _list_s3_keys(file_key_prefix: str) -> list[str]:
     return keys
 
 
-def _get_perms_from_s3(file_key: str) -> str | None:
-    s3 = _get_s3_client()
-
-    try:
-        item = s3.get_object(Bucket=nrl_auth_bucket_name, Key=file_key)
-    except s3.exceptions.NoSuchKey:
-        print(f"Permissions file {file_key} does not exist in the bucket.")
-        return None
-
-    if "Body" not in item:
-        print(f"No body found for permissions file {file_key}.")
-        return None
-
-    return item["Body"].read().decode("utf-8")
-
-
-def list_apps() -> None:
+def list_apps(supplier_type: SupplierType) -> None:
     """
-    List all applications in the NRL environment.
+    List all consumer or producer applications in the NRL environment.
+
+    Apps ending in .json have app-level permissions
     """
-    keys = _list_s3_keys("")
-    apps = {key.split("/")[0] for key in keys}
+    if supplier_type.lower() not in SupplierType.list():
+        print("Usage: list apps for a given supplier type")
+        print("  list_apps consumer")
+        print("  list_apps producer")
+        return
+
+    keys = _list_s3_keys(f"{supplier_type}/")
+    apps = {key.split("/")[1] for key in keys[1:]}
+    app_level_perm_files = {key for key in apps if key and key.endswith(".json")}
+    apps_with_orgs = {key for key in apps if key and not key.endswith(".json")}
 
     if not apps:
         print("No applications found in the bucket.")
         return
 
-    print(f"There are {len(apps)} apps in {nrl_env} env:")
-    for app in apps:
-        print(f"- {app}")
-
-
-def list_orgs(app_id: str) -> None:
-    """
-    List all organizations for a specific application.
-    """
-    keys = _list_s3_keys(f"{app_id}/")
-    orgs = [
-        key.split("/", maxsplit=2)[1].removesuffix(".json")
-        for key in keys
-        if key and key.endswith(".json")
-    ]
-
-    if not orgs:
-        print(f"No organizations found for app {app_id}.")
-
-    print(f"There are {len(orgs)} organizations for app {app_id}:")
-    for org in orgs:
-        print(f"- {org}")
-
-
-def list_allowed_types() -> None:
-    """
-    List all pointer types that can be used in permissions.
-    """
-    print("The following pointer-types are allowed:")
-
-    for pointer_type, attributes in TYPE_ATTRIBUTES.items():
-        print("- %-45s (%s)" % (pointer_type, attributes["display"][:45]))
-
-
-def show_perms(app_id: str, org_ods: str) -> None:
-    """
-    Show the permissions for a specific application and organization.
-    """
-    perms = _get_perms_from_s3(f"{app_id}/{org_ods}.json")
-
-    if not perms:
-        print(f"No permissions file found for {app_id}/{org_ods}.")
-        return
-
-    pointertype_perms = json.loads(perms)
-    if not pointertype_perms:
-        print(f"No pointer-types found in permission file for {app_id}/{org_ods}.")
-        return
-
-    type_data = {
-        pointertype_perm: TYPE_ATTRIBUTES.get(
-            pointertype_perm, {"display": "Unknown type"}
-        )
-        for pointertype_perm in pointertype_perms
-    }
-    types = [
-        "%-45s (%s)" % (type_data[pointertype_perm]["display"][:44], pointertype_perm)
-        for pointertype_perm in pointertype_perms
-    ]
-
-    print(f"{app_id}/{org_ods} is allowed to access these pointer-types:")
-    for type_display in types:
-        print(f"- {type_display}")
-
-
-def set_perms(app_id: str, org_ods: str, *pointer_types: str) -> None:
-    """
-    Set permissions for an application and organization to access specific pointer types.
-    """
-    if not pointer_types:
-        print(
-            "No pointer types provided. Please specify at least one pointer type or use clear_perms command."
-        )
-        return
-
-    if len(pointer_types) == 1 and pointer_types[0] == "all":
-        print("Setting permissions for access to all pointer types.")
-        pointer_types = tuple(TYPE_ATTRIBUTES.keys())
-
-    unknown_types = [pt for pt in pointer_types if pt not in TYPE_ATTRIBUTES]
-    if unknown_types:
-        print(f"Error: Unknown pointer types provided: {', '.join(unknown_types)}")
-        print()
-        return
-
-    permissions_content = json.dumps(pointer_types, indent=4)
-
-    if COMPARE_AND_CONFIRM:
-        current_perms = _get_perms_from_s3(f"{app_id}/{org_ods}.json")
-        if current_perms == permissions_content:
-            print(
-                f"No changes needed for {app_id}/{org_ods}. Current permissions match the new ones."
-            )
-            return
-
-        print()
-        print(f"Current permissions for {app_id}/{org_ods}:")
-        print(current_perms if current_perms else "No permissions set.")
-
-        print()
-        print("New permissions to be set to:")
-        print(f"{permissions_content}")
-
-        print()
-        confirm = (
-            input("Do you want to proceed with these changes? (yes/NO): ")
-            .strip()
-            .lower()
-        )
-        if confirm != "yes":
-            print("Operation cancelled at user request.")
-            return
-
-    s3 = _get_s3_client()
-    s3.put_object(
-        Bucket=nrl_auth_bucket_name,
-        Key=f"{app_id}/{org_ods}.json",
-        Body=permissions_content,
-        ContentType="application/json",
-    )
+    print(f"There are {len(apps)} apps in {nrl_env} env")
 
     print()
-    print(f"Set permissions for {app_id}/{org_ods}")
+    print(f"There are {len(apps_with_orgs)} apps containing org-level permissions:")
+    for app_with_orgs in apps_with_orgs:
+        print(f"- {app_with_orgs}")
 
     print()
-    show_perms(app_id, org_ods)
-
-
-def clear_perms(app_id: str, org_ods: str) -> None:
-    """
-    Clear permissions for an application and organization.
-    This will remove all permissions for the specified app and org.
-    """
-    if COMPARE_AND_CONFIRM:
-        current_perms = _get_perms_from_s3(f"{app_id}/{org_ods}.json")
-        if not current_perms or current_perms == "[]":
-            print(
-                f"No need to clear permissions for {app_id}/{org_ods} as it currently has no permissions set."
-            )
-            return
-
-        print()
-        print(f"Current permissions for {app_id}/{org_ods}:")
-        print(current_perms)
-
-        print()
-        confirm = (
-            input("Are you SURE you want to clear these permissions? (yes/NO): ")
-            .strip()
-            .lower()
-        )
-        if confirm != "yes":
-            print("Operation cancelled at user request.")
-            return
-
-    s3 = _get_s3_client()
-    s3.put_object(
-        Bucket=nrl_auth_bucket_name,
-        Key=f"{app_id}/{org_ods}.json",
-        Body="[]",
-        ContentType="application/json",
-    )
-    print(f"Cleared permissions for {app_id}/{org_ods}.")
+    print(f"There are {len(app_level_perm_files)} apps with app-level permissions:")
+    for app_level in app_level_perm_files:
+        print(f"- {app_level}")
 
 
 if __name__ == "__main__":
     fire.Fire(
         {
             "list_apps": list_apps,
-            "list_orgs": list_orgs,
-            "list_allowed_types": list_allowed_types,
-            "show_perms": show_perms,
-            "set_perms": set_perms,
-            "clear_perms": clear_perms,
+            # "list_orgs": list_orgs,
+            # "list_allowed_types": list_allowed_types,
+            # "show_perms": show_perms,
+            # "set_perms": set_perms,
+            # "clear_perms": clear_perms,
         }
     )

--- a/scripts/manage_permissions.py
+++ b/scripts/manage_permissions.py
@@ -58,9 +58,9 @@ currently_supported_access_controls = [
 ]
 
 
-print(f"Using NRL environment: {nrl_env}")
-print(f"Using NRL auth bucket: {nrl_auth_bucket_name}")
-print(f"Compare and confirm mode: {COMPARE_AND_CONFIRM}")
+print(f"📚 Using NRL environment: {nrl_env}")
+print(f"🪣  Using NRL auth bucket: {nrl_auth_bucket_name}")
+print(f"🔍 Compare and confirm mode: {COMPARE_AND_CONFIRM}")
 print()
 
 
@@ -85,7 +85,7 @@ def _list_s3_keys(file_key_prefix: str) -> list[str]:
             keys.extend([item["Key"] for item in page["Contents"]])
 
     if not keys:
-        print(f"No files found with prefix: {file_key_prefix}")
+        print(f"👀 No files found with prefix: {file_key_prefix}")
         return []
 
     return keys
@@ -97,11 +97,11 @@ def _get_perms_from_s3(file_key: str) -> str | None:
     try:
         item = s3.get_object(Bucket=nrl_auth_bucket_name, Key=file_key)
     except s3.exceptions.NoSuchKey:
-        print(f"Permissions file {file_key} does not exist in the bucket.")
+        print(f"👀 Permissions file {file_key} does not exist in the bucket.")
         return None
 
     if "Body" not in item:
-        print(f"No body found for permissions file {file_key}.")
+        print(f"❌ Error: no body found for permissions file {file_key}.")
         return None
 
     return item["Body"].read().decode("utf-8")
@@ -111,10 +111,10 @@ def _build_lookup_path(
     supplier_type: str, app_id: str, org_ods: str | None
 ) -> str | None:
     if supplier_type.lower() not in SupplierType.list():
-        print(f"Error: invalid supplier {supplier_type}")
+        print(f"❌ Error: invalid supplier {supplier_type}")
         return
     if not app_id:
-        print("Error: please provide an app_id")
+        print("❌ Error: please provide an app_id")
         return
 
     if org_ods:
@@ -123,17 +123,17 @@ def _build_lookup_path(
 
 
 def _load_or_setup_perms(lookup_path: str) -> dict:
-    print(f"Looking up permissions for {lookup_path}")
+    print(f"⏳ Looking up permissions for {lookup_path}")
     perms_ugly = _get_perms_from_s3(lookup_path)
     if not perms_ugly:
-        print("Setting up new permissions file...")
+        print("✨ Setting up new permissions file...")
         return {}
     print()
     return json.loads(perms_ugly)
 
 
 def _confirm_proceed(
-    prompt: str = "Do you want to proceed with these changes?",
+    prompt: str = "❓ Do you want to proceed with these changes?",
 ) -> bool:
     """
     If COMPARE_AND_CONFIRM=true, ask the user to confirm before writing changes.
@@ -143,7 +143,7 @@ def _confirm_proceed(
     print()
     confirm = input(f"{prompt} (yes/NO): ").strip().lower()
     if confirm != "yes":
-        print("Operation cancelled at user request.")
+        print("❌ Operation cancelled at user request.")
         return False
     return True
 
@@ -167,10 +167,13 @@ def _save_updated_perms(
         ContentType="application/json",
     )
     print()
-    print(f"{success_message.strip()} for {lookup_path}")
+    print(f"🎉 {success_message.strip()} for {lookup_path}")
 
     print()
     show_perms(supplier_type, app_id, org_ods)
+
+    print("💡 Remember to update the lambda layer for these changes to take effect")
+    print()
 
 
 json_file_ending = ".json"
@@ -185,7 +188,7 @@ def list_apps(supplier_type: SupplierType) -> None:
         list_apps producer
     """
     if supplier_type.lower() not in SupplierType.list():
-        print(f"Error: invalid supplier {supplier_type}")
+        print(f"❌ Error: invalid supplier {supplier_type}")
         return
 
     keys = _list_s3_keys(f"{supplier_type}/")
@@ -198,18 +201,23 @@ def list_apps(supplier_type: SupplierType) -> None:
     apps_with_orgs = {key for key in apps if key and not key.endswith(json_file_ending)}
 
     if not apps:
-        print("No applications found in the bucket.")
+        print(f"👀 No applications found in the {nrl_env} bucket.")
         return
 
-    print(f"There are {len(apps)} apps in {nrl_env} env")
+    def there_are_x_apps(app_count: int):
+        is_are = "is" if app_count is 1 else "are"
+        s = "" if app_count is 1 else "s"
+        return f"There {is_are} {app_count} app{s}"
+
+    print(f"{there_are_x_apps(len(apps))} in the {nrl_env} env")
 
     print()
-    print(f"There are {len(apps_with_orgs)} apps containing org-level permissions:")
+    print(f"{there_are_x_apps(len(apps_with_orgs))} containing org-level permissions:")
     for app_with_orgs in apps_with_orgs:
         print(f"- {app_with_orgs}")
 
     print()
-    print(f"There are {len(app_level_perm_files)} apps with app-level permissions:")
+    print(f"{there_are_x_apps(len(app_level_perm_files))} with app-level permissions:")
     for app_level in app_level_perm_files:
         print(f"- {app_level}")
     print()
@@ -223,7 +231,7 @@ def list_orgs(supplier_type: SupplierType, app_id: str) -> None:
         list_orgs producer <app_id>
     """
     if supplier_type.lower() not in SupplierType.list():
-        print(f"Error: invalid supplier {supplier_type}")
+        print(f"❌ Error: invalid supplier {supplier_type}")
         return
 
     keys = _list_s3_keys(f"{supplier_type}/{app_id}/")
@@ -234,9 +242,14 @@ def list_orgs(supplier_type: SupplierType, app_id: str) -> None:
     ]
 
     if not orgs:
-        print(f"No organizations found for {supplier_type} app {app_id}.")
+        print()
+        print(f"👀 No organizations found for {supplier_type} app {app_id}.")
+        return
 
-    print(f"There are {len(orgs)} organizations for app {app_id}:")
+    org_count = len(orgs)
+    is_are = "is" if org_count == 1 else "are"
+    s = "" if org_count == 1 else "s"
+    print(f"There {is_are} {org_count} organization{s} for app {app_id}:")
     for org in orgs:
         print(f"- {org}")
     print()
@@ -321,12 +334,12 @@ def show_perms(supplier_type: SupplierType, app_id: str, org_ods=None) -> None:
     perms_ugly = _get_perms_from_s3(lookup_path)
 
     if not perms_ugly:
-        print(f"No permissions file found for {lookup_path}.")
+        print(f"👀 No permissions file found for {lookup_path}.")
         return
 
     perms_pretty = json.loads(perms_ugly)
     if not perms_pretty:
-        print(f"No permissions found in file for {lookup_path}.")
+        print(f"👀 No permissions found in file for {lookup_path}.")
         return
 
     print(f"{lookup_path} is allowed access to the following...")
@@ -335,7 +348,7 @@ def show_perms(supplier_type: SupplierType, app_id: str, org_ods=None) -> None:
         _print_perm_with_lookup(
             perm,
             perms_pretty.get(perm, []),
-            PERMISSION_KEY_ATTRIBUTES.get(perm)["permission_lookup"],
+            PERMISSION_KEY_ATTRIBUTES.get(perm)["attribute_lookup"],
         )
 
 
@@ -360,7 +373,7 @@ def add_perm(
         add_perm access_controls producer <app_id> allow_all_types allow_supersede_with_delete_failure
     """
     if permission_key not in currently_supported_permission_keys:
-        print(f"Error: invalid permission being set: {permission_key}")
+        print(f"❌ Error: invalid permission being set: {permission_key}")
         print(f"Supported permission keys: {currently_supported_permission_keys}")
         return
 
@@ -377,19 +390,21 @@ def add_perm(
 
     if not items_to_add:
         print(
-            f"No {permission_name} provided. Please specify at least one {permission_name_singular}."
+            f"❌ Error: no {permission_name} provided. Please specify at least one {permission_name_singular}."
         )
         return
 
     if len(items_to_add) == 1 and items_to_add[0] == "all":
-        print(f"Setting permissions for access to all {permission_name}.")
+        print(f"📚 Setting permissions for access to all {permission_name}.")
         items_to_add = all_assignable_permission_items
 
     unknown_items = [
         item for item in items_to_add if item not in all_assignable_permission_items
     ]
     if unknown_items:
-        print(f"Error: Unknown {permission_name} provided: {', '.join(unknown_items)}")
+        print(
+            f"❌ Error: Unknown {permission_name} provided: {', '.join(unknown_items)}"
+        )
         print()
         return
 
@@ -401,7 +416,7 @@ def add_perm(
     ]
     if already_added_items:
         print(
-            f"Error: Unable to add {permission_name}. These {permission_name} are already assigned to {lookup_path}:"
+            f"❌ Error: Unable to add {permission_name}. These {permission_name} are already assigned to {lookup_path}:"
         )
         _print_perm_with_lookup("", already_added_items, permission_lookup)
         print()
@@ -416,7 +431,7 @@ def add_perm(
 
     add_count = len(items_to_add)
     if not _confirm_proceed(
-        f"Do you want to proceed with these changes and add {add_count} {permission_name if add_count >1 else permission_name_singular}?"
+        f"❓ Do you want to proceed with these changes and add {add_count} {permission_name_singular if add_count == 1 else permission_name}?"
     ):
         return
 
@@ -442,7 +457,7 @@ def remove_perm(
         remove_perm access_controls producer <app_id> allow_all_types allow_supersede_with_delete_failure
     """
     if permission_key not in currently_supported_permission_keys:
-        print(f"Error: invalid permission being set: {permission_key}")
+        print(f"❌ Error: invalid permission being set: {permission_key}")
         print(f"Supported permission keys: {currently_supported_permission_keys}")
         return
 
@@ -459,7 +474,7 @@ def remove_perm(
 
     if not items_to_remove:
         print(
-            f"No {permission_name} provided. Please specify at least one {permission_name_singular}."
+            f"👀 No {permission_name} provided. Please specify at least one {permission_name_singular}."
         )
         return
 
@@ -467,11 +482,13 @@ def remove_perm(
         item for item in items_to_remove if item not in all_assignable_permission_items
     ]
     if unknown_items:
-        print(f"Error: Unknown {permission_name} provided: {', '.join(unknown_items)}")
+        print(
+            f"❌ Error: Unknown {permission_name} provided: {', '.join(unknown_items)}"
+        )
         print()
         return
 
-    print(f"Looking up permissions for {lookup_path}")
+    print(f"⏳ Looking up permissions for {lookup_path}")
     perms_ugly = _get_perms_from_s3(lookup_path)
     if not perms_ugly:
         return
@@ -486,7 +503,7 @@ def remove_perm(
     ]
     if items_not_assigned:
         print(
-            f"Error: Unable to remove {permission_name}. These {permission_name} aren't assigned to {lookup_path}:"
+            f"❌ Error: Unable to remove {permission_name}. These {permission_name} aren't assigned to {lookup_path}:"
         )
         _print_perm("", items_not_assigned)
         print()
@@ -503,7 +520,7 @@ def remove_perm(
 
     remove_count = len(items_to_remove)
     if not _confirm_proceed(
-        f"Do you want to proceed with these changes and remove {remove_count} {permission_name if remove_count >1 else permission_name_singular}?"
+        f"❓ Do you want to proceed with these changes and remove {remove_count} {permission_name_singular if remove_count == 1 else permission_name}?"
     ):
         return
 
@@ -530,7 +547,7 @@ def clear_perms(supplier_type: SupplierType, app_id: str, org_ods=None) -> None:
     current_perms = _get_perms_from_s3(lookup_path)
     if not current_perms or current_perms == "{}":
         print(
-            f"No need to clear permissions for {lookup_path} as it currently has no permissions set."
+            f"⏭️ No need to clear permissions for {lookup_path} as it currently has no permissions set."
         )
         return
 

--- a/scripts/manage_permissions.py
+++ b/scripts/manage_permissions.py
@@ -9,7 +9,7 @@ from enum import Enum
 import fire
 from aws_session_assume import get_boto_session
 
-from nrlf.core.constants import TYPE_ATTRIBUTES, AccessControls
+from nrlf.core.constants import CATEGORY_ATTRIBUTES, TYPE_ATTRIBUTES, AccessControls
 
 nrl_env = os.getenv("ENV", "dev")
 nrl_auth_bucket_name = os.getenv(
@@ -167,21 +167,44 @@ def list_available_access_controls() -> None:
 
 
 def _print_perm(
-    perms_pretty: dict, lookup_path: str, perm_pretty_name: str, perm_key: str
+    perm_pretty_name: str,
+    perm_to_print: list,
 ):
+    # if not perm_to_print:
+    #     return
     print()
-    access_controls = perms_pretty.get(perm_key, [])
-    if access_controls:
-        print(f"{lookup_path} has these {perm_pretty_name}s:")
-        for control in access_controls:
-            print(f"- {control}")
-    else:
-        print(f"{lookup_path} has no {perm_pretty_name}s")
+    plural = (
+        perm_pretty_name if perm_pretty_name.endswith("s") else f"{perm_pretty_name}s"
+    )
+    print(f"{plural.upper()} ({len(perm_to_print)})")
+    for perm in perm_to_print:
+        print(f"- {perm}")
+
+
+def _print_perm_with_lookup(
+    perm_pretty_name: str,
+    perm_to_print: list,
+    attribute_lookup: dict[str, dict[str, str]],
+):
+    """
+    Lookup human-readable names for a permission and print
+    """
+    printable = []
+    for perm_item in perm_to_print:
+        display_name = attribute_lookup.get(
+            perm_item, {"display": f"Unknown {perm_pretty_name.lower()}"}
+        )["display"]
+        printable_perm_and_display_name = "%-45s (%s)" % (
+            display_name[:44],
+            perm_item,
+        )
+        printable.append(printable_perm_and_display_name)
+    _print_perm(perm_pretty_name, printable)
 
 
 def show_perms(supplier_type: SupplierType, app_id: str, org_ods=None) -> None:
     """
-    Show the permissions for a given application or organization.
+    Show permissions for a given application or organization.
     """
     if supplier_type.lower() not in SupplierType.list() or not app_id:
         print("Usage: show permissions for a given organisation or app")
@@ -204,37 +227,38 @@ def show_perms(supplier_type: SupplierType, app_id: str, org_ods=None) -> None:
 
     perms_pretty = json.loads(perms_ugly)
     if not perms_pretty:
-        print(f"No pointer-types found in permission file for {lookup_path}.")
+        print(f"No permissions found in file for {lookup_path}.")
         return
 
-    pretty_type_data = {
-        pointertype_perm: TYPE_ATTRIBUTES.get(
-            pointertype_perm, {"display": "Unknown type"}
-        )
-        for pointertype_perm in perms_pretty.get("types")
-    }
-    types = [
-        "%-45s (%s)"
-        % (pretty_type_data[pointertype_perm]["display"][:44], pointertype_perm)
-        for pointertype_perm in perms_pretty.get("types")
-    ]
-    print(f"{lookup_path} is allowed to access these pointer-types:")
-    for type_display in types:
-        print(f"- {type_display}")
+    print(f"{lookup_path} is allowed access to the following...")
 
-    _print_perm(
-        perms_pretty,
-        lookup_path,
-        perm_pretty_name="access control",
-        perm_key="access_controls",
+    _print_perm_with_lookup(
+        "pointer type", perms_pretty.get("types", []), TYPE_ATTRIBUTES
     )
 
-    # _print_perm(
-    #     perms_pretty,
-    #     lookup_path,
-    #     perm_pretty_name="API interaction",
-    #     perm_key="interaction",
-    # )
+    _print_perm_with_lookup(
+        "pointer categories", perms_pretty.get("categories", []), CATEGORY_ATTRIBUTES
+    )
+
+    _print_perm(
+        "access control",
+        perms_pretty.get("access_controls", []),
+    )
+
+    _print_perm(
+        "API interaction",
+        perms_pretty.get("interaction", []),
+    )
+
+    _print_perm(
+        "Produce for authors",
+        perms_pretty.get("produce_for_authors", []),
+    )
+
+    _print_perm(
+        "Produce for custodians",
+        perms_pretty.get("produce_for_custodians", []),
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/manage_permissions.py
+++ b/scripts/manage_permissions.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python
 """
-Manage app ans organisation v2 permissions for NRLF apps in a given environment ENV
+Manage app and organisation v2 permissions for NRLF apps in a given environment ENV
+
+```sh
+ENV=dev \
+COMPARE_AND_CONFIRM=true \
+poetry run python ./scripts/manage_permissions.py <command> <args>
+```
 """
 import json
 import os
@@ -15,7 +21,6 @@ nrl_env = os.getenv("ENV", "dev")
 nrl_auth_bucket_name = os.getenv(
     "NRL_AUTH_BUCKET_NAME", f"nhsd-nrlf--{nrl_env}-authorization-store"
 )
-
 COMPARE_AND_CONFIRM = (
     True
     if nrl_env == "prod"
@@ -236,29 +241,82 @@ def show_perms(supplier_type: SupplierType, app_id: str, org_ods=None) -> None:
         "pointer type", perms_pretty.get("types", []), TYPE_ATTRIBUTES
     )
 
-    _print_perm_with_lookup(
-        "pointer categories", perms_pretty.get("categories", []), CATEGORY_ATTRIBUTES
-    )
+    # _print_perm_with_lookup(
+    #     "pointer categories", perms_pretty.get("categories", []), CATEGORY_ATTRIBUTES
+    # )
 
     _print_perm(
         "access control",
         perms_pretty.get("access_controls", []),
     )
 
-    _print_perm(
-        "API interaction",
-        perms_pretty.get("interaction", []),
-    )
+    # _print_perm(
+    #     "API interaction",
+    #     perms_pretty.get("interaction", []),
+    # )
 
-    _print_perm(
-        "Produce for authors",
-        perms_pretty.get("produce_for_authors", []),
-    )
+    # _print_perm(
+    #     "Produce for authors",
+    #     perms_pretty.get("produce_for_authors", []),
+    # )
 
-    _print_perm(
-        "Produce for custodians",
-        perms_pretty.get("produce_for_custodians", []),
+    # _print_perm(
+    #     "Produce for custodians",
+    #     perms_pretty.get("produce_for_custodians", []),
+    # )
+
+
+def clear_perms(supplier_type, app_id: str, org_ods=None) -> None:
+    """
+    Clear permissions for an application or organization.
+    This will remove all permissions for the specified app and org.
+
+    COMPARE_AND_CONFIRM=true \
+    poetry run python ./scripts/manage_permissions.py clear_perms consumer ANJALI_POSTMAN_APP TEST4
+    """
+    if supplier_type.lower() not in SupplierType.list() or not app_id:
+        print("Usage: clear permissions for a given organisation or app")
+        print("  clear_perms consumer <app_id> <org_ods>")
+        print("  clear_perms producer <app_id> <org_ods>")
+        print("  clear_perms consumer <app_id>")
+        print("  clear_perms producer <app_id>")
+        return
+
+    if org_ods:
+        lookup_path = f"{supplier_type}/{app_id}/{org_ods}.json"
+    else:
+        lookup_path = f"{supplier_type}/{app_id}.json"
+
+    if COMPARE_AND_CONFIRM:
+        current_perms = _get_perms_from_s3(lookup_path)
+        if not current_perms or current_perms == "{}":
+            print(
+                f"No need to clear permissions for {lookup_path} as it currently has no permissions set."
+            )
+            return
+
+        print()
+        print(f"Current permissions for {lookup_path}:")
+        print(current_perms)
+
+        print()
+        confirm = (
+            input("Are you SURE you want to clear these permissions? (yes/NO): ")
+            .strip()
+            .lower()
+        )
+        if confirm != "yes":
+            print("Operation cancelled at user request.")
+            return
+
+    s3 = _get_s3_client()
+    s3.put_object(
+        Bucket=nrl_auth_bucket_name,
+        Key=lookup_path,
+        Body="{}",
+        ContentType="application/json",
     )
+    print(f"Cleared permissions for {lookup_path}.")
 
 
 if __name__ == "__main__":
@@ -270,6 +328,7 @@ if __name__ == "__main__":
             "list_available_access_controls": list_available_access_controls,
             "show_perms": show_perms,
             # "set_perms": set_perms,
-            # "clear_perms": clear_perms,
+            "clear_perms": clear_perms,
+            # "help": help,
         }
     )

--- a/scripts/manage_permissions.py
+++ b/scripts/manage_permissions.py
@@ -17,11 +17,11 @@ from aws_session_assume import get_boto_session
 
 from nrlf.core.constants import (
     CATEGORY_ATTRIBUTES,
+    PERMISSION_KEY_ATTRIBUTES,
     TYPE_ATTRIBUTES,
     AccessControls,
     Categories,
     PointerTypes,
-    SupplierType,
     V2PermissionKey,
 )
 
@@ -34,6 +34,16 @@ COMPARE_AND_CONFIRM = (
     if nrl_env == "prod"
     else os.getenv("COMPARE_AND_CONFIRM", "false").lower() == "true"
 )
+
+
+class SupplierType(Enum):
+    PRODUCER = "producer"
+    CONSUMER = "consumer"
+
+    @staticmethod
+    def list():
+        return [supplier.value for supplier in SupplierType]
+
 
 currently_supported_permission_keys = [
     V2PermissionKey.TYPES.value,
@@ -97,7 +107,9 @@ def _get_perms_from_s3(file_key: str) -> str | None:
     return item["Body"].read().decode("utf-8")
 
 
-def _build_lookup_path(supplier_type: str, app_id: str, org_ods: str | None) -> str:
+def _build_lookup_path(
+    supplier_type: str, app_id: str, org_ods: str | None
+) -> str | None:
     if supplier_type.lower() not in SupplierType.list():
         print(f"Error: invalid supplier {supplier_type}")
         return
@@ -111,23 +123,25 @@ def _build_lookup_path(supplier_type: str, app_id: str, org_ods: str | None) -> 
 
 
 def _load_or_setup_perms(lookup_path: str) -> dict:
+    print(f"Looking up permissions for {lookup_path}")
     perms_ugly = _get_perms_from_s3(lookup_path)
     if not perms_ugly:
         print("Setting up new permissions file...")
         return {}
+    print()
     return json.loads(perms_ugly)
 
 
 def _confirm_proceed(
-    prompt: str = "Do you want to proceed with these changes? (yes/NO): ",
+    prompt: str = "Do you want to proceed with these changes?",
 ) -> bool:
     """
-    If COMPARE_AND_CONFIRM enabled, ask the user to confirm before writing changes.
+    If COMPARE_AND_CONFIRM=true, ask the user to confirm before writing changes.
     """
     if not COMPARE_AND_CONFIRM:
         return True
     print()
-    confirm = input(prompt).strip().lower()
+    confirm = input(f"{prompt} (yes/NO): ").strip().lower()
     if confirm != "yes":
         print("Operation cancelled at user request.")
         return False
@@ -159,6 +173,9 @@ def _save_updated_perms(
     show_perms(supplier_type, app_id, org_ods)
 
 
+json_file_ending = ".json"
+
+
 def list_apps(supplier_type: SupplierType) -> None:
     """
     List all consumer or producer applications for a given supplier type
@@ -174,9 +191,11 @@ def list_apps(supplier_type: SupplierType) -> None:
     keys = _list_s3_keys(f"{supplier_type}/")
     apps = {key.split("/")[1] for key in keys[1:]}
     app_level_perm_files = {
-        key.removesuffix(".json") for key in apps if key and key.endswith(".json")
+        key.removesuffix(json_file_ending)
+        for key in apps
+        if key and key.endswith(json_file_ending)
     }
-    apps_with_orgs = {key for key in apps if key and not key.endswith(".json")}
+    apps_with_orgs = {key for key in apps if key and not key.endswith(json_file_ending)}
 
     if not apps:
         print("No applications found in the bucket.")
@@ -209,9 +228,9 @@ def list_orgs(supplier_type: SupplierType, app_id: str) -> None:
 
     keys = _list_s3_keys(f"{supplier_type}/{app_id}/")
     orgs = [
-        key.split("/", maxsplit=2)[2].removesuffix(".json")
+        key.split("/", maxsplit=2)[2].removesuffix(json_file_ending)
         for key in keys
-        if key and key.endswith(".json")
+        if key and key.endswith(json_file_ending)
     ]
 
     if not orgs:
@@ -249,8 +268,6 @@ def _print_perm(
     perm_pretty_name: str,
     perm_to_print: list,
 ):
-    # if not perm_to_print:
-    #     return
     print()
     if perm_pretty_name:
         plural = (
@@ -314,51 +331,35 @@ def show_perms(supplier_type: SupplierType, app_id: str, org_ods=None) -> None:
 
     print(f"{lookup_path} is allowed access to the following...")
 
-    _print_perm_with_lookup(
-        "pointer type", perms_pretty.get("types", []), TYPE_ATTRIBUTES
-    )
-
-    # _print_perm_with_lookup(
-    #     "pointer categories", perms_pretty.get("categories", []), CATEGORY_ATTRIBUTES
-    # )
-
-    _print_perm(
-        "access control",
-        perms_pretty.get("access_controls", []),
-    )
-
-    # _print_perm(
-    #     "API interaction",
-    #     perms_pretty.get("interaction", []),
-    # )
-
-    # _print_perm(
-    #     "Produce for authors",
-    #     perms_pretty.get("produce_for_authors", []),
-    # )
-
-    # _print_perm(
-    #     "Produce for custodians",
-    #     perms_pretty.get("produce_for_custodians", []),
-    # )
+    for perm in currently_supported_permission_keys:
+        _print_perm_with_lookup(
+            perm,
+            perms_pretty.get(perm, []),
+            PERMISSION_KEY_ATTRIBUTES.get(perm)["permission_lookup"],
+        )
 
 
-def _add_perm(
-    permission_key: V2PermissionKey,
-    all_assignable_permission_items: dict,
-    permission_lookup: dict[str, dict[str, str]],
+def add_perm(
+    permission_key: str,
     supplier_type: SupplierType,
     app_id: str,
     org_ods=None,
-    *permission_items_to_add: str,
+    *items_to_add: str,
 ) -> None:
     """
-    Add one type of permission to an app or org.
+    Add items to any permission for a given app or org.
+        add_perm <permission_key> <supplier_type> <app_id> <permission_items>
 
-    TODO:
-    highlight new additions in proposed pointer types list e.g. [NEW]
+    Add pointer types to a consumer org:
+        add_perm types consumer <app_id> <org_ods> http://snomed.info/sct|736253002 http://snomed.info/sct|887701000000100
+
+    Add all current pointer types to a producer org:
+        add_perm types producer <app_id> <org_ods> all
+
+    Add access controls to a producer app:
+        add_perm access_controls producer <app_id> allow_all_types allow_supersede_with_delete_failure
     """
-    if permission_key.value not in currently_supported_permission_keys:
+    if permission_key not in currently_supported_permission_keys:
         print(f"Error: invalid permission being set: {permission_key}")
         print(f"Supported permission keys: {currently_supported_permission_keys}")
         return
@@ -367,204 +368,64 @@ def _add_perm(
     if not lookup_path:
         return
 
-    permission_name_plural = permission_key.human_readable(plural=True)
-    permission_name_singular = permission_key.human_readable()
+    (
+        permission_name,
+        permission_name_singular,
+        permission_lookup,
+        all_assignable_permission_items,
+    ) = PERMISSION_KEY_ATTRIBUTES.get(permission_key).values()
 
-    if not permission_items_to_add:
+    if not items_to_add:
         print(
-            f"No {permission_name_plural} provided. Please specify at least one {permission_name_singular}."
+            f"No {permission_name} provided. Please specify at least one {permission_name_singular}."
         )
         return
 
-    if len(permission_items_to_add) == 1 and permission_items_to_add[0] == "all":
-        print(f"Setting permissions for access to all {permission_name_plural}.")
-        permission_items_to_add = all_assignable_permission_items
+    if len(items_to_add) == 1 and items_to_add[0] == "all":
+        print(f"Setting permissions for access to all {permission_name}.")
+        items_to_add = all_assignable_permission_items
 
     unknown_items = [
-        item
-        for item in permission_items_to_add
-        if item not in all_assignable_permission_items
+        item for item in items_to_add if item not in all_assignable_permission_items
     ]
     if unknown_items:
-        print(
-            f"Error: Unknown {permission_name_plural} provided: {', '.join(unknown_items)}"
-        )
+        print(f"Error: Unknown {permission_name} provided: {', '.join(unknown_items)}")
         print()
         return
 
     current_perms = _load_or_setup_perms(lookup_path)
-    current_permission_items: list = current_perms.get(permission_key.value, [])
+    current_permission_items: list = current_perms.get(permission_key, [])
 
     already_added_items = [
-        item for item in permission_items_to_add if item in current_permission_items
+        item for item in items_to_add if item in current_permission_items
     ]
     if already_added_items:
         print(
-            f"Error: Unable to add {permission_name_plural}. These {permission_name_plural} are already assigned to {lookup_path}:"
+            f"Error: Unable to add {permission_name}. These {permission_name} are already assigned to {lookup_path}:"
         )
         _print_perm_with_lookup("", already_added_items, permission_lookup)
         print()
         return
 
-    proposed_permission_items = current_permission_items + list(permission_items_to_add)
+    proposed_permission_items = current_permission_items + list(items_to_add)
     _print_perm_with_lookup(
-        f"proposed {permission_name_plural}",
+        f"proposed {permission_name}",
         proposed_permission_items,
         permission_lookup,
     )
 
-    if not _confirm_proceed():
+    add_count = len(items_to_add)
+    if not _confirm_proceed(
+        f"Do you want to proceed with these changes and add {add_count} {permission_name if add_count >1 else permission_name_singular}?"
+    ):
         return
 
-    current_perms[permission_key.value] = proposed_permission_items
+    current_perms[permission_key] = proposed_permission_items
     _save_updated_perms(lookup_path, current_perms, supplier_type, app_id, org_ods)
 
 
-def add_permission(
-    perm_key: str,
-    supplier_type: SupplierType,
-    app_id: str,
-    org_ods=None,
-    *items_to_add: str,
-):
-    """
-    Add items to any permission for a given app or org.
-        add_permission <permission_key> <supplier_type> <app_id> <permission_items>
-
-    Add pointer types to a consumer org:
-        add_permission types consumer <app_id> <org_ods> http://snomed.info/sct\|736253002 http://snomed.info/sct\|887701000000100
-
-    Add all current pointer types to a producer org:
-        add_permission types producer <app_id> <org_ods> all
-
-    Add access controls to a producer app:
-        add_permission access_controls producer <app_id> allow_all_types allow_supersede_with_delete_failure
-    """
-    match perm_key:
-        case V2PermissionKey.ACCESS_CONTROLS.value:
-            return _add_perm(
-                V2PermissionKey.ACCESS_CONTROLS,
-                AccessControls.list(),
-                None,
-                supplier_type,
-                app_id,
-                org_ods,
-                *items_to_add,
-            )
-
-        case V2PermissionKey.TYPES.value:
-            _add_perm(
-                V2PermissionKey.TYPES,
-                PointerTypes.list(),
-                TYPE_ATTRIBUTES,
-                supplier_type,
-                app_id,
-                org_ods,
-                *items_to_add,
-            )
-
-        # case V2PermissionKey.CATEGORIES.value:
-        #     _add_perm(
-        #         V2PermissionKey.CATEGORIES,
-        #         Categories.list(),
-        #         CATEGORY_ATTRIBUTES,
-        #         supplier_type,
-        #         app_id,
-        #         org_ods,
-        #         *items_to_add,
-        #     )
-
-        case _:
-            print(f"Unrecognised or unsupported permission key: {perm_key}")
-            print(f"Must be one of: {", ".join(V2PermissionKey.list())}")
-
-
-def _remove_perm(
-    permission_key: V2PermissionKey,
-    all_assignable_permission_items: dict,
-    permission_lookup: dict[str, dict[str, str]],
-    supplier_type: SupplierType,
-    app_id: str,
-    org_ods=None,
-    *permission_items_to_remove: str,
-) -> None:
-    """
-    Remove one type of permission to an app or org.
-
-    TODO:
-    highlight new additions in proposed pointer types list e.g. [NEW]
-    """
-    if permission_key.value not in currently_supported_permission_keys:
-        print(f"Error: invalid permission being set: {permission_key}")
-        print(f"Supported permission keys: {currently_supported_permission_keys}")
-        return
-
-    lookup_path = _build_lookup_path(supplier_type, app_id, org_ods)
-    if not lookup_path:
-        return
-
-    permission_name_plural = permission_key.human_readable(plural=True)
-    permission_name_singular = permission_key.human_readable()
-
-    if not permission_items_to_remove:
-        print(
-            f"No {permission_name_plural} provided. Please specify at least one {permission_name_singular}."
-        )
-        return
-
-    unknown_items = [
-        item
-        for item in permission_items_to_remove
-        if item not in all_assignable_permission_items
-    ]
-    if unknown_items:
-        print(
-            f"Error: Unknown {permission_name_plural} provided: {', '.join(unknown_items)}"
-        )
-        print()
-        return
-
-    perms_ugly = _get_perms_from_s3(lookup_path)
-    if not perms_ugly:
-        return
-
-    current_perms = json.loads(perms_ugly)
-    current_permission_items: list = current_perms.get(permission_key.value, [])
-
-    # Cannot remove permission items that aren't already assigned
-    items_not_assigned = [
-        item
-        for item in permission_items_to_remove
-        if item not in current_permission_items
-    ]
-    if items_not_assigned:
-        print(
-            f"Error: Unable to remove {permission_name_plural}. These {permission_name_plural} aren't assigned to {lookup_path}:"
-        )
-        _print_perm("", items_not_assigned)
-        print()
-        return
-
-    proposed_permission_items = [
-        item
-        for item in current_permission_items
-        if item not in permission_items_to_remove
-    ]
-    _print_perm_with_lookup(
-        f"proposed {permission_name_plural}",
-        proposed_permission_items,
-        permission_lookup,
-    )
-
-    if not _confirm_proceed():
-        return
-
-    current_perms[permission_key.value] = proposed_permission_items
-    _save_updated_perms(lookup_path, current_perms, supplier_type, app_id, org_ods)
-
-
-def remove_permission(
-    perm_key: str,
+def remove_perm(
+    permission_key: str,
     supplier_type: SupplierType,
     app_id: str,
     org_ods=None,
@@ -572,51 +433,82 @@ def remove_permission(
 ):
     """
     Remove items from any permission for a given app or org.
-        remove_permission <permission_key> <supplier_type> <app_id> <permission_items>
+        remove_perm <permission_key> <supplier_type> <app_id> <permission_items>
 
     Remove pointer types from a consumer org:
-        remove_permission types consumer <app_id> <org_ods> http://snomed.info/sct\|736253002 http://snomed.info/sct\|887701000000100
+        remove_perm types consumer <app_id> <org_ods> http://snomed.info/sct|736253002 http://snomed.info/sct|887701000000100
 
     Remove access controls from a producer app:
-        remove_permission access_controls producer <app_id> allow_all_types allow_supersede_with_delete_failure
+        remove_perm access_controls producer <app_id> allow_all_types allow_supersede_with_delete_failure
     """
-    match perm_key:
-        case V2PermissionKey.ACCESS_CONTROLS.value:
-            return _remove_perm(
-                V2PermissionKey.ACCESS_CONTROLS,
-                AccessControls.list(),
-                None,
-                supplier_type,
-                app_id,
-                org_ods,
-                *items_to_remove,
-            )
+    if permission_key not in currently_supported_permission_keys:
+        print(f"Error: invalid permission being set: {permission_key}")
+        print(f"Supported permission keys: {currently_supported_permission_keys}")
+        return
 
-        case V2PermissionKey.TYPES.value:
-            _remove_perm(
-                V2PermissionKey.TYPES,
-                PointerTypes.list(),
-                TYPE_ATTRIBUTES,
-                supplier_type,
-                app_id,
-                org_ods,
-                *items_to_remove,
-            )
+    lookup_path = _build_lookup_path(supplier_type, app_id, org_ods)
+    if not lookup_path:
+        return
 
-        # case V2PermissionKey.CATEGORIES.value:
-        #     _remove_perm(
-        #         V2PermissionKey.CATEGORIES,
-        #         Categories.list(),
-        #         CATEGORY_ATTRIBUTES,
-        #         supplier_type,
-        #         app_id,
-        #         org_ods,
-        #         *items_to_remove,
-        #     )
+    (
+        permission_name,
+        permission_name_singular,
+        permission_lookup,
+        all_assignable_permission_items,
+    ) = PERMISSION_KEY_ATTRIBUTES.get(permission_key).values()
 
-        case _:
-            print(f"Unrecognised or unsupported permission key: {perm_key}")
-            print(f"Supported permission keys: {currently_supported_permission_keys}")
+    if not items_to_remove:
+        print(
+            f"No {permission_name} provided. Please specify at least one {permission_name_singular}."
+        )
+        return
+
+    unknown_items = [
+        item for item in items_to_remove if item not in all_assignable_permission_items
+    ]
+    if unknown_items:
+        print(f"Error: Unknown {permission_name} provided: {', '.join(unknown_items)}")
+        print()
+        return
+
+    print(f"Looking up permissions for {lookup_path}")
+    perms_ugly = _get_perms_from_s3(lookup_path)
+    if not perms_ugly:
+        return
+    print()
+
+    current_perms = json.loads(perms_ugly)
+    current_permission_items: list = current_perms.get(permission_key, [])
+
+    # Cannot remove permission items that aren't already assigned
+    items_not_assigned = [
+        item for item in items_to_remove if item not in current_permission_items
+    ]
+    if items_not_assigned:
+        print(
+            f"Error: Unable to remove {permission_name}. These {permission_name} aren't assigned to {lookup_path}:"
+        )
+        _print_perm("", items_not_assigned)
+        print()
+        return
+
+    proposed_permission_items = [
+        item for item in current_permission_items if item not in items_to_remove
+    ]
+    _print_perm_with_lookup(
+        f"proposed {permission_name}",
+        proposed_permission_items,
+        permission_lookup,
+    )
+
+    remove_count = len(items_to_remove)
+    if not _confirm_proceed(
+        f"Do you want to proceed with these changes and remove {remove_count} {permission_name if remove_count >1 else permission_name_singular}?"
+    ):
+        return
+
+    current_perms[permission_key] = proposed_permission_items
+    _save_updated_perms(lookup_path, current_perms, supplier_type, app_id, org_ods)
 
 
 def clear_perms(supplier_type: SupplierType, app_id: str, org_ods=None) -> None:
@@ -647,9 +539,7 @@ def clear_perms(supplier_type: SupplierType, app_id: str, org_ods=None) -> None:
         print(f"Current permissions for {lookup_path}:")
         print(current_perms)
 
-        if not _confirm_proceed(
-            "Are you SURE you want to clear these permissions? (yes/NO): "
-        ):
+        if not _confirm_proceed("Are you SURE you want to clear these permissions?"):
             return
 
     _save_updated_perms(
@@ -670,8 +560,8 @@ if __name__ == "__main__":
             "list_available_pointer_types": list_available_pointer_types,
             "list_available_access_controls": list_available_access_controls,
             "show_perms": show_perms,
-            "add_permission": add_permission,
-            "remove_permission": remove_permission,
+            "add_perm": add_perm,
+            "remove_perm": remove_perm,
             "clear_perms": clear_perms,
         }
     )

--- a/scripts/manage_permissions.py
+++ b/scripts/manage_permissions.py
@@ -172,7 +172,8 @@ def _save_updated_perms(
     print()
     show_perms(supplier_type, app_id, org_ods)
 
-    print("💡 Remember to update the lambda layer for these changes to take effect")
+    print()
+    print("💡 Remember to update the lambda layer for these changes to take effect 💡")
     print()
 
 
@@ -415,12 +416,16 @@ def add_perm(
         item for item in items_to_add if item in current_permission_items
     ]
     if already_added_items:
-        print(
-            f"❌ Error: Unable to add {permission_name}. These {permission_name} are already assigned to {lookup_path}:"
-        )
+        if len(already_added_items) == len(items_to_add):
+            print(
+                f"⏭️  Skipping: All requested {permission_name} are already assigned to {lookup_path}"
+            )
+            print()
+            return
+
+        print(f"👬 Skipping {permission_name} already assigned to {lookup_path}:")
         _print_perm_with_lookup("", already_added_items, permission_lookup)
         print()
-        return
 
     proposed_permission_items = current_permission_items + list(items_to_add)
     _print_perm_with_lookup(
@@ -497,17 +502,20 @@ def remove_perm(
     current_perms = json.loads(perms_ugly)
     current_permission_items: list = current_perms.get(permission_key, [])
 
-    # Cannot remove permission items that aren't already assigned
     items_not_assigned = [
         item for item in items_to_remove if item not in current_permission_items
     ]
     if items_not_assigned:
-        print(
-            f"❌ Error: Unable to remove {permission_name}. These {permission_name} aren't assigned to {lookup_path}:"
-        )
+        if len(items_not_assigned) == len(items_to_remove):
+            print(
+                f"⏭️  Skipping: None of the requested {permission_name} are assigned to {lookup_path}"
+            )
+            print()
+            return
+
+        print(f"👬 Skipping {permission_name} not already assigned to {lookup_path}:")
         _print_perm("", items_not_assigned)
         print()
-        return
 
     proposed_permission_items = [
         item for item in current_permission_items if item not in items_to_remove
@@ -547,7 +555,7 @@ def clear_perms(supplier_type: SupplierType, app_id: str, org_ods=None) -> None:
     current_perms = _get_perms_from_s3(lookup_path)
     if not current_perms or current_perms == "{}":
         print(
-            f"⏭️ No need to clear permissions for {lookup_path} as it currently has no permissions set."
+            f"⏭️  No need to clear permissions for {lookup_path} as it currently has no permissions set."
         )
         return
 

--- a/scripts/manage_permissions.py
+++ b/scripts/manage_permissions.py
@@ -75,7 +75,9 @@ def list_apps(supplier_type: SupplierType) -> None:
 
     keys = _list_s3_keys(f"{supplier_type}/")
     apps = {key.split("/")[1] for key in keys[1:]}
-    app_level_perm_files = {key for key in apps if key and key.endswith(".json")}
+    app_level_perm_files = {
+        key.removesuffix(".json") for key in apps if key and key.endswith(".json")
+    }
     apps_with_orgs = {key for key in apps if key and not key.endswith(".json")}
 
     if not apps:
@@ -95,11 +97,37 @@ def list_apps(supplier_type: SupplierType) -> None:
         print(f"- {app_level}")
 
 
+def list_orgs(supplier_type: SupplierType, app_id: str) -> None:
+    """
+    List all organizations for a specific consumer or producer application.
+    """
+
+    if supplier_type.lower() not in SupplierType.list():
+        print("Usage: list organisations for a given app and supplier type")
+        print("  list_orgs consumer <app_id>")
+        print("  list_orgs producer <app_id>")
+        return
+
+    keys = _list_s3_keys(f"{supplier_type}/{app_id}/")
+    orgs = [
+        key.split("/", maxsplit=2)[2].removesuffix(".json")
+        for key in keys
+        if key and key.endswith(".json")
+    ]
+
+    if not orgs:
+        print(f"No organizations found for {supplier_type} app {app_id}.")
+
+    print(f"There are {len(orgs)} organizations for app {app_id}:")
+    for org in orgs:
+        print(f"- {org}")
+
+
 if __name__ == "__main__":
     fire.Fire(
         {
             "list_apps": list_apps,
-            # "list_orgs": list_orgs,
+            "list_orgs": list_orgs,
             # "list_allowed_types": list_allowed_types,
             # "show_perms": show_perms,
             # "set_perms": set_perms,

--- a/scripts/manage_permissions.py
+++ b/scripts/manage_permissions.py
@@ -8,6 +8,8 @@ from enum import Enum
 import fire
 from aws_session_assume import get_boto_session
 
+from nrlf.core.constants import TYPE_ATTRIBUTES, AccessControls
+
 nrl_env = os.getenv("ENV", "dev")
 nrl_auth_bucket_name = os.getenv(
     "NRL_AUTH_BUCKET_NAME", f"nhsd-nrlf--{nrl_env}-authorization-store"
@@ -123,12 +125,33 @@ def list_orgs(supplier_type: SupplierType, app_id: str) -> None:
         print(f"- {org}")
 
 
+def list_available_pointer_types() -> None:
+    """
+    List all pointer types that can be used in permissions.
+    """
+    print("The following pointer-types can be assigned:")
+
+    for pointer_type, attributes in TYPE_ATTRIBUTES.items():
+        print("- %-45s (%s)" % (pointer_type, attributes["display"][:45]))
+
+
+def list_available_access_controls() -> None:
+    """
+    List all access controls that can be assigned in permissions.
+    """
+    print("The following access controls can be assigned:")
+
+    for control in AccessControls.list():
+        print(f"- {control}")
+
+
 if __name__ == "__main__":
     fire.Fire(
         {
             "list_apps": list_apps,
             "list_orgs": list_orgs,
-            # "list_allowed_types": list_allowed_types,
+            "list_available_pointer_types": list_available_pointer_types,
+            "list_available_access_controls": list_available_access_controls,
             # "show_perms": show_perms,
             # "set_perms": set_perms,
             # "clear_perms": clear_perms,

--- a/scripts/manage_permissions.py
+++ b/scripts/manage_permissions.py
@@ -178,10 +178,13 @@ def _print_perm(
     # if not perm_to_print:
     #     return
     print()
-    plural = (
-        perm_pretty_name if perm_pretty_name.endswith("s") else f"{perm_pretty_name}s"
-    )
-    print(f"{plural.upper()} ({len(perm_to_print)})")
+    if perm_pretty_name:
+        plural = (
+            perm_pretty_name
+            if perm_pretty_name.endswith("s")
+            else f"{perm_pretty_name}s"
+        )
+        print(f"{plural.upper()} ({len(perm_to_print)})")
     for perm in perm_to_print:
         print(f"- {perm}")
 
@@ -269,16 +272,21 @@ def show_perms(supplier_type: SupplierType, app_id: str, org_ods=None) -> None:
 def add_pointer_type_perms(
     supplier_type: SupplierType, app_id: str, org_ods=None, *pointer_types_to_add: str
 ) -> None:
-    # TODO:
-    # confirm before proceeding mode
-    # formatting help for pointer types ?
-    # highlight new additions in proposed pointer types list e.g. [NEW]
+    """
+    TODO:
+    confirm before proceeding mode
+    formatting help for pointer types ?
+    validate not adding a duplicate type
+    add list of all pointer types vs adding access control
+    highlight new additions in proposed pointer types list e.g. [NEW]
+    don't create at app level if ODS level present & backwards too? - hmm maybe too fancy
+    """
     if supplier_type.lower() not in SupplierType.list() or not app_id:
         print("Usage: add pointer type permissions for a given organisation or app")
-        print("  show_perms consumer <app_id> <org_ods> <pointer_types>")
-        print("  show_perms producer <app_id> <org_ods> <pointer_types>")
-        print("  show_perms consumer <app_id> <pointer_types>")
-        print("  show_perms producer <app_id> <pointer_types>")
+        print("  add_pointer_type_perms consumer <app_id> <org_ods> <pointer_types>")
+        print("  add_pointer_type_perms producer <app_id> <org_ods> <pointer_types>")
+        print("  add_pointer_type_perms consumer <app_id> <pointer_types>")
+        print("  add_pointer_type_perms producer <app_id> <pointer_types>")
         return
 
     if not pointer_types_to_add:
@@ -291,6 +299,10 @@ def add_pointer_type_perms(
         lookup_path = f"{supplier_type}/{app_id}/{org_ods}.json"
     else:
         lookup_path = f"{supplier_type}/{app_id}.json"
+
+    if len(pointer_types_to_add) == 1 and pointer_types_to_add[0] == "all":
+        print("Setting permissions for access to all pointer types.")
+        pointer_types_to_add = tuple(TYPE_ATTRIBUTES.keys())
 
     unknown_types = [pt for pt in pointer_types_to_add if pt not in TYPE_ATTRIBUTES]
     if unknown_types:
@@ -305,19 +317,35 @@ def add_pointer_type_perms(
 
     current_perms = json.loads(perms_ugly)
     current_pointer_types: list = current_perms.get("types", [])
-    if all(
-        new_pointer_type in current_pointer_types
+
+    already_added_types = list(
+        new_pointer_type
         for new_pointer_type in pointer_types_to_add
-    ):
-        print(
-            f"No changes needed for {lookup_path}. These pointer types are already assigned."
-        )
+        if new_pointer_type in current_pointer_types
+    )
+    if len(already_added_types):
+        print(f"Error: These pointer types are already assigned to {lookup_path}:")
+        _print_perm_with_lookup("", already_added_types, TYPE_ATTRIBUTES)
+        print()
         return
 
     proposed_pointer_types = current_pointer_types + list(pointer_types_to_add)
+    print()
     _print_perm_with_lookup(
         "proposed pointer types", proposed_pointer_types, TYPE_ATTRIBUTES
     )
+
+    if COMPARE_AND_CONFIRM:
+        print()
+        confirm = (
+            input("Do you want to proceed with these changes? (yes/NO): ")
+            .strip()
+            .lower()
+        )
+        if confirm != "yes":
+            print("Operation cancelled at user request.")
+            return
+
     current_perms["types"] = proposed_pointer_types
 
     s3 = _get_s3_client()
@@ -329,7 +357,7 @@ def add_pointer_type_perms(
     )
 
     print()
-    print(f"Set permissions for lookup_path")
+    print(f"Set permissions for {lookup_path}")
 
     print()
     show_perms(supplier_type, app_id, org_ods)

--- a/scripts/manage_permissions.py
+++ b/scripts/manage_permissions.py
@@ -2,6 +2,7 @@
 """
 Manage app ans organisation v2 permissions for NRLF apps in a given environment ENV
 """
+import json
 import os
 from enum import Enum
 
@@ -63,6 +64,22 @@ def _list_s3_keys(file_key_prefix: str) -> list[str]:
     return keys
 
 
+def _get_perms_from_s3(file_key: str) -> str | None:
+    s3 = _get_s3_client()
+
+    try:
+        item = s3.get_object(Bucket=nrl_auth_bucket_name, Key=file_key)
+    except s3.exceptions.NoSuchKey:
+        print(f"Permissions file {file_key} does not exist in the bucket.")
+        return None
+
+    if "Body" not in item:
+        print(f"No body found for permissions file {file_key}.")
+        return None
+
+    return item["Body"].read().decode("utf-8")
+
+
 def list_apps(supplier_type: SupplierType) -> None:
     """
     List all consumer or producer applications in the NRL environment.
@@ -103,7 +120,6 @@ def list_orgs(supplier_type: SupplierType, app_id: str) -> None:
     """
     List all organizations for a specific consumer or producer application.
     """
-
     if supplier_type.lower() not in SupplierType.list():
         print("Usage: list organisations for a given app and supplier type")
         print("  list_orgs consumer <app_id>")
@@ -150,6 +166,77 @@ def list_available_access_controls() -> None:
         print(f"- {control}")
 
 
+def _print_perm(
+    perms_pretty: dict, lookup_path: str, perm_pretty_name: str, perm_key: str
+):
+    print()
+    access_controls = perms_pretty.get(perm_key, [])
+    if access_controls:
+        print(f"{lookup_path} has these {perm_pretty_name}s:")
+        for control in access_controls:
+            print(f"- {control}")
+    else:
+        print(f"{lookup_path} has no {perm_pretty_name}s")
+
+
+def show_perms(supplier_type: SupplierType, app_id: str, org_ods=None) -> None:
+    """
+    Show the permissions for a given application or organization.
+    """
+    if supplier_type.lower() not in SupplierType.list() or not app_id:
+        print("Usage: show permissions for a given organisation or app")
+        print("  show_perms consumer <app_id> <org_ods>")
+        print("  show_perms producer <app_id> <org_ods>")
+        print("  show_perms consumer <app_id>")
+        print("  show_perms producer <app_id>")
+        return
+
+    if org_ods:
+        lookup_path = f"{supplier_type}/{app_id}/{org_ods}.json"
+    else:
+        lookup_path = f"{supplier_type}/{app_id}.json"
+
+    perms_ugly = _get_perms_from_s3(lookup_path)
+
+    if not perms_ugly:
+        print(f"No permissions file found for {lookup_path}.")
+        return
+
+    perms_pretty = json.loads(perms_ugly)
+    if not perms_pretty:
+        print(f"No pointer-types found in permission file for {lookup_path}.")
+        return
+
+    pretty_type_data = {
+        pointertype_perm: TYPE_ATTRIBUTES.get(
+            pointertype_perm, {"display": "Unknown type"}
+        )
+        for pointertype_perm in perms_pretty.get("types")
+    }
+    types = [
+        "%-45s (%s)"
+        % (pretty_type_data[pointertype_perm]["display"][:44], pointertype_perm)
+        for pointertype_perm in perms_pretty.get("types")
+    ]
+    print(f"{lookup_path} is allowed to access these pointer-types:")
+    for type_display in types:
+        print(f"- {type_display}")
+
+    _print_perm(
+        perms_pretty,
+        lookup_path,
+        perm_pretty_name="access control",
+        perm_key="access_controls",
+    )
+
+    # _print_perm(
+    #     perms_pretty,
+    #     lookup_path,
+    #     perm_pretty_name="API interaction",
+    #     perm_key="interaction",
+    # )
+
+
 if __name__ == "__main__":
     fire.Fire(
         {
@@ -157,7 +244,7 @@ if __name__ == "__main__":
             "list_orgs": list_orgs,
             "list_available_pointer_types": list_available_pointer_types,
             "list_available_access_controls": list_available_access_controls,
-            # "show_perms": show_perms,
+            "show_perms": show_perms,
             # "set_perms": set_perms,
             # "clear_perms": clear_perms,
         }

--- a/scripts/manage_permissions.py
+++ b/scripts/manage_permissions.py
@@ -266,7 +266,76 @@ def show_perms(supplier_type: SupplierType, app_id: str, org_ods=None) -> None:
     # )
 
 
-def clear_perms(supplier_type, app_id: str, org_ods=None) -> None:
+def add_pointer_type_perms(
+    supplier_type: SupplierType, app_id: str, org_ods=None, *pointer_types_to_add: str
+) -> None:
+    # TODO:
+    # confirm before proceeding mode
+    # formatting help for pointer types ?
+    # highlight new additions in proposed pointer types list e.g. [NEW]
+    if supplier_type.lower() not in SupplierType.list() or not app_id:
+        print("Usage: add pointer type permissions for a given organisation or app")
+        print("  show_perms consumer <app_id> <org_ods> <pointer_types>")
+        print("  show_perms producer <app_id> <org_ods> <pointer_types>")
+        print("  show_perms consumer <app_id> <pointer_types>")
+        print("  show_perms producer <app_id> <pointer_types>")
+        return
+
+    if not pointer_types_to_add:
+        print(
+            "No pointer types provided. Please specify at least one pointer type or use clear_perms command."
+        )
+        return
+
+    if org_ods:
+        lookup_path = f"{supplier_type}/{app_id}/{org_ods}.json"
+    else:
+        lookup_path = f"{supplier_type}/{app_id}.json"
+
+    unknown_types = [pt for pt in pointer_types_to_add if pt not in TYPE_ATTRIBUTES]
+    if unknown_types:
+        print(f"Error: Unknown pointer types provided: {', '.join(unknown_types)}")
+        print()
+        return
+
+    perms_ugly = _get_perms_from_s3(lookup_path)
+    if not perms_ugly:
+        print(f"Setting up new permissions file...")
+        perms_ugly = "{}"
+
+    current_perms = json.loads(perms_ugly)
+    current_pointer_types: list = current_perms.get("types", [])
+    if all(
+        new_pointer_type in current_pointer_types
+        for new_pointer_type in pointer_types_to_add
+    ):
+        print(
+            f"No changes needed for {lookup_path}. These pointer types are already assigned."
+        )
+        return
+
+    proposed_pointer_types = current_pointer_types + list(pointer_types_to_add)
+    _print_perm_with_lookup(
+        "proposed pointer types", proposed_pointer_types, TYPE_ATTRIBUTES
+    )
+    current_perms["types"] = proposed_pointer_types
+
+    s3 = _get_s3_client()
+    s3.put_object(
+        Bucket=nrl_auth_bucket_name,
+        Key=lookup_path,
+        Body=json.dumps(current_perms, indent=4),
+        ContentType="application/json",
+    )
+
+    print()
+    print(f"Set permissions for lookup_path")
+
+    print()
+    show_perms(supplier_type, app_id, org_ods)
+
+
+def clear_perms(supplier_type: SupplierType, app_id: str, org_ods=None) -> None:
     """
     Clear permissions for an application or organization.
     This will remove all permissions for the specified app and org.
@@ -327,7 +396,7 @@ if __name__ == "__main__":
             "list_available_pointer_types": list_available_pointer_types,
             "list_available_access_controls": list_available_access_controls,
             "show_perms": show_perms,
-            # "set_perms": set_perms,
+            "add_pointer_type_to_perms": add_pointer_type_perms,
             "clear_perms": clear_perms,
             # "help": help,
         }

--- a/scripts/manage_permissions.py
+++ b/scripts/manage_permissions.py
@@ -141,7 +141,12 @@ def list_available_access_controls() -> None:
     """
     print("The following access controls can be assigned:")
 
-    for control in AccessControls.list():
+    currently_supported_access_controls = [
+        AccessControls.ALLOW_ALL_TYPES,
+        AccessControls.ALLOW_OVERRIDE_CREATION_DATETIME,
+        AccessControls.ALLOW_SUPERSEDE_WITH_DELETE_FAILURE,
+    ]
+    for control in currently_supported_access_controls:
         print(f"- {control}")
 
 

--- a/scripts/manage_permissions.py
+++ b/scripts/manage_permissions.py
@@ -27,6 +27,13 @@ COMPARE_AND_CONFIRM = (
     else os.getenv("COMPARE_AND_CONFIRM", "false").lower() == "true"
 )
 
+currently_supported_access_controls = [
+    AccessControls.ALLOW_ALL_TYPES,
+    AccessControls.ALLOW_OVERRIDE_CREATION_DATETIME,
+    AccessControls.ALLOW_SUPERSEDE_WITH_DELETE_FAILURE,
+]
+
+
 print(f"Using NRL environment: {nrl_env}")
 print(f"Using NRL auth bucket: {nrl_auth_bucket_name}")
 print(f"Compare and confirm mode: {COMPARE_AND_CONFIRM}")
@@ -162,11 +169,6 @@ def list_available_access_controls() -> None:
     """
     print("The following access controls can be assigned:")
 
-    currently_supported_access_controls = [
-        AccessControls.ALLOW_ALL_TYPES,
-        AccessControls.ALLOW_OVERRIDE_CREATION_DATETIME,
-        AccessControls.ALLOW_SUPERSEDE_WITH_DELETE_FAILURE,
-    ]
     for control in currently_supported_access_controls:
         print(f"- {control}")
 
@@ -269,6 +271,47 @@ def show_perms(supplier_type: SupplierType, app_id: str, org_ods=None) -> None:
     # )
 
 
+def _save_pointer_types(
+    lookup_path: str,
+    current_perms: dict,
+    proposed_pointer_types: list,
+    supplier_type: SupplierType,
+    app_id: str,
+    org_ods,
+) -> None:
+    print()
+    _print_perm_with_lookup(
+        "proposed pointer types", proposed_pointer_types, TYPE_ATTRIBUTES
+    )
+
+    if COMPARE_AND_CONFIRM:
+        print()
+        confirm = (
+            input("Do you want to proceed with these changes? (yes/NO): ")
+            .strip()
+            .lower()
+        )
+        if confirm != "yes":
+            print("Operation cancelled at user request.")
+            return
+
+    current_perms["types"] = proposed_pointer_types
+
+    s3 = _get_s3_client()
+    s3.put_object(
+        Bucket=nrl_auth_bucket_name,
+        Key=lookup_path,
+        Body=json.dumps(current_perms, indent=4),
+        ContentType="application/json",
+    )
+
+    print()
+    print(f"Set permissions for {lookup_path}")
+
+    print()
+    show_perms(supplier_type, app_id, org_ods)
+
+
 def add_pointer_type_perms(
     supplier_type: SupplierType, app_id: str, org_ods=None, *pointer_types_to_add: str
 ) -> None:
@@ -279,7 +322,6 @@ def add_pointer_type_perms(
 
     TODO:
     highlight new additions in proposed pointer types list e.g. [NEW]
-    don't create at app level if ODS level present & backwards too? - hmm maybe too fancy
     """
     if supplier_type.lower() not in SupplierType.list() or not app_id:
         print("Usage: add pointer type permissions for a given organisation or app")
@@ -290,9 +332,7 @@ def add_pointer_type_perms(
         return
 
     if not pointer_types_to_add:
-        print(
-            "No pointer types provided. Please specify at least one pointer type or use clear_perms command."
-        )
+        print("No pointer types provided. Please specify at least one pointer type.")
         return
 
     if org_ods:
@@ -332,10 +372,90 @@ def add_pointer_type_perms(
         return
 
     proposed_pointer_types = current_pointer_types + list(pointer_types_to_add)
-    print()
-    _print_perm_with_lookup(
-        "proposed pointer types", proposed_pointer_types, TYPE_ATTRIBUTES
+    _save_pointer_types(
+        lookup_path,
+        current_perms,
+        proposed_pointer_types,
+        supplier_type,
+        app_id,
+        org_ods,
     )
+
+
+def add_access_control_perms(
+    supplier_type: SupplierType, app_id: str, org_ods=None, *access_controls_to_add: str
+) -> None:
+    """
+    Add permissions for a given list of access controls to an app or org.
+
+    Specify access_controls = all to add a list of all (current) access controls.
+
+    TODO:
+    highlight new additions in proposed access controls list e.g. [NEW]
+    """
+    if supplier_type.lower() not in SupplierType.list() or not app_id:
+        print("Usage: add access control permissions for a given organisation or app")
+        print(
+            "  add_access_control_perms consumer <app_id> <org_ods> <access_controls>"
+        )
+        print(
+            "  add_access_control_perms producer <app_id> <org_ods> <access_controls>"
+        )
+        print("  add_access_control_perms consumer <app_id> <access_controls>")
+        print("  add_access_control_perms producer <app_id> <access_controls>")
+        return
+
+    if not access_controls_to_add:
+        print(
+            "No access controls provided. Please specify at least one access control."
+        )
+        return
+
+    if org_ods:
+        lookup_path = f"{supplier_type}/{app_id}/{org_ods}.json"
+    else:
+        lookup_path = f"{supplier_type}/{app_id}.json"
+
+    unknown_access_controls = [
+        pt
+        for pt in access_controls_to_add
+        if pt not in currently_supported_access_controls
+    ]
+    if unknown_access_controls:
+        print(
+            f"Error: Unknown or unsupported access controls provided: {', '.join(unknown_access_controls)}"
+        )
+        print(
+            f"Error: Unknown or unsupported access controls provided: {', '.join(unknown_access_controls)}"
+        )
+        print()
+        return
+
+    perms_ugly = _get_perms_from_s3(lookup_path)
+    if not perms_ugly:
+        print(f"Setting up new permissions file...")
+        perms_ugly = "{}"
+
+    current_perms = json.loads(perms_ugly)
+    current_access_controls: list = current_perms.get("access_controls", [])
+
+    already_added_access_controls = list(
+        new_access_control
+        for new_access_control in access_controls_to_add
+        if new_access_control in current_access_controls
+    )
+    if len(already_added_access_controls):
+        print(
+            f"Error: Unable to add access controls. These access controls are already assigned to {lookup_path}:"
+        )
+        _print_perm("", already_added_access_controls)
+        print()
+        return
+
+    proposed_access_controls = current_access_controls + list(access_controls_to_add)
+
+    print()
+    _print_perm("proposed access controls", proposed_access_controls)
 
     if COMPARE_AND_CONFIRM:
         print()
@@ -348,7 +468,7 @@ def add_pointer_type_perms(
             print("Operation cancelled at user request.")
             return
 
-    current_perms["types"] = proposed_pointer_types
+    current_perms["access_controls"] = proposed_access_controls
 
     s3 = _get_s3_client()
     s3.put_object(
@@ -425,37 +545,14 @@ def remove_pointer_type_perms(
         for current_pointer_type in current_pointer_types
         if current_pointer_type not in pointer_types_to_remove
     ]
-    print()
-    _print_perm_with_lookup(
-        "proposed pointer types", proposed_pointer_types, TYPE_ATTRIBUTES
+    _save_pointer_types(
+        lookup_path,
+        current_perms,
+        proposed_pointer_types,
+        supplier_type,
+        app_id,
+        org_ods,
     )
-
-    if COMPARE_AND_CONFIRM:
-        print()
-        confirm = (
-            input("Do you want to proceed with these changes? (yes/NO): ")
-            .strip()
-            .lower()
-        )
-        if confirm != "yes":
-            print("Operation cancelled at user request.")
-            return
-
-    current_perms["types"] = proposed_pointer_types
-
-    s3 = _get_s3_client()
-    s3.put_object(
-        Bucket=nrl_auth_bucket_name,
-        Key=lookup_path,
-        Body=json.dumps(current_perms, indent=4),
-        ContentType="application/json",
-    )
-
-    print()
-    print(f"Set permissions for {lookup_path}")
-
-    print()
-    show_perms(supplier_type, app_id, org_ods)
 
 
 def clear_perms(supplier_type: SupplierType, app_id: str, org_ods=None) -> None:
@@ -520,6 +617,7 @@ if __name__ == "__main__":
             "list_available_access_controls": list_available_access_controls,
             "show_perms": show_perms,
             "add_pointer_type_to_perms": add_pointer_type_perms,
+            "add_access_control_to_perms": add_access_control_perms,
             "remove_pointer_type_perms": remove_pointer_type_perms,
             "clear_perms": clear_perms,
             # "help": help,

--- a/scripts/manage_permissions.py
+++ b/scripts/manage_permissions.py
@@ -273,11 +273,11 @@ def add_pointer_type_perms(
     supplier_type: SupplierType, app_id: str, org_ods=None, *pointer_types_to_add: str
 ) -> None:
     """
+    Add permissions for a given list of pointer types to an app or org.
+
+    Specify pointer_types = all to add a list of all (current) pointer types.
+
     TODO:
-    confirm before proceeding mode
-    formatting help for pointer types ?
-    validate not adding a duplicate type
-    add list of all pointer types vs adding access control
     highlight new additions in proposed pointer types list e.g. [NEW]
     don't create at app level if ODS level present & backwards too? - hmm maybe too fancy
     """
@@ -324,12 +324,107 @@ def add_pointer_type_perms(
         if new_pointer_type in current_pointer_types
     )
     if len(already_added_types):
-        print(f"Error: These pointer types are already assigned to {lookup_path}:")
+        print(
+            f"Error: Unable to add pointer types. These pointer types are already assigned to {lookup_path}:"
+        )
         _print_perm_with_lookup("", already_added_types, TYPE_ATTRIBUTES)
         print()
         return
 
     proposed_pointer_types = current_pointer_types + list(pointer_types_to_add)
+    print()
+    _print_perm_with_lookup(
+        "proposed pointer types", proposed_pointer_types, TYPE_ATTRIBUTES
+    )
+
+    if COMPARE_AND_CONFIRM:
+        print()
+        confirm = (
+            input("Do you want to proceed with these changes? (yes/NO): ")
+            .strip()
+            .lower()
+        )
+        if confirm != "yes":
+            print("Operation cancelled at user request.")
+            return
+
+    current_perms["types"] = proposed_pointer_types
+
+    s3 = _get_s3_client()
+    s3.put_object(
+        Bucket=nrl_auth_bucket_name,
+        Key=lookup_path,
+        Body=json.dumps(current_perms, indent=4),
+        ContentType="application/json",
+    )
+
+    print()
+    print(f"Set permissions for {lookup_path}")
+
+    print()
+    show_perms(supplier_type, app_id, org_ods)
+
+
+def remove_pointer_type_perms(
+    supplier_type: SupplierType,
+    app_id: str,
+    org_ods=None,
+    *pointer_types_to_remove: str,
+) -> None:
+    """
+    Remove a list of pointer type permissions for a given app or org.
+    """
+    if supplier_type.lower() not in SupplierType.list() or not app_id:
+        print("Usage: remove pointer type permissions for a given organisation or app")
+        print("  remove_pointer_type_perms consumer <app_id> <org_ods> <pointer_types>")
+        print("  remove_pointer_type_perms producer <app_id> <org_ods> <pointer_types>")
+        print("  remove_pointer_type_perms consumer <app_id> <pointer_types>")
+        print("  remove_pointer_type_perms producer <app_id> <pointer_types>")
+        return
+
+    if not pointer_types_to_remove:
+        print(
+            "No pointer types provided. Please specify at least one pointer type or use clear_perms command."
+        )
+        return
+
+    if org_ods:
+        lookup_path = f"{supplier_type}/{app_id}/{org_ods}.json"
+    else:
+        lookup_path = f"{supplier_type}/{app_id}.json"
+
+    unknown_types = [pt for pt in pointer_types_to_remove if pt not in TYPE_ATTRIBUTES]
+    if unknown_types:
+        print(f"Error: Unknown pointer types provided: {', '.join(unknown_types)}")
+        print()
+        return
+
+    perms_ugly = _get_perms_from_s3(lookup_path)
+    if not perms_ugly:
+        return
+
+    current_perms = json.loads(perms_ugly)
+    current_pointer_types: list = current_perms.get("types", [])
+
+    # Cannot remove pointer types not already assigned
+    types_not_assigned = list(
+        type_to_remove
+        for type_to_remove in pointer_types_to_remove
+        if type_to_remove not in current_pointer_types
+    )
+    if len(types_not_assigned):
+        print(
+            f"Error: Unable to remove pointer types. These pointer types aren't assigned to {lookup_path}:"
+        )
+        _print_perm_with_lookup("", types_not_assigned, TYPE_ATTRIBUTES)
+        print()
+        return
+
+    proposed_pointer_types = [
+        current_pointer_type
+        for current_pointer_type in current_pointer_types
+        if current_pointer_type not in pointer_types_to_remove
+    ]
     print()
     _print_perm_with_lookup(
         "proposed pointer types", proposed_pointer_types, TYPE_ATTRIBUTES
@@ -425,6 +520,7 @@ if __name__ == "__main__":
             "list_available_access_controls": list_available_access_controls,
             "show_perms": show_perms,
             "add_pointer_type_to_perms": add_pointer_type_perms,
+            "remove_pointer_type_perms": remove_pointer_type_perms,
             "clear_perms": clear_perms,
             # "help": help,
         }

--- a/scripts/manage_permissions.py
+++ b/scripts/manage_permissions.py
@@ -205,8 +205,8 @@ def list_apps(supplier_type: SupplierType) -> None:
         return
 
     def there_are_x_apps(app_count: int):
-        is_are = "is" if app_count is 1 else "are"
-        s = "" if app_count is 1 else "s"
+        is_are = "is" if app_count == 1 else "are"
+        s = "" if app_count == 1 else "s"
         return f"There {is_are} {app_count} app{s}"
 
     print(f"{there_are_x_apps(len(apps))} in the {nrl_env} env")

--- a/scripts/manage_permissions_v1.py
+++ b/scripts/manage_permissions_v1.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python
+"""
+Manage organisation pointer type permissions for NRLF apps in a given environment ENV
+"""
+
+import json
+import os
+
+import fire
+from aws_session_assume import get_boto_session
+
+from nrlf.core.constants import TYPE_ATTRIBUTES
+
+nrl_env = os.getenv("ENV", "dev")
+nrl_auth_bucket_name = os.getenv(
+    "NRL_AUTH_BUCKET_NAME", f"nhsd-nrlf--{nrl_env}-authorization-store"
+)
+
+COMPARE_AND_CONFIRM = (
+    True
+    if nrl_env == "prod"
+    else os.getenv("COMPARE_AND_CONFIRM", "false").lower() == "true"
+)
+
+print(f"Using NRL environment: {nrl_env}")
+print(f"Using NRL auth bucket: {nrl_auth_bucket_name}")
+print(f"Compare and confirm mode: {COMPARE_AND_CONFIRM}")
+print()
+
+
+def _get_s3_client():
+    boto_session = get_boto_session(nrl_env)
+    return boto_session.client("s3")
+
+
+def _list_s3_keys(file_key_prefix: str) -> list[str]:
+    s3 = _get_s3_client()
+    paginator = s3.get_paginator("list_objects_v2")
+
+    params = {
+        "Bucket": nrl_auth_bucket_name,
+        "Prefix": file_key_prefix,
+    }
+
+    page_iterator = paginator.paginate(**params)
+    keys: list[str] = []
+    for page in page_iterator:
+        if "Contents" in page:
+            keys.extend([item["Key"] for item in page["Contents"]])
+
+    if not keys:
+        print(f"No files found with prefix: {file_key_prefix}")
+        return []
+
+    return keys
+
+
+def _get_perms_from_s3(file_key: str) -> str | None:
+    s3 = _get_s3_client()
+
+    try:
+        item = s3.get_object(Bucket=nrl_auth_bucket_name, Key=file_key)
+    except s3.exceptions.NoSuchKey:
+        print(f"Permissions file {file_key} does not exist in the bucket.")
+        return None
+
+    if "Body" not in item:
+        print(f"No body found for permissions file {file_key}.")
+        return None
+
+    return item["Body"].read().decode("utf-8")
+
+
+def list_apps() -> None:
+    """
+    List all applications in the NRL environment.
+    """
+    keys = _list_s3_keys("")
+    apps = {key.split("/")[0] for key in keys}
+
+    if not apps:
+        print("No applications found in the bucket.")
+        return
+
+    print(f"There are {len(apps)} apps in {nrl_env} env:")
+    for app in apps:
+        print(f"- {app}")
+
+
+def list_orgs(app_id: str) -> None:
+    """
+    List all organizations for a specific application.
+    """
+    keys = _list_s3_keys(f"{app_id}/")
+    orgs = [
+        key.split("/", maxsplit=2)[1].removesuffix(".json")
+        for key in keys
+        if key and key.endswith(".json")
+    ]
+
+    if not orgs:
+        print(f"No organizations found for app {app_id}.")
+
+    print(f"There are {len(orgs)} organizations for app {app_id}:")
+    for org in orgs:
+        print(f"- {org}")
+
+
+def list_available_types() -> None:
+    """
+    List all pointer types that can be used in permissions.
+    """
+    print("The following pointer-types can be assigned:")
+
+    for pointer_type, attributes in TYPE_ATTRIBUTES.items():
+        print("- %-45s (%s)" % (pointer_type, attributes["display"][:45]))
+
+
+def show_perms(app_id: str, org_ods: str) -> None:
+    """
+    Show the permissions for a specific application and organization.
+    """
+    perms = _get_perms_from_s3(f"{app_id}/{org_ods}.json")
+
+    if not perms:
+        print(f"No permissions file found for {app_id}/{org_ods}.")
+        return
+
+    pointertype_perms = json.loads(perms)
+    if not pointertype_perms:
+        print(f"No pointer-types found in permission file for {app_id}/{org_ods}.")
+        return
+
+    type_data = {
+        pointertype_perm: TYPE_ATTRIBUTES.get(
+            pointertype_perm, {"display": "Unknown type"}
+        )
+        for pointertype_perm in pointertype_perms
+    }
+    types = [
+        "%-45s (%s)" % (type_data[pointertype_perm]["display"][:44], pointertype_perm)
+        for pointertype_perm in pointertype_perms
+    ]
+
+    print(f"{app_id}/{org_ods} is allowed to access these pointer-types:")
+    for type_display in types:
+        print(f"- {type_display}")
+
+
+def set_perms(app_id: str, org_ods: str, *pointer_types: str) -> None:
+    """
+    Set permissions for an application and organization to access specific pointer types.
+    """
+    if not pointer_types:
+        print(
+            "No pointer types provided. Please specify at least one pointer type or use clear_perms command."
+        )
+        return
+
+    if len(pointer_types) == 1 and pointer_types[0] == "all":
+        print("Setting permissions for access to all pointer types.")
+        pointer_types = tuple(TYPE_ATTRIBUTES.keys())
+
+    unknown_types = [pt for pt in pointer_types if pt not in TYPE_ATTRIBUTES]
+    if unknown_types:
+        print(f"Error: Unknown pointer types provided: {', '.join(unknown_types)}")
+        print()
+        return
+
+    permissions_content = json.dumps(pointer_types, indent=4)
+
+    if COMPARE_AND_CONFIRM:
+        current_perms = _get_perms_from_s3(f"{app_id}/{org_ods}.json")
+        if current_perms == permissions_content:
+            print(
+                f"No changes needed for {app_id}/{org_ods}. Current permissions match the new ones."
+            )
+            return
+
+        print()
+        print(f"Current permissions for {app_id}/{org_ods}:")
+        print(current_perms if current_perms else "No permissions set.")
+
+        print()
+        print("New permissions to be set to:")
+        print(f"{permissions_content}")
+
+        print()
+        confirm = (
+            input("Do you want to proceed with these changes? (yes/NO): ")
+            .strip()
+            .lower()
+        )
+        if confirm != "yes":
+            print("Operation cancelled at user request.")
+            return
+
+    s3 = _get_s3_client()
+    s3.put_object(
+        Bucket=nrl_auth_bucket_name,
+        Key=f"{app_id}/{org_ods}.json",
+        Body=permissions_content,
+        ContentType="application/json",
+    )
+
+    print()
+    print(f"Set permissions for {app_id}/{org_ods}")
+
+    print()
+    show_perms(app_id, org_ods)
+
+
+def clear_perms(app_id: str, org_ods: str) -> None:
+    """
+    Clear permissions for an application and organization.
+    This will remove all permissions for the specified app and org.
+    """
+    if COMPARE_AND_CONFIRM:
+        current_perms = _get_perms_from_s3(f"{app_id}/{org_ods}.json")
+        if not current_perms or current_perms == "[]":
+            print(
+                f"No need to clear permissions for {app_id}/{org_ods} as it currently has no permissions set."
+            )
+            return
+
+        print()
+        print(f"Current permissions for {app_id}/{org_ods}:")
+        print(current_perms)
+
+        print()
+        confirm = (
+            input("Are you SURE you want to clear these permissions? (yes/NO): ")
+            .strip()
+            .lower()
+        )
+        if confirm != "yes":
+            print("Operation cancelled at user request.")
+            return
+
+    s3 = _get_s3_client()
+    s3.put_object(
+        Bucket=nrl_auth_bucket_name,
+        Key=f"{app_id}/{org_ods}.json",
+        Body="[]",
+        ContentType="application/json",
+    )
+    print(f"Cleared permissions for {app_id}/{org_ods}.")
+
+
+if __name__ == "__main__":
+    fire.Fire(
+        {
+            "list_apps": list_apps,
+            "list_orgs": list_orgs,
+            "list_allowed_types": list_allowed_types,
+            "show_perms": show_perms,
+            "set_perms": set_perms,
+            "clear_perms": clear_perms,
+        }
+    )

--- a/scripts/manage_permissions_v1.py
+++ b/scripts/manage_permissions_v1.py
@@ -252,7 +252,7 @@ if __name__ == "__main__":
         {
             "list_apps": list_apps,
             "list_orgs": list_orgs,
-            "list_allowed_types": list_allowed_types,
+            "list_available_types": list_available_types,
             "show_perms": show_perms,
             "set_perms": set_perms,
             "clear_perms": clear_perms,

--- a/scripts/tests/test_manage_permissions.py
+++ b/scripts/tests/test_manage_permissions.py
@@ -1,0 +1,434 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from manage_permissions import (
+    add_perm,
+    clear_perms,
+    list_apps,
+    list_orgs,
+    remove_perm,
+    show_perms,
+)
+
+from nrlf.core.constants import AccessControls, PointerTypes
+
+MODULE = "manage_permissions"
+
+APP_ID = "test-app-001"
+ORG_ODS = "X26"
+BUCKET = "nhsd-nrlf--dev-authorization-store"
+
+SAMPLE_POINTER_TYPES = [
+    PointerTypes.MENTAL_HEALTH_PLAN.value,
+    PointerTypes.ADVANCE_CARE_PLAN.value,
+]
+SAMPLE_ACCESS_CONTROLS = [
+    AccessControls.ALLOW_ALL_TYPES.value,
+    AccessControls.ALLOW_OVERRIDE_CREATION_DATETIME.value,
+]
+
+_NoSuchKey = type("NoSuchKey", (Exception,), {})
+
+
+def _make_s3_mock(
+    body: bytes | None = None, raise_no_such_key: bool = False
+) -> MagicMock:
+    s3 = MagicMock()
+    s3.exceptions.NoSuchKey = _NoSuchKey
+    if raise_no_such_key:
+        s3.get_object.side_effect = _NoSuchKey("key not found")
+    elif body is not None:
+        import io
+
+        s3.get_object.return_value = {"Body": io.BytesIO(body)}
+    return s3
+
+
+def _make_paginator(pages: list[dict]) -> MagicMock:
+    paginator = MagicMock()
+    paginator.paginate.return_value = pages
+    return paginator
+
+
+# ---------------------------------------------------------------------------
+# show_perms
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{MODULE}._get_s3_client")
+def test_show_perms_prints_all_permissions(mock_get_s3, capsys):
+    existing_perms = {
+        "types": SAMPLE_POINTER_TYPES,
+        "access_controls": SAMPLE_ACCESS_CONTROLS,
+    }
+    mock_get_s3.return_value = _make_s3_mock(body=json.dumps(existing_perms).encode())
+
+    show_perms("consumer", APP_ID, ORG_ODS)
+
+    output = capsys.readouterr().out
+    for pointer_type in SAMPLE_POINTER_TYPES:
+        assert pointer_type in output
+    for control in SAMPLE_ACCESS_CONTROLS:
+        assert control in output
+
+
+@patch(f"{MODULE}._get_s3_client")
+def test_show_perms_prints_no_file_message_when_missing(mock_get_s3, capsys):
+    s3 = _make_s3_mock(raise_no_such_key=True)
+    mock_get_s3.return_value = s3
+
+    show_perms("consumer", APP_ID, ORG_ODS)
+
+    assert "No permissions file found" in capsys.readouterr().out
+
+
+@patch(f"{MODULE}._get_s3_client")
+def test_show_perms_prints_no_perms_message_when_empty_json(mock_get_s3, capsys):
+    perms = {}
+    s3 = _make_s3_mock(body=json.dumps(perms).encode())
+    mock_get_s3.return_value = s3
+
+    show_perms("producer", APP_ID, ORG_ODS)
+
+    assert "No permissions found" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# add_perm
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{MODULE}._get_s3_client")
+def test_add_perm_adds_new_type(mock_get_s3):
+    existing_perms = {"types": [SAMPLE_POINTER_TYPES[0]]}
+    s3 = _make_s3_mock(body=json.dumps(existing_perms).encode())
+    mock_get_s3.return_value = s3
+
+    add_perm("types", "producer", APP_ID, None, SAMPLE_POINTER_TYPES[1])
+
+    s3.put_object.assert_called_once_with(
+        Bucket=BUCKET,
+        Key=f"producer/{APP_ID}.json",
+        Body=json.dumps({"types": SAMPLE_POINTER_TYPES}, indent=4),
+        ContentType="application/json",
+    )
+
+
+@patch(f"{MODULE}._get_s3_client")
+def test_add_perm_all_keyword_adds_all_types(mock_get_s3):
+    existing_perms = {}
+    s3 = _make_s3_mock(body=json.dumps(existing_perms).encode())
+    mock_get_s3.return_value = s3
+
+    add_perm("types", "consumer", APP_ID, ORG_ODS, "all")
+
+    s3.put_object.assert_called_once_with(
+        Bucket=BUCKET,
+        Key=f"consumer/{APP_ID}/{ORG_ODS}.json",
+        Body=json.dumps({"types": PointerTypes.list()}, indent=4),
+        ContentType="application/json",
+    )
+
+
+@patch(f"{MODULE}._get_s3_client")
+@patch(f"{MODULE}.COMPARE_AND_CONFIRM", True)
+@patch("builtins.input", return_value="yes")
+def test_add_perm_adds_access_control(mock_input, mock_get_s3):
+    existing_perms = {}
+    s3 = _make_s3_mock(body=json.dumps(existing_perms).encode())
+    mock_get_s3.return_value = s3
+
+    add_perm(
+        "access_controls",
+        "producer",
+        APP_ID,
+        None,
+        AccessControls.ALLOW_ALL_TYPES.value,
+    )
+
+    s3.put_object.assert_called_once_with(
+        Bucket=BUCKET,
+        Key=f"producer/{APP_ID}.json",
+        Body=json.dumps(
+            {"access_controls": [AccessControls.ALLOW_ALL_TYPES.value]}, indent=4
+        ),
+        ContentType="application/json",
+    )
+
+
+@patch(f"{MODULE}._get_s3_client")
+def test_add_perm_rejects_already_assigned_items(mock_get_s3, capsys):
+    existing_perms = {"types": SAMPLE_POINTER_TYPES}
+    mock_get_s3.return_value = _make_s3_mock(body=json.dumps(existing_perms).encode())
+
+    add_perm("types", "consumer", APP_ID, None, SAMPLE_POINTER_TYPES[0])
+
+    assert "already assigned" in capsys.readouterr().out
+
+
+@patch(f"{MODULE}._get_s3_client")
+@patch(f"{MODULE}.COMPARE_AND_CONFIRM", True)
+@patch("builtins.input", return_value="no")
+def test_add_perm_cancelled_by_user_does_not_save(mock_input, mock_get_s3):
+    existing_perms = {}
+    s3 = _make_s3_mock(body=json.dumps(existing_perms).encode())
+    mock_get_s3.return_value = s3
+
+    add_perm("types", "consumer", APP_ID, None, SAMPLE_POINTER_TYPES[0])
+
+    s3.put_object.assert_not_called()
+
+
+def test_add_perm_rejects_invalid_permission_key(capsys):
+    add_perm("invalid_key", "consumer", APP_ID, None, SAMPLE_POINTER_TYPES[0])
+
+    assert "invalid permission" in capsys.readouterr().out.lower()
+
+
+def test_add_perm_rejects_no_items(capsys):
+    add_perm("types", "producer", APP_ID, ORG_ODS)
+
+    assert "No pointer types provided" in capsys.readouterr().out
+
+
+def test_add_perm_rejects_unknown_items(capsys):
+    add_perm("types", "consumer", APP_ID, None, "http://unknown.example.com|999")
+
+    assert "Unknown pointer types provided" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# remove_perm
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{MODULE}._get_s3_client")
+def test_remove_perm_removes_type(mock_get_s3):
+    existing_perms = {"types": SAMPLE_POINTER_TYPES}
+    s3 = _make_s3_mock(body=json.dumps(existing_perms).encode())
+    mock_get_s3.return_value = s3
+
+    type_to_remove = SAMPLE_POINTER_TYPES[0]
+
+    remove_perm("types", "consumer", APP_ID, ORG_ODS, type_to_remove)
+
+    saved_perms = s3.put_object.call_args[1]["Body"]
+    assert type_to_remove not in saved_perms
+    assert SAMPLE_POINTER_TYPES[1] in saved_perms
+
+
+@patch(f"{MODULE}._get_s3_client")
+def test_remove_perm_removes_access_control(mock_get_s3):
+    existing_perms = {"access_controls": SAMPLE_ACCESS_CONTROLS}
+    s3 = _make_s3_mock(body=json.dumps(existing_perms).encode())
+    mock_get_s3.return_value = s3
+
+    control_to_remove = SAMPLE_ACCESS_CONTROLS[0]
+
+    remove_perm("access_controls", "producer", APP_ID, None, control_to_remove)
+
+    saved_perms = s3.put_object.call_args[1]["Body"]
+    assert control_to_remove not in saved_perms
+    assert SAMPLE_ACCESS_CONTROLS[1] in saved_perms
+
+
+@patch(f"{MODULE}._get_s3_client")
+def test_remove_perm_rejects_items_not_currently_assigned(mock_get_s3, capsys):
+    existing_perms = {"types": [SAMPLE_POINTER_TYPES[0]]}
+    mock_get_s3.return_value = _make_s3_mock(body=json.dumps(existing_perms).encode())
+
+    remove_perm("types", "consumer", APP_ID, None, SAMPLE_POINTER_TYPES[1])
+
+    assert "aren't assigned" in capsys.readouterr().out
+
+
+@patch(f"{MODULE}._get_s3_client")
+def test_remove_perm_returns_early_if_no_perms_file(mock_get_s3, capsys):
+    mock_get_s3.return_value = _make_s3_mock(raise_no_such_key=True)
+
+    remove_perm("types", "consumer", APP_ID, ORG_ODS, SAMPLE_POINTER_TYPES[0])
+
+    assert "does not exist" in capsys.readouterr().out
+
+
+@patch(f"{MODULE}._get_s3_client")
+@patch(f"{MODULE}.COMPARE_AND_CONFIRM", True)
+@patch("builtins.input", return_value="no")
+def test_remove_perm_cancelled_by_user_does_not_save(mock_input, mock_get_s3):
+    existing_perms = {"types": SAMPLE_POINTER_TYPES}
+    s3 = _make_s3_mock(body=json.dumps(existing_perms).encode())
+    mock_get_s3.return_value = s3
+
+    remove_perm("types", "consumer", APP_ID, None, SAMPLE_POINTER_TYPES[0])
+
+    mock_get_s3.put_object.assert_not_called()
+
+
+def test_remove_perm_rejects_invalid_permission_key(capsys):
+    remove_perm("invalid_key", "consumer", APP_ID, None, SAMPLE_POINTER_TYPES[0])
+
+    assert "invalid permission" in capsys.readouterr().out.lower()
+
+
+def test_remove_perm_rejects_no_items(capsys):
+    remove_perm("types", "producer", APP_ID)
+
+    assert "No pointer types provided" in capsys.readouterr().out
+
+
+def test_remove_perm_rejects_unknown_items(capsys):
+    remove_perm("types", "consumer", APP_ID, ORG_ODS, "http://unknown.example.com|999")
+
+    assert "Unknown pointer types provided" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# clear_perms
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{MODULE}._get_s3_client")
+def test_clear_perms_saves_empty_dict(mock_get_s3):
+    existing_perms = {
+        "types": SAMPLE_POINTER_TYPES,
+        "access_controls": SAMPLE_ACCESS_CONTROLS,
+    }
+    s3 = _make_s3_mock(body=json.dumps(existing_perms).encode())
+    mock_get_s3.return_value = s3
+
+    clear_perms("consumer", APP_ID)
+
+    saved_perms = s3.put_object.call_args[1]["Body"]
+    assert saved_perms == "{}"
+
+
+@patch(f"{MODULE}._get_s3_client")
+@patch(f"{MODULE}.COMPARE_AND_CONFIRM", True)
+@patch("builtins.input", return_value="no")
+def test_clear_perms_cancelled_by_user_does_not_save(mock_input, mock_get_s3):
+    existing_perms = {"types": SAMPLE_POINTER_TYPES}
+    s3 = _make_s3_mock(body=json.dumps(existing_perms).encode())
+    mock_get_s3.return_value = s3
+
+    clear_perms("consumer", APP_ID)
+
+    s3.put_object.assert_not_called()
+
+
+@patch(f"{MODULE}._get_s3_client")
+def test_clear_perms_skips_when_no_perms_exist(mock_get_s3, capsys):
+    mock_get_s3.return_value = _make_s3_mock(raise_no_such_key=True)
+
+    clear_perms("consumer", APP_ID)
+
+    assert "no permissions" in capsys.readouterr().out.lower()
+
+
+@patch(f"{MODULE}._get_s3_client")
+def test_clear_perms_skips_when_perms_is_empty_json(mock_get_s3, capsys):
+    mock_get_s3.return_value = _make_s3_mock(body=json.dumps({}).encode())
+
+    clear_perms("producer", APP_ID, ORG_ODS)
+
+    assert "no permissions" in capsys.readouterr().out.lower()
+
+
+# ---------------------------------------------------------------------------
+# list_apps
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{MODULE}._get_s3_client")
+def test_list_apps_groups_app_level_and_org_level(mock_get_s3, capsys):
+    s3 = MagicMock()
+    mock_get_s3.return_value = s3
+    # Simulate: first key is the folder itself, then org-level and app-level perms
+    s3.get_paginator.return_value = _make_paginator(
+        [
+            {
+                "Contents": [
+                    {"Key": "consumer/"},
+                    {"Key": "consumer/app-with-org-perms/"},
+                    {"Key": "consumer/app-with-only-app-perms.json"},
+                ]
+            },
+        ]
+    )
+
+    list_apps("consumer")
+
+    output = capsys.readouterr().out
+    assert "org-level permissions:\n- app-with-org-perms" in output
+    assert "app-level permissions:\n- app-with-only-app-perms" in output
+
+
+@patch(f"{MODULE}._get_s3_client")
+def test_list_apps_no_apps_found(mock_get_s3, capsys):
+    s3 = MagicMock()
+    mock_get_s3.return_value = s3
+    s3.get_paginator.return_value = _make_paginator([{}])
+
+    list_apps("consumer")
+
+    output = capsys.readouterr().out
+    assert "No applications found" in output
+
+
+@patch(f"{MODULE}._get_s3_client")
+def test_list_apps_invalid_supplier_type_prints_error(mock_get_s3, capsys):
+    list_apps("invalid")
+
+    mock_get_s3.assert_not_called()
+    assert "invalid supplier" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# list_orgs
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{MODULE}._get_s3_client")
+def test_list_orgs_invalid_supplier_prints_error(mock_get_s3, capsys):
+    list_orgs("invalid", APP_ID)
+
+    mock_get_s3.assert_not_called()
+    assert "invalid supplier" in capsys.readouterr().out
+
+
+@patch(f"{MODULE}._get_s3_client")
+def test_list_orgs_no_orgs_found(mock_get_s3, capsys):
+    s3 = MagicMock()
+    mock_get_s3.return_value = s3
+    s3.get_paginator.return_value = _make_paginator([{}])
+
+    list_orgs("producer", APP_ID)
+
+    assert "No organizations found" in capsys.readouterr().out
+
+
+@patch(f"{MODULE}._get_s3_client")
+def test_list_orgs_lists_org_codes(mock_get_s3, capsys):
+    s3 = MagicMock()
+    mock_get_s3.return_value = s3
+    # Simulate: first key is the folder itself, then org-level and app-level perms
+    s3.get_paginator.return_value = _make_paginator(
+        [
+            {
+                "Contents": [
+                    {"Key": "producer/"},
+                    {
+                        "Key": f"producer/{APP_ID}/X26.json",
+                    },
+                    {
+                        "Key": f"producer/{APP_ID}/Y27.json",
+                    },
+                ]
+            },
+        ]
+    )
+
+    list_orgs("producer", APP_ID)
+
+    output = capsys.readouterr().out
+    assert "There are 2 organizations for app test-app-001:\n- X26\n- Y27" in output

--- a/scripts/tests/test_manage_permissions.py
+++ b/scripts/tests/test_manage_permissions.py
@@ -189,7 +189,7 @@ def test_add_perm_rejects_invalid_permission_key(capsys):
 def test_add_perm_rejects_no_items(capsys):
     add_perm("types", "producer", APP_ID, ORG_ODS)
 
-    assert "No pointer types provided" in capsys.readouterr().out
+    assert "no pointer types provided" in capsys.readouterr().out
 
 
 def test_add_perm_rejects_unknown_items(capsys):

--- a/scripts/tests/test_manage_permissions.py
+++ b/scripts/tests/test_manage_permissions.py
@@ -234,13 +234,43 @@ def test_remove_perm_removes_access_control(mock_get_s3):
 
 
 @patch(f"{MODULE}._get_s3_client")
-def test_remove_perm_rejects_items_not_currently_assigned(mock_get_s3, capsys):
+def test_remove_perm_skips_update_if_all_items_not_currently_assigned(
+    mock_get_s3, capsys
+):
     existing_perms = {"types": [SAMPLE_POINTER_TYPES[0]]}
     mock_get_s3.return_value = _make_s3_mock(body=json.dumps(existing_perms).encode())
 
     remove_perm("types", "consumer", APP_ID, None, SAMPLE_POINTER_TYPES[1])
 
-    assert "aren't assigned" in capsys.readouterr().out
+    assert (
+        "Skipping: None of the requested pointer types are assigned"
+        in capsys.readouterr().out
+    )
+    mock_get_s3.put_object.assert_not_called()
+
+
+@patch(f"{MODULE}._get_s3_client")
+def test_remove_perm_skips_items_not_currently_assigned(mock_get_s3, capsys):
+    existing_perms = {"access_controls": [SAMPLE_ACCESS_CONTROLS[0]]}
+    s3 = _make_s3_mock(body=json.dumps(existing_perms).encode())
+    mock_get_s3.return_value = s3
+
+    remove_perm(
+        "access_controls",
+        "producer",
+        APP_ID,
+        ORG_ODS,
+        SAMPLE_ACCESS_CONTROLS[0],
+        SAMPLE_ACCESS_CONTROLS[1],
+    )
+
+    assert "Skipping access controls not already assigned" in capsys.readouterr().out
+    s3.put_object.assert_called_once_with(
+        Bucket=BUCKET,
+        Key=f"producer/{APP_ID}/{ORG_ODS}.json",
+        Body=json.dumps({"access_controls": []}, indent=4),
+        ContentType="application/json",
+    )
 
 
 @patch(f"{MODULE}._get_s3_client")

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -78,7 +78,7 @@ WARN[0484] {"issue":[{"severity":"error","code":"forbidden","details":{"coding":
 To resolve this, we can give the organisation `TD2L9A` permission to access the pointer type `824321000000109` on the default app:
 
 ```sh
-ENV=perftest poetry run python ./scripts/manage_permissions.py set_perms X26-NRL-6981ad7d-cff4-4613-93d0-df60e5e2fc52 TD2L9A http://snomed.info/sct\|824321000000109
+ENV=perftest poetry run python ./scripts/manage_permissions_v1.py set_perms X26-NRL-6981ad7d-cff4-4613-93d0-df60e5e2fc52 TD2L9A http://snomed.info/sct\|824321000000109
 ```
 
 ### Prepare to run tests


### PR DESCRIPTION
- renamed existing manage permissions script -> manage_permissions_v1.py
- manage_permissions.py is for managing v2 permissions now
- for v2 permissions, you can use this script to:
    - list apps & orgs and show their permissions
    - list assignable pointer types & access controls (limited to currently supported access controls)
    - add and remove supported permissions - only types & access controls currently. Will not let you remove a permission not already assigned or add a permission already assigned.
    - clear permissions
- This is hopefully easily extensible for anyone adding support for new future permissions e.g. interactions, categories. Will just need to add to the list of supported keys `currently_supported_permission_keys` and fill in any `PERMISSION_KEY_ATTRIBUTES`