### PR TITLE
NRL-2130 add details on how to deploy backup infra to readme

### DIFF
--- a/terraform/backup-infrastructure/README.md
+++ b/terraform/backup-infrastructure/README.md
@@ -4,12 +4,12 @@ This directory contains AWS backup terraform resources which are global to a giv
 
 Each subdirectory corresponds to each AWS account (`prod` and `test`).
 
-**Backup infrastructure should be deployed manually and not be run as part of CI.**
+**Backup infrastructure is deployed manually and not run as part of CI.**
 
 ## Table of Contents
 
 1. [Prerequisites](#prerequisites)
-2. [Initialise shell environment](#initialise-shell-environment)
+2. [Backup account pairings](#backup-account-pairings)
 3. [Deploy backup resources](#deploy-backup-resources)
 4. [Tear down backup resources](#tear-down-backup-resources)
 
@@ -18,6 +18,19 @@ Each subdirectory corresponds to each AWS account (`prod` and `test`).
 Before deploying the NRLF backup infrastructure, you will need:
 
 - An AWS backup account that have already been bootstrapped, as described in [bootstrap/README.md](../bootstrap/README.md). This is a one-time account setup step.
+
+## Backup account pairings
+
+Each account sends immutable copies of its backups to a corresponding backup account
+
+| SOURCE_ACCOUNT | BACKUP_ACCOUNT |
+| -------------- | -------------- |
+| TEST           | TEST BACKUP    |
+| PROD           | PROD BACKUP    |
+
+where SOURCE_ACCOUNT is the account that will be sending backups and BACKUP_ACCOUNT is the corresponding backup account.
+
+We might use SOURCE_ACCOUNT=DEV BACKUP_ACCOUNT=TEST BACKUP to prove out changes in development, but always set it back to the above.
 
 ## Deploy backup resources
 
@@ -32,29 +45,31 @@ $ terraform init && ( \
     terraform workspace select test )
 ```
 
-If you want to apply changes to prod, use the `prod` directory and the `backup-infra-prod` terraform workspace.
+If you want to apply changes to prod, use the `prod` directory and the `prod` terraform workspace and assume the admin role on the mgmt account.
 
 Once you have your workspace set, you can plan your changes with:
 
 ```shell
 $ terraform plan \
-    -var 'source_account_id=SOURCE_ACCOUNT_ID" \
-    -var 'assume_account=AWS_ACCOUNT_ID' \
+    -var 'source_account_id=SOURCE_ACCOUNT_ID' \
+    -var 'assume_account=BACKUP_ACCOUNT_ID' \
     -var 'assume_role=terraform'
 ```
 
-Replacing SOURCE_ACCOUNT with the account id that will be sending backups to the backup account and AWS_ACCOUNT_ID with the AWS account id of your backup account.
+Replacing SOURCE_ACCOUNT_ID with the account id that will be sending backups and BACKUP_ACCOUNT_ID with the account id of the [corresponding backup account](#backup-account-pairings).
 
 Once you're happy with your planned changes, you can apply them with:
 
 ```shell
 $ terraform apply \
-    -var 'source_account_id=SOURCE_ACCOUNT_ID" \
-    -var 'assume_account=AWS_ACCOUNT_ID' \
+    -var 'source_account_id=SOURCE_ACCOUNT_ID' \
+    -var 'assume_account=BACKUP_ACCOUNT_ID' \
     -var 'assume_role=terraform'
 ```
 
-Replacing SOURCE_ACCOUNT with the account id that will be sending backups to the backup account and AWS_ACCOUNT_ID with the AWS account id of your backup account.
+Replacing SOURCE_ACCOUNT_ID with the account id that will be sending backups and BACKUP_ACCOUNT_ID with the account id of the [corresponding backup account](#backup-account-pairings).
+
+> Record the plan/apply output somewhere for posterity e.g. the release ticket. When deploying backup-infra changes to prod, you'd want to be able to compare the plan output to that of the test account.
 
 ## Tear down backup resources
 
@@ -73,15 +88,15 @@ $ terraform init && ( \
     terraform workspace select test )
 ```
 
-If you want to destroy resources in prod, use the `prod` directory and the `backup-infra-prod` terraform workspace.
+If you want to destroy resources in prod, use the `prod` directory and the `prod` terraform workspace and assume the admin role on the mgmt account.
 
 And then, to tear down:
 
 ```shell
 $ terraform destroy \
-    -var 'source_account_id=SOURCE_ACCOUNT_ID" \
-    -var 'assume_account=AWS_ACCOUNT_ID' \
+    -var 'source_account_id=SOURCE_ACCOUNT_ID' \
+    -var 'assume_account=BACKUP_ACCOUNT_ID' \
     -var 'assume_role=terraform'
 ```
 
-Replacing SOURCE_ACCOUNT with the account id that will be sending backups to the backup account and AWS_ACCOUNT_ID with the AWS account id of your backup account.
+Replacing SOURCE_ACCOUNT_ID with the account id that will be sending backups and BACKUP_ACCOUNT_ID with the account id of the [corresponding backup account](#backup-account-pairings).


### PR DESCRIPTION
To avoid mucking up the next time I deploy to test 😁 

These instructions are now referenced by the release instructions:
- [Schedule release KOP](https://nhsd-confluence.digital.nhs.uk/spaces/CLP/pages/924262143/KOP-NRLF-007+-+Schedule+an+NRLF+Release#KOPNRLF007ScheduleanNRLFRelease-Deployallbackup-infrastructuretoTEST%26TESTBACKUPaccounts) 
- [Prod release KOP](https://nhsd-confluence.digital.nhs.uk/spaces/CLP/pages/895685287/KOP-NRLF-002+-+Release+NRLF+to+Live#KOPNRLF002ReleaseNRLFtoLive-Deployanybackup-infrastructurechangestoPROD%26PRODBACKUP)